### PR TITLE
Add reports update and daily automation instructions

### DIFF
--- a/docs/13_EXISTING_NODE_GUIDE_PT_BR.md
+++ b/docs/13_EXISTING_NODE_GUIDE_PT_BR.md
@@ -187,6 +187,39 @@ sudo -u postgres psql -c "create database lightningos owner losapp;"
 4) No config.yaml:
 - postgres.db_name: "lnd" (pode manter o padrao; nao e usado se o LND nao usa Postgres)
 
+## Atualização dos Relatórios
+### 1) Sincronização de custos e lucros diários
+Comando para calcular e armazenar os custos e lucros diários, garantindo que os relatórios financeiros apresentem informações corretas e completas.
+```bash
+/opt/lightningos/manager/lightningos-manager reports-backfill --from YYYY-MM-DD --to YYYY-MM-DD
+```
+
+### 2) Agendamento diário de atualização
+Configure um systemd timer para executar diariamente um serviço que atualiza o banco de dados com os dados do dia anterior.
+```bash
+sudo cp lightningos-light/templates/systemd/lightningos-reports.timer \
+  /etc/systemd/system/lightningos-reports.timer
+```
+
+```bash
+sudo cp lightningos-light/templates/systemd/lightningos-reports.service \
+  /etc/systemd/system/lightningos-reports.service
+```
+
+### 3) Ajustes recomendados
+Edite o arquivo lightningos-reports.service e ajuste conforme o seu ambiente:
+- User=admin
+- Group=admin
+```bash
+sudo ${EDITOR:-nano} /etc/systemd/system/lightningos-reports.service
+```
+
+### 4) Habilite e inicie
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now lightningos-reports.timer
+```
+
 ## Systemd do manager
 1) Copie a unit e ajuste User/Group:
 ```bash

--- a/docs/14_EXISTING_NODE_GUIDE_EN.md
+++ b/docs/14_EXISTING_NODE_GUIDE_EN.md
@@ -187,6 +187,39 @@ sudo -u postgres psql -c "create database lightningos owner losapp;"
 4) In config.yaml:
 - postgres.db_name: "lnd" (keep the default; not used if LND does not use Postgres)
 
+## Reports Update
+### 1) Daily cost and profit synchronization
+Command to calculate and store daily costs and profits, ensuring that financial reports display accurate and complete information.
+```bash
+/opt/lightningos/manager/lightningos-manager reports-backfill --from YYYY-MM-DD --to YYYY-MM-DD
+```
+
+### 2) Daily update scheduling
+Configure a systemd timer to run a service daily that updates the database with the previous day's data.
+```bash
+sudo cp lightningos-light/templates/systemd/lightningos-reports.timer \
+  /etc/systemd/system/lightningos-reports.timer
+```
+
+```bash
+sudo cp lightningos-light/templates/systemd/lightningos-reports.service \
+  /etc/systemd/system/lightningos-reports.service
+```
+
+### 3) Recommended adjustments
+Edit the lightningos-reports.service file and adjust it according to your environment:
+- User=admin
+- Group=admin
+```bash
+sudo ${EDITOR:-nano} /etc/systemd/system/lightningos-reports.service
+```
+
+### 4) Enable and start
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now lightningos-reports.timer
+```
+
 ## Manager systemd unit
 1) Copy the unit and edit User/Group:
 ```bash


### PR DESCRIPTION
This PR adds a new section to the existing node guide explaining:

• How to backfill daily costs and profits for reports  
• How to configure a systemd service and timer to automatically update the database daily  

These additions help users keep financial reports accurate and up to date.