### PR TITLE
Update comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If it still fails, try:
 sudo iptables -I INPUT -i br-<id> -p tcp --dport 10009 -j ACCEPT
 ```
 
-**Attention (existing nodes):** If you already have a Lightning node with LND/Bitcoin running, do not use `install.sh`.
+**Attention (existing nodes):** If you already have a Lightning node with LND/Bitcoin running, do not use `install.sh`.  
 Follow the Existing Node Guide instead:
 - PT-BR: `docs/13_EXISTING_NODE_GUIDE_PT_BR.md`
 - EN: `docs/14_EXISTING_NODE_GUIDE_EN.md`
@@ -118,75 +118,6 @@ Notes:
 - The UI version label comes from `ui/public/version.txt`.
 - PostgreSQL uses the PGDG repository by default. Set `POSTGRES_VERSION=18` (or another major) to override.
 - Tor uses the Tor Project repository when available. If your Ubuntu codename is unsupported, it falls back to `jammy`.
-
----
-
-## ⚠️ Raspberry Pi 5 + Debian 12 (Community Fork)
-
-> **This fork** adds community-maintained support for running LightningOS Light on a
-> **Raspberry Pi 5 (8 GB RAM)** with **Debian 12 Bookworm (aarch64)** on top of an existing Bitcoin Core node.
->
-> The official `install.sh` targets Ubuntu Server 22.04/24.04. Several manual adjustments are
-> required on Debian 12. This section documents all of them.
-
-### Key differences from Ubuntu install
-
-| Topic | Ubuntu (official) | Debian 12 (this fork) |
-|---|---|---|
-| Installer | `install_existing.sh` or `install_existing_pi.sh` | Manual steps (see guide) |
-| Tor group | `tor` | `debian-tor` |
-| Go binary | Downloaded by installer | Must install `linux-arm64` manually |
-| GoTTY binary | Bundled | Must replace with `linux-arm64` build |
-| REST port | 8080 (default) | May conflict — use 8082 |
-| PostgreSQL | APT (PGDG) | Docker container (recommended) |
-| journalctl logs in UI | Works | Shows warning (cosmetic only) |
-
-### Quick start (Raspberry Pi 5 / Debian 12)
-
-For the **complete step-by-step guide with all commands and troubleshooting**, see:
-
-📄 **[`docs/INSTALL_RASPBERRYPI5_DEBIAN12.md`](docs/INSTALL_RASPBERRYPI5_DEBIAN12.md)**
-
-High-level flow:
-
-```
-1. Verify aarch64 Debian 12 + Bitcoin Core synced
-2. Add ZMQ to bitcoin.conf + create /data symlinks
-3. Install Go 1.24 linux-arm64 manually
-4. Install Node.js 20.x
-5. Deploy PostgreSQL via Docker
-6. Clone repo → compile manager (Go) → build UI (npm)
-7. Install LND v0.20.0 linux-arm64 + configure systemd
-8. Apply Debian-specific fixes (Tor group, GoTTY, port)
-9. Start services → access https://<IP>:8443 → run wizard
-```
-
-### Tested configuration
-
-| Component | Version |
-|---|---|
-| Hardware | Raspberry Pi 5 — 8 GB RAM |
-| OS | Debian 12 Bookworm (`Linux 6.12.62+rpt-rpi-2712 aarch64`) |
-| Storage | 1.8 TB SSD at `/mnt/ssd` |
-| Bitcoin Core | Fully synced, data at `/mnt/ssd/bitcoin` |
-| LND | v0.20.0-beta |
-| LightningOS | v0.3.0-beta |
-| Go | 1.24.0 linux-arm64 |
-| Node.js | 20.x |
-| PostgreSQL | 16 (Docker) |
-
-### Community support
-
-This adaptation was developed and documented by the **Brazilian Lightning Network community**.
-
-> ⚡ If this guide helped you, consider sending a donation via Lightning to the node that made it possible:
->
-> **Alias:** `RaspNode-BR`
-> **Pubkey:** `025b2f2679168c49dc72b6ac93ba8b9b7f782113eef613b7bc09bcf53ea05b792c`
-
-For questions and support: [BR⚡LN Community](https://services.br-ln.com)
-
----
 
 ## Installer permissions (what `install.sh` enforces)
 - Users:
@@ -444,6 +375,47 @@ Autofee Results lines:
 
 Tag glossary (Autofee Results):
 - Full reference: `docs/AUTOFEE_TAG_GLOSSARY_EN.md` (EN) and `docs/AUTOFEE_TAG_GLOSSARIO_PT_BR.md` (PT-BR).
+- Channel role and trend:
+- `sink`, `source`, `router`, `unknown`, `trend-up`, `trend-down`, `trend-flat`.
+- Movement controls:
+- `stepcap`, `stepcap-lock`, `floor-lock`, `floor-relax-stall`, `reversal-guard`, `reversal-confirmed`, `downcap-general`, `htlc-low-sample-downcap`, `hold-small`, `same-ppm`, `cooldown`, `cooldown-profit`, `cooldown-skip`, `rebal-recent`, `rebal-attempt`, `rebal-recent-noup`.
+- Profit and margin controls:
+- `neg-margin`, `negm+X%`, `no-down-low`, `no-down-neg-margin`, `global-neg-lock`, `lock-skip-no-chan-rebal`, `lock-skip-sink-profit`, `profit-protect-lock`, `profit-protect-relax`.
+- Outrate/floor controls:
+- `outrate-floor`, `peg`, `peg-grace`, `peg-demand`, `revfloor`, `sink-floor`.
+- Adaptive controls:
+- `circuit-breaker`, `extreme-drain`, `extreme-drain-unlock`, `extreme-drain-turbo`.
+- Stagnation and anti-lock controls:
+- `stagnation`, `stagnation-rN`, `stagnation-cap-<ppm>`, `normalize-out`, `normalize-rebal`, `stagnation-floor`, `stagnation-floor-relax`, `stagnation-neg-override`, `stagnation-pressure`, `peg-paused-stagnation`.
+- Low-out/no-signal controls:
+- `low-out-slow-up`, `low-out-noflow-cap`, `no-signal-noup`, `no-signal-floor-relax`.
+- Discovery/explorer:
+- `discovery`, `discovery-hard`, `explorer`, `surge*`.
+- HTLC signals:
+- `htlc-policy-hot`, `htlc-liquidity-hot`, `htlc-forward-hot`, `htlc-sample-low`, `htlc-neutral-lock`, `htlc-liq+X%`, `htlc-policy+X%`, `htlc-liq-nodown`, `htlc-policy-nodown`, `htlc-neutral-nodown`, `htlc-step-boost`.
+- Super-source and inbound:
+- `super-source`, `super-source-like`, `new-inbound`, `bootstrap`, `inb-<n>`.
+- Seed and fallback provenance:
+- `seed:amboss`, `seed:amboss-missing`, `seed:amboss-empty`, `seed:amboss-error`, `seed:med`, `seed:vol-<n>%`, `seed:ratio<factor>`, `seed:outrate`, `seed:mem`, `seed:default`, `seed:guard`, `seed:p95cap`, `seed:absmax`, `out-fallback-21d`, `rebal-fallback-21d`.
+
+Reading examples:
+- Example A (healthy profitable sink):
+```text
+keep 844 ppm | target 844 | out_ratio 0.21 | out_ppm7d~625 | rebal_ppm7d~513 | floor>=657(peg) | margin~61 | ... outrate-floor peg peg-demand ...
+```
+Meaning: channel is moving and profitable, floor remains anchored to market/rebalance references, no forced change.
+
+- Example B (high local ratio, idle, no quality signal):
+```text
+keep 1500 ppm | target 1500 | out_ratio 0.24 | out_ppm7d~0 | rebal_ppm7d~0 | ... low-out-slow-up no-signal-noup no-signal-floor-relax ...
+```
+Meaning: Autofee detected missing reliable signal and avoided blind upward repricing.
+
+- Example C (stagnation pressure on high local ratio):
+```text
+keep 1461 ppm | target 1139 | out_ratio 0.35 | ... stagnation normalize-out stagnation-r5 stagnation-cap-1139 stagnation-floor peg-paused-stagnation ...
+```
+Meaning: stagnation logic is actively trying to normalize down while preventing conflicting peg pressure.
 
 ## Node Retirement
 Node Retirement is a guided workflow to safely decommission an LND node, close channels in an orderly way, and provide an auditable recovery trail.
@@ -459,6 +431,87 @@ Core model:
 - Only one active retirement session can run at a time.
 - Every step writes events and state to Postgres so progress survives UI refresh/restart.
 - A mandatory disclaimer gate exists for manual sessions.
+
+State machine (high level):
+- `created`: session accepted.
+- `snapshot_taken`: baseline balances/channels captured.
+- `quiescing`: best-effort stop of rebalance/autofee + forwarding disable.
+- `draining_htlcs`: waits until pending HTLC count reaches zero.
+- `ready_for_coop_confirmation`: manual confirmation gate before cooperative close.
+- `closing_coop`: cooperative close attempts for eligible channels.
+- `awaiting_user_decision`: channels that need operator decision (`wait` vs `force_close`).
+- `force_closing`: applies force-close where explicitly approved.
+- `monitoring_onchain`: waits for all tracked channels to finish close lifecycle.
+- terminal states: `completed`, `dry_run_completed`, `failed`, `canceled`.
+
+Cooperative close fee policy:
+- Node Retirement currently calls LND cooperative close with `sat_per_vbyte=0` (LND dynamic estimator/default confirmation target).
+- This keeps retirement behavior consistent with LND fee estimation and avoids external fee dependency during decommission.
+
+UI components:
+- Disclaimer + session creation panel:
+- choose `Dry-run mode (simulate only)` or live run.
+- Retirement steps board:
+- badge per step (`Completed`, `In progress`, `Pending`).
+- Sessions list:
+- shows source, run mode, state, timestamps, and last error.
+- Initial Snapshot panel:
+- baseline at session start (open/pending channels, HTLC count, on-chain and Lightning balances).
+- Reconciliation panel:
+- final summary when finished (balances/channels) and transfer result when applicable.
+- Channel timeline (initial vs current):
+- per-channel comparison from captured initial state to latest state (active flags, local/remote balances, pending HTLCs, close mode/txid, decision, errors).
+- Session events:
+- ordered runtime event trail for diagnostics/audit.
+- Cooperative close confirmation modal:
+- explicit no-return confirmation gate for manual sessions.
+- Channel exception actions:
+- per-channel `Wait` / `Force close` decisions for offline/stuck cases.
+- Transfer audit (succession-triggered sessions):
+- destination, attempts, status badge, txid with explorer link, confirmations, fee policy, timestamps, errors.
+
+Dry-run behavior:
+- Simulates the full orchestration path without submitting real cooperative/force closes.
+- Produces snapshot, channel timeline updates, session events, and final reconciliation as `dry_run_completed`.
+- Intended to validate policy + operator understanding before live retirement.
+
+### Succession Mode (dead-man switch)
+Succession Mode automates retirement trigger when proof-of-life is not confirmed in time.
+
+Defaults and prerequisites:
+- Disabled by default.
+- Can only be armed when Telegram `Activity mirror` is enabled in Notifications.
+- Uses the same retirement engine with `source=succession`.
+
+Configuration in UI:
+- `Enable succession mode`: arms scheduler.
+- `Succession dry-run`: when enabled, scheduler-triggered retirement sessions are created as dry-run.
+- `External on-chain destination address`: sweep destination for recovered funds.
+- `Liveness check interval (days)`: delay after a valid confirmation before reminder window starts.
+- `Daily reminder grace window (days)`: deadline window after reminders begin.
+- `Min confirmations before auto-transfer`: waits for UTXOs with at least this depth before succession sweep.
+- `Auto-transfer fee rate (sat/vbyte)`: if `0`, LND estimates dynamically.
+- `Pre-approve FC for offline peers` and `Pre-approve FC for stuck HTLC channels`: exception policy for unattended flows.
+
+Proof-of-life inputs:
+- UI button: `I'm alive (UI)`.
+- Telegram command/message: `/alive` or `estou vivo`.
+- Either path resets `last_alive_at`, `next_check_at`, and `deadline_at`.
+
+Reminder and trigger cycle:
+- Scheduler checks succession status every minute.
+- Before `next_check_at`: state remains armed.
+- Between `next_check_at` and `deadline_at`: sends one Telegram reminder per day.
+- After `deadline_at`: triggers Node Retirement automatically (live or dry-run according to succession config).
+
+Simulation controls:
+- `Simulate alive`: records liveness confirmation immediately.
+- `Simulate not alive`: now triggers an immediate succession retirement session in dry-run for validation.
+
+Operational notes:
+- If another retirement session is already active, succession enters waiting mode and retries later.
+- Completion status is mirrored in succession state (`retirement_completed` / `dry_run_completed`) and can notify Telegram.
+- For live succession runs, auto-transfer monitoring tracks submission and confirmation of the sweep transaction.
 
 ## Web terminal (optional)
 LightningOS Light can expose a protected web terminal using GoTTY.
@@ -546,3 +599,5 @@ cd ..
 sudo rm -rf /opt/lightningos/ui/*
 sudo cp -a ui/dist/. /opt/lightningos/ui/
 ```
+
+

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If it still fails, try:
 sudo iptables -I INPUT -i br-<id> -p tcp --dport 10009 -j ACCEPT
 ```
 
-**Attention (existing nodes):** If you already have a Lightning node with LND/Bitcoin running, do not use `install.sh`.  
+**Attention (existing nodes):** If you already have a Lightning node with LND/Bitcoin running, do not use `install.sh`.
 Follow the Existing Node Guide instead:
 - PT-BR: `docs/13_EXISTING_NODE_GUIDE_PT_BR.md`
 - EN: `docs/14_EXISTING_NODE_GUIDE_EN.md`
@@ -118,6 +118,75 @@ Notes:
 - The UI version label comes from `ui/public/version.txt`.
 - PostgreSQL uses the PGDG repository by default. Set `POSTGRES_VERSION=18` (or another major) to override.
 - Tor uses the Tor Project repository when available. If your Ubuntu codename is unsupported, it falls back to `jammy`.
+
+---
+
+## ⚠️ Raspberry Pi 5 + Debian 12 (Community Fork)
+
+> **This fork** adds community-maintained support for running LightningOS Light on a
+> **Raspberry Pi 5 (8 GB RAM)** with **Debian 12 Bookworm (aarch64)** on top of an existing Bitcoin Core node.
+>
+> The official `install.sh` targets Ubuntu Server 22.04/24.04. Several manual adjustments are
+> required on Debian 12. This section documents all of them.
+
+### Key differences from Ubuntu install
+
+| Topic | Ubuntu (official) | Debian 12 (this fork) |
+|---|---|---|
+| Installer | `install_existing.sh` or `install_existing_pi.sh` | Manual steps (see guide) |
+| Tor group | `tor` | `debian-tor` |
+| Go binary | Downloaded by installer | Must install `linux-arm64` manually |
+| GoTTY binary | Bundled | Must replace with `linux-arm64` build |
+| REST port | 8080 (default) | May conflict — use 8082 |
+| PostgreSQL | APT (PGDG) | Docker container (recommended) |
+| journalctl logs in UI | Works | Shows warning (cosmetic only) |
+
+### Quick start (Raspberry Pi 5 / Debian 12)
+
+For the **complete step-by-step guide with all commands and troubleshooting**, see:
+
+📄 **[`docs/INSTALL_RASPBERRYPI5_DEBIAN12.md`](docs/INSTALL_RASPBERRYPI5_DEBIAN12.md)**
+
+High-level flow:
+
+```
+1. Verify aarch64 Debian 12 + Bitcoin Core synced
+2. Add ZMQ to bitcoin.conf + create /data symlinks
+3. Install Go 1.24 linux-arm64 manually
+4. Install Node.js 20.x
+5. Deploy PostgreSQL via Docker
+6. Clone repo → compile manager (Go) → build UI (npm)
+7. Install LND v0.20.0 linux-arm64 + configure systemd
+8. Apply Debian-specific fixes (Tor group, GoTTY, port)
+9. Start services → access https://<IP>:8443 → run wizard
+```
+
+### Tested configuration
+
+| Component | Version |
+|---|---|
+| Hardware | Raspberry Pi 5 — 8 GB RAM |
+| OS | Debian 12 Bookworm (`Linux 6.12.62+rpt-rpi-2712 aarch64`) |
+| Storage | 1.8 TB SSD at `/mnt/ssd` |
+| Bitcoin Core | Fully synced, data at `/mnt/ssd/bitcoin` |
+| LND | v0.20.0-beta |
+| LightningOS | v0.3.0-beta |
+| Go | 1.24.0 linux-arm64 |
+| Node.js | 20.x |
+| PostgreSQL | 16 (Docker) |
+
+### Community support
+
+This adaptation was developed and documented by the **Brazilian Lightning Network community**.
+
+> ⚡ If this guide helped you, consider sending a donation via Lightning to the node that made it possible:
+>
+> **Alias:** `RaspNode-BR`
+> **Pubkey:** `025b2f2679168c49dc72b6ac93ba8b9b7f782113eef613b7bc09bcf53ea05b792c`
+
+For questions and support: [BR⚡LN Community](https://services.br-ln.com)
+
+---
 
 ## Installer permissions (what `install.sh` enforces)
 - Users:
@@ -375,47 +444,6 @@ Autofee Results lines:
 
 Tag glossary (Autofee Results):
 - Full reference: `docs/AUTOFEE_TAG_GLOSSARY_EN.md` (EN) and `docs/AUTOFEE_TAG_GLOSSARIO_PT_BR.md` (PT-BR).
-- Channel role and trend:
-- `sink`, `source`, `router`, `unknown`, `trend-up`, `trend-down`, `trend-flat`.
-- Movement controls:
-- `stepcap`, `stepcap-lock`, `floor-lock`, `floor-relax-stall`, `reversal-guard`, `reversal-confirmed`, `downcap-general`, `htlc-low-sample-downcap`, `hold-small`, `same-ppm`, `cooldown`, `cooldown-profit`, `cooldown-skip`, `rebal-recent`, `rebal-attempt`, `rebal-recent-noup`.
-- Profit and margin controls:
-- `neg-margin`, `negm+X%`, `no-down-low`, `no-down-neg-margin`, `global-neg-lock`, `lock-skip-no-chan-rebal`, `lock-skip-sink-profit`, `profit-protect-lock`, `profit-protect-relax`.
-- Outrate/floor controls:
-- `outrate-floor`, `peg`, `peg-grace`, `peg-demand`, `revfloor`, `sink-floor`.
-- Adaptive controls:
-- `circuit-breaker`, `extreme-drain`, `extreme-drain-unlock`, `extreme-drain-turbo`.
-- Stagnation and anti-lock controls:
-- `stagnation`, `stagnation-rN`, `stagnation-cap-<ppm>`, `normalize-out`, `normalize-rebal`, `stagnation-floor`, `stagnation-floor-relax`, `stagnation-neg-override`, `stagnation-pressure`, `peg-paused-stagnation`.
-- Low-out/no-signal controls:
-- `low-out-slow-up`, `low-out-noflow-cap`, `no-signal-noup`, `no-signal-floor-relax`.
-- Discovery/explorer:
-- `discovery`, `discovery-hard`, `explorer`, `surge*`.
-- HTLC signals:
-- `htlc-policy-hot`, `htlc-liquidity-hot`, `htlc-forward-hot`, `htlc-sample-low`, `htlc-neutral-lock`, `htlc-liq+X%`, `htlc-policy+X%`, `htlc-liq-nodown`, `htlc-policy-nodown`, `htlc-neutral-nodown`, `htlc-step-boost`.
-- Super-source and inbound:
-- `super-source`, `super-source-like`, `new-inbound`, `bootstrap`, `inb-<n>`.
-- Seed and fallback provenance:
-- `seed:amboss`, `seed:amboss-missing`, `seed:amboss-empty`, `seed:amboss-error`, `seed:med`, `seed:vol-<n>%`, `seed:ratio<factor>`, `seed:outrate`, `seed:mem`, `seed:default`, `seed:guard`, `seed:p95cap`, `seed:absmax`, `out-fallback-21d`, `rebal-fallback-21d`.
-
-Reading examples:
-- Example A (healthy profitable sink):
-```text
-keep 844 ppm | target 844 | out_ratio 0.21 | out_ppm7d~625 | rebal_ppm7d~513 | floor>=657(peg) | margin~61 | ... outrate-floor peg peg-demand ...
-```
-Meaning: channel is moving and profitable, floor remains anchored to market/rebalance references, no forced change.
-
-- Example B (high local ratio, idle, no quality signal):
-```text
-keep 1500 ppm | target 1500 | out_ratio 0.24 | out_ppm7d~0 | rebal_ppm7d~0 | ... low-out-slow-up no-signal-noup no-signal-floor-relax ...
-```
-Meaning: Autofee detected missing reliable signal and avoided blind upward repricing.
-
-- Example C (stagnation pressure on high local ratio):
-```text
-keep 1461 ppm | target 1139 | out_ratio 0.35 | ... stagnation normalize-out stagnation-r5 stagnation-cap-1139 stagnation-floor peg-paused-stagnation ...
-```
-Meaning: stagnation logic is actively trying to normalize down while preventing conflicting peg pressure.
 
 ## Node Retirement
 Node Retirement is a guided workflow to safely decommission an LND node, close channels in an orderly way, and provide an auditable recovery trail.
@@ -431,87 +459,6 @@ Core model:
 - Only one active retirement session can run at a time.
 - Every step writes events and state to Postgres so progress survives UI refresh/restart.
 - A mandatory disclaimer gate exists for manual sessions.
-
-State machine (high level):
-- `created`: session accepted.
-- `snapshot_taken`: baseline balances/channels captured.
-- `quiescing`: best-effort stop of rebalance/autofee + forwarding disable.
-- `draining_htlcs`: waits until pending HTLC count reaches zero.
-- `ready_for_coop_confirmation`: manual confirmation gate before cooperative close.
-- `closing_coop`: cooperative close attempts for eligible channels.
-- `awaiting_user_decision`: channels that need operator decision (`wait` vs `force_close`).
-- `force_closing`: applies force-close where explicitly approved.
-- `monitoring_onchain`: waits for all tracked channels to finish close lifecycle.
-- terminal states: `completed`, `dry_run_completed`, `failed`, `canceled`.
-
-Cooperative close fee policy:
-- Node Retirement currently calls LND cooperative close with `sat_per_vbyte=0` (LND dynamic estimator/default confirmation target).
-- This keeps retirement behavior consistent with LND fee estimation and avoids external fee dependency during decommission.
-
-UI components:
-- Disclaimer + session creation panel:
-- choose `Dry-run mode (simulate only)` or live run.
-- Retirement steps board:
-- badge per step (`Completed`, `In progress`, `Pending`).
-- Sessions list:
-- shows source, run mode, state, timestamps, and last error.
-- Initial Snapshot panel:
-- baseline at session start (open/pending channels, HTLC count, on-chain and Lightning balances).
-- Reconciliation panel:
-- final summary when finished (balances/channels) and transfer result when applicable.
-- Channel timeline (initial vs current):
-- per-channel comparison from captured initial state to latest state (active flags, local/remote balances, pending HTLCs, close mode/txid, decision, errors).
-- Session events:
-- ordered runtime event trail for diagnostics/audit.
-- Cooperative close confirmation modal:
-- explicit no-return confirmation gate for manual sessions.
-- Channel exception actions:
-- per-channel `Wait` / `Force close` decisions for offline/stuck cases.
-- Transfer audit (succession-triggered sessions):
-- destination, attempts, status badge, txid with explorer link, confirmations, fee policy, timestamps, errors.
-
-Dry-run behavior:
-- Simulates the full orchestration path without submitting real cooperative/force closes.
-- Produces snapshot, channel timeline updates, session events, and final reconciliation as `dry_run_completed`.
-- Intended to validate policy + operator understanding before live retirement.
-
-### Succession Mode (dead-man switch)
-Succession Mode automates retirement trigger when proof-of-life is not confirmed in time.
-
-Defaults and prerequisites:
-- Disabled by default.
-- Can only be armed when Telegram `Activity mirror` is enabled in Notifications.
-- Uses the same retirement engine with `source=succession`.
-
-Configuration in UI:
-- `Enable succession mode`: arms scheduler.
-- `Succession dry-run`: when enabled, scheduler-triggered retirement sessions are created as dry-run.
-- `External on-chain destination address`: sweep destination for recovered funds.
-- `Liveness check interval (days)`: delay after a valid confirmation before reminder window starts.
-- `Daily reminder grace window (days)`: deadline window after reminders begin.
-- `Min confirmations before auto-transfer`: waits for UTXOs with at least this depth before succession sweep.
-- `Auto-transfer fee rate (sat/vbyte)`: if `0`, LND estimates dynamically.
-- `Pre-approve FC for offline peers` and `Pre-approve FC for stuck HTLC channels`: exception policy for unattended flows.
-
-Proof-of-life inputs:
-- UI button: `I'm alive (UI)`.
-- Telegram command/message: `/alive` or `estou vivo`.
-- Either path resets `last_alive_at`, `next_check_at`, and `deadline_at`.
-
-Reminder and trigger cycle:
-- Scheduler checks succession status every minute.
-- Before `next_check_at`: state remains armed.
-- Between `next_check_at` and `deadline_at`: sends one Telegram reminder per day.
-- After `deadline_at`: triggers Node Retirement automatically (live or dry-run according to succession config).
-
-Simulation controls:
-- `Simulate alive`: records liveness confirmation immediately.
-- `Simulate not alive`: now triggers an immediate succession retirement session in dry-run for validation.
-
-Operational notes:
-- If another retirement session is already active, succession enters waiting mode and retries later.
-- Completion status is mirrored in succession state (`retirement_completed` / `dry_run_completed`) and can notify Telegram.
-- For live succession runs, auto-transfer monitoring tracks submission and confirmation of the sweep transaction.
 
 ## Web terminal (optional)
 LightningOS Light can expose a protected web terminal using GoTTY.
@@ -599,5 +546,3 @@ cd ..
 sudo rm -rf /opt/lightningos/ui/*
 sudo cp -a ui/dist/. /opt/lightningos/ui/
 ```
-
-

--- a/docs/16_INSTALL_RASPBERRYPI5_DEBIAN12.md
+++ b/docs/16_INSTALL_RASPBERRYPI5_DEBIAN12.md
@@ -1,0 +1,819 @@
+# Installing LightningOS Light on Raspberry Pi 5 — Debian 12 (Bookworm)
+
+> **Community guide** — Adaptation of the official LightningOS Light installer for
+> **Raspberry Pi 5 (8 GB RAM)** running **Debian 12 Bookworm (aarch64)** with an existing Bitcoin Core node.
+>
+> Original project: [https://github.com/jvxis/brln-os-light](https://github.com/jvxis/brln-os-light)
+> This fork: [https://github.com/MarcosJRcwb/brln-os-light](https://github.com/MarcosJRcwb/brln-os-light)
+
+---
+
+[Leia em Português](INSTALL_RASPBERRYPI5_DEBIAN12_PT_BR.md)
+
+
+---
+
+## Why a separate guide?
+
+The official `install.sh` and `install_existing_pi.sh` target **Ubuntu Server 22.04/24.04**.
+Debian 12 differs in several important ways that cause silent failures if not addressed:
+
+| Issue | Detail |
+|---|---|
+| Tor group name | Debian uses `debian-tor`, not `tor` |
+| Go binary architecture | Installer may pull `amd64` — must force `arm64` |
+| GoTTY binary architecture | Bundled binary is `amd64` — must replace |
+| REST port conflict | Port 8080 may be in use — use 8082 |
+| PostgreSQL install method | PGDG apt may not work cleanly — use Docker |
+| journalctl in UI | Shows permission warning — cosmetic only, no impact |
+
+---
+
+## Prerequisites
+
+| Item | Requirement |
+|---|---|
+| Hardware | Raspberry Pi 5, 8 GB RAM |
+| OS | Debian 12 Bookworm, aarch64 |
+| Storage | External SSD, minimum 1 TB (2 TB recommended) |
+| Bitcoin Core | Already installed and **fully synced** |
+| Access | SSH (PuTTY or any terminal) or local terminal |
+| Internet | Stable connection throughout installation |
+
+> ⚠️ **Do not start until Bitcoin Core is 100% synced.**
+> You can verify with: `bitcoin-cli getblockchaininfo | grep verificationprogress`
+> The value must be `0.9999...` or `1`.
+
+---
+
+## Installation overview
+
+```
+PHASE 1: Environment preparation
+  1.1  Verify OS and architecture
+  1.2  Confirm Bitcoin Core is running and synced
+  1.3  Add ZMQ to bitcoin.conf
+  1.4  Create /data symlinks
+       ↓
+PHASE 2: Dependencies
+  2.1  Install Go 1.24 (linux-arm64 — mandatory)
+  2.2  Install Node.js 20.x
+  2.3  Deploy PostgreSQL via Docker
+       ↓
+PHASE 3: LightningOS installation
+  3.1  Clone repository
+  3.2  Create users and directories
+  3.3  Compile manager (Go build)
+  3.4  Compile UI (npm build)
+  3.5  Generate TLS certificate
+       ↓
+PHASE 4: LND installation
+  4.1  Download LND v0.20.0 (linux-arm64)
+  4.2  Create systemd service
+       ↓
+PHASE 5: Debian-specific fixes
+  5.1  Check port 8080 conflict
+  5.2  Configure Tor with debian-tor group
+  5.3  Replace GoTTY with arm64 build
+  5.4  Set group permissions
+  5.5  Configure secrets.env and config.yaml
+  5.6  Create LightningOS systemd service
+       ↓
+PHASE 6: Validation
+  6.1  Verify all services
+  6.2  Access UI and run wizard
+  6.3  Create wallet — write down seed phrase
+```
+
+> **One command at a time.** Verify the output before proceeding to the next step.
+
+---
+
+## PHASE 1 — Environment preparation
+
+### 1.1 Verify the operating system
+
+```bash
+uname -a
+```
+
+Expected output (must contain `aarch64` and `Debian`):
+```
+Linux raspnode 6.12.62+rpt-rpi-2712 #1 SMP PREEMPT Debian aarch64 GNU/Linux
+```
+
+> ❌ If `aarch64` is not present: this guide does not apply to your hardware.
+
+---
+
+### 1.2 Verify Bitcoin Core
+
+```bash
+systemctl status bitcoin --no-pager | head -10
+```
+
+Expected: `Active: active (running)`
+
+> ⏳ If syncing: wait for `verificationprogress` to reach `1` before continuing.
+
+---
+
+### 1.3 Add ZMQ to bitcoin.conf
+
+LND requires ZMQ to receive real-time block and transaction notifications.
+
+Check if already configured:
+```bash
+sudo grep zmq /etc/bitcoin/bitcoin.conf
+```
+
+If the lines below are already present, skip to step 1.4:
+```
+zmqpubrawblock=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:28333
+```
+
+If not, add them:
+```bash
+sudo bash -c 'printf "\n# ZMQ for LND\nzmqpubrawblock=tcp://127.0.0.1:28332\nzmqpubrawtx=tcp://127.0.0.1:28333\n" >> /etc/bitcoin/bitcoin.conf'
+```
+
+Restart Bitcoin Core and verify:
+```bash
+sudo systemctl restart bitcoin
+sleep 30 && systemctl status bitcoin --no-pager | grep Active
+```
+
+---
+
+### 1.4 Create /data symlinks
+
+LightningOS expects data under `/data/bitcoin` and `/data/lnd`.
+Adapt the paths below to match your actual SSD mount point.
+
+```bash
+sudo mkdir -p /data
+sudo ln -sf /mnt/ssd/bitcoin /data/bitcoin
+sudo mkdir -p /mnt/ssd/lnd
+sudo ln -sf /mnt/ssd/lnd /data/lnd
+sudo ln -sf /etc/bitcoin/bitcoin.conf /mnt/ssd/bitcoin/bitcoin.conf
+```
+
+Verify:
+```bash
+ls -la /data/
+```
+
+Expected:
+```
+bitcoin -> /mnt/ssd/bitcoin
+lnd -> /mnt/ssd/lnd
+```
+
+---
+
+## PHASE 2 — Dependencies
+
+### 2.1 Install Go 1.24 (linux-arm64 — CRITICAL)
+
+> ⚠️ **Common failure point:** automatic scripts may download the `amd64` binary.
+> Always install `linux-arm64` manually on Raspberry Pi.
+
+```bash
+cd /tmp && curl -LO https://go.dev/dl/go1.24.0.linux-arm64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.0.linux-arm64.tar.gz
+```
+
+Verify (must show `linux/arm64`):
+```bash
+/usr/local/go/bin/go version
+```
+
+Expected:
+```
+go version go1.24.0 linux/arm64
+```
+
+> ❌ If output shows `amd64`: delete and reinstall using the correct file above.
+
+---
+
+### 2.2 Install Node.js 20.x
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+node --version
+```
+
+Expected: `v20.x.x`
+
+---
+
+### 2.3 Deploy PostgreSQL via Docker
+
+Verify Docker is installed:
+```bash
+docker --version
+```
+
+If not installed:
+```bash
+sudo apt-get install -y docker.io docker-compose-plugin
+sudo systemctl enable --now docker
+```
+
+Create data directory and Docker Compose file:
+
+```bash
+sudo mkdir -p /mnt/ssd/postgres/data /opt/lightningos-postgres
+```
+
+Create `/opt/lightningos-postgres/docker-compose.yml` with the content below.
+**Replace all placeholder passwords with strong values of your choice and record them securely.**
+
+```yaml
+version: "3.8"
+services:
+  postgres:
+    image: postgres:16
+    container_name: lightningos-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: losadmin
+      POSTGRES_PASSWORD: <STRONG_ADMIN_PASSWORD>
+      POSTGRES_DB: postgres
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - /mnt/ssd/postgres/data:/var/lib/postgresql/data
+```
+
+Start PostgreSQL:
+```bash
+cd /opt/lightningos-postgres && sudo docker compose up -d
+sleep 10 && sudo docker ps | grep postgres
+```
+
+Expected: container with status `Up`.
+
+Create the required databases and users (replace passwords to match your compose file):
+```bash
+sudo docker exec -it lightningos-postgres psql -U losadmin -c "
+CREATE USER lndpg WITH PASSWORD '<LND_DB_PASSWORD>';
+CREATE DATABASE lnd OWNER lndpg;
+CREATE USER losapp WITH PASSWORD '<APP_DB_PASSWORD>';
+CREATE DATABASE lightningos OWNER losapp;
+GRANT ALL PRIVILEGES ON DATABASE lnd TO lndpg;
+GRANT ALL PRIVILEGES ON DATABASE lightningos TO losapp;
+"
+```
+
+---
+
+## PHASE 3 — LightningOS installation
+
+### 3.1 Clone the repository
+
+```bash
+sudo git clone https://github.com/MarcosJRcwb/brln-os-light /opt/brln-os-light
+ls /opt/brln-os-light/lightningos-light/
+```
+
+---
+
+### 3.2 Create users and directories
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin lightningos 2>/dev/null || echo "already exists"
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin lnd 2>/dev/null || echo "already exists"
+sudo mkdir -p /opt/lightningos/manager /opt/lightningos/ui
+sudo mkdir -p /etc/lightningos/tls
+sudo mkdir -p /var/lib/lightningos /var/log/lightningos
+```
+
+---
+
+### 3.3 Compile the manager (Go backend)
+
+> ⏳ This step can take **5 to 15 minutes**. No output is shown during compilation — this is normal.
+
+```bash
+cd /opt/brln-os-light/lightningos-light
+sudo GOFLAGS="-mod=mod" /usr/local/go/bin/go build -o dist/lightningos-manager ./cmd/lightningos-manager
+```
+
+Verify the binary was created (should be 20–40 MB):
+```bash
+ls -lh dist/lightningos-manager
+```
+
+Install:
+```bash
+sudo install -m 0755 dist/lightningos-manager /opt/lightningos/manager/lightningos-manager
+```
+
+> ❌ If you get module errors: run `sudo /usr/local/go/bin/go mod download` first.
+
+---
+
+### 3.4 Build the UI (frontend)
+
+```bash
+cd /opt/brln-os-light/lightningos-light/ui
+sudo npm install
+```
+
+> ⏳ Wait for npm packages to install (~5 minutes).
+
+```bash
+sudo npm run build
+sudo cp -a dist/. /opt/lightningos/ui/
+```
+
+Verify:
+```bash
+ls /opt/lightningos/ui/ | head -5
+```
+
+Expected: `index.html  assets/  ...`
+
+---
+
+### 3.5 Generate self-signed TLS certificate
+
+```bash
+sudo openssl req -x509 -newkey rsa:4096 \
+  -keyout /etc/lightningos/tls/server.key \
+  -out /etc/lightningos/tls/server.crt \
+  -days 3650 -nodes \
+  -subj "/CN=lightningos" \
+  -addext "subjectAltName=IP:127.0.0.1,IP:0.0.0.0"
+```
+
+---
+
+## PHASE 4 — LND installation
+
+### 4.1 Download LND v0.20.0 (linux-arm64)
+
+> ⚠️ Always use `linux-arm64`. The `amd64` binary returns `Exec format error` on Raspberry Pi.
+
+```bash
+cd /tmp
+curl -LO https://github.com/lightningnetwork/lnd/releases/download/v0.20.0-beta/lnd-linux-arm64-v0.20.0-beta.tar.gz
+tar -xzf lnd-linux-arm64-v0.20.0-beta.tar.gz
+sudo install -m 0755 lnd-linux-arm64-v0.20.0-beta/lnd /usr/local/bin/lnd
+sudo install -m 0755 lnd-linux-arm64-v0.20.0-beta/lncli /usr/local/bin/lncli
+lnd --version
+```
+
+Expected: `lnd version 0.20.0-beta`
+
+---
+
+### 4.2 Configure lnd.conf
+
+Create `/mnt/ssd/lnd/lnd.conf` with the content below.
+
+> **Replace:**
+> - `<YOUR_RPC_USER>` and `<YOUR_RPC_PASS>` with your Bitcoin Core RPC credentials
+> - `<LND_DB_PASSWORD>` with the PostgreSQL password you set in Phase 2
+> - If port 8080 is in use, keep `restlisten=127.0.0.1:8082` (see step 5.1)
+
+```ini
+[Application Options]
+alias=MyNode-BR
+color=#ff9900
+debuglevel=info
+restlisten=127.0.0.1:8082
+
+# Uncomment after creating wallet:
+# wallet-unlock-password-file=/data/lnd/password.txt
+# wallet-unlock-allow-create=true
+
+tlsautorefresh=true
+tlsextraip=127.0.0.1
+tlsdisableautofill=true
+
+accept-keysend=true
+accept-amp=true
+allow-circular-route=true
+
+[Bitcoin]
+bitcoin.mainnet=1
+bitcoin.node=bitcoind
+bitcoin.basefee=1000
+bitcoin.feerate=1
+bitcoin.timelockdelta=144
+
+[db]
+db.backend=postgres
+db.use-native-sql=true
+
+[postgres]
+db.postgres.dsn=postgres://lndpg:<LND_DB_PASSWORD>@127.0.0.1:5432/lnd?sslmode=disable
+db.postgres.timeout=0
+
+[Bitcoind]
+bitcoind.rpchost=127.0.0.1:8332
+bitcoind.rpcuser=<YOUR_RPC_USER>
+bitcoind.rpcpass=<YOUR_RPC_PASS>
+bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+bitcoind.estimatemode=ECONOMICAL
+
+[tor]
+tor.active=true
+tor.v3=true
+tor.skip-proxy-for-clearnet-targets=false
+tor.streamisolation=true
+
+[rpcmiddleware]
+rpcmiddleware.enable=true
+```
+
+Set permissions:
+```bash
+sudo chown -R lnd:lnd /mnt/ssd/lnd
+sudo chmod 750 /mnt/ssd/lnd
+```
+
+---
+
+### 4.3 Create LND systemd service
+
+Create `/etc/systemd/system/lnd.service`:
+
+```ini
+[Unit]
+Description=Lightning Network Daemon (LND)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/lnd --lnddir=/data/lnd
+ExecStop=/usr/local/bin/lncli --lnddir=/data/lnd stop
+Restart=on-failure
+RestartSec=60
+Type=notify
+TimeoutStartSec=1200
+TimeoutStopSec=3600
+User=lnd
+Group=lnd
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable lnd
+sudo systemctl start lnd
+sleep 30 && systemctl status lnd --no-pager | grep Active
+```
+
+Expected: `Active: active (running)`
+Note: "wallet locked" in logs is normal before wallet creation.
+
+---
+
+## PHASE 5 — Debian-specific fixes
+
+### 5.1 Check port 8080 conflict
+
+```bash
+ss -tlnp | grep 8080
+```
+
+- If a service appears: use `restlisten=127.0.0.1:8082` in `lnd.conf` (already set in the template above).
+- If nothing appears: the default port is free and `8082` still works fine.
+
+---
+
+### 5.2 Configure Tor — debian-tor group
+
+> ⚠️ **Critical Debian difference:** the Tor cookie group is `debian-tor`, not `tor`.
+> Missing this step causes LND to fail connecting to Tor silently.
+
+```bash
+sudo usermod -aG debian-tor lnd
+```
+
+Verify Tor is running and configure if needed:
+```bash
+systemctl status tor --no-pager | head -5
+```
+
+If not installed:
+```bash
+sudo apt-get install -y tor
+```
+
+Add required Tor configuration if not present:
+```bash
+sudo bash -c 'grep -q "ControlPort 9051" /etc/tor/torrc || cat >> /etc/tor/torrc << EOF
+
+# LightningOS LND
+ControlPort 9051
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+EOF'
+sudo systemctl restart tor
+```
+
+---
+
+### 5.3 Replace GoTTY with arm64 build
+
+> ⚠️ The GoTTY binary bundled by the installer is `amd64`. It returns `Exec format error` on Raspberry Pi.
+> Replace it with the correct `arm64` build.
+
+```bash
+curl -L https://github.com/sorenisanerd/gotty/releases/download/v1.5.0/gotty_v1.5.0_linux_arm64.tar.gz \
+  -o /tmp/gotty.tar.gz
+tar -xzf /tmp/gotty.tar.gz -C /tmp
+sudo install -m 0755 /tmp/gotty /usr/local/bin/gotty
+gotty --version
+```
+
+Expected: `gotty version v1.5.0`
+
+---
+
+### 5.4 Set group permissions
+
+```bash
+sudo usermod -aG lnd lightningos
+sudo usermod -aG docker lightningos
+```
+
+---
+
+### 5.5 Configure secrets.env and config.yaml
+
+Create `/etc/lightningos/secrets.env` — replace all placeholder values:
+
+```bash
+sudo tee /etc/lightningos/secrets.env > /dev/null << 'EOF'
+LND_PG_DSN=postgres://lndpg:<LND_DB_PASSWORD>@127.0.0.1:5432/lnd?sslmode=disable
+NOTIFICATIONS_PG_DSN=postgres://losapp:<APP_DB_PASSWORD>@127.0.0.1:5432/lightningos?sslmode=disable
+NOTIFICATIONS_PG_ADMIN_DSN=postgres://losadmin:<ADMIN_DB_PASSWORD>@127.0.0.1:5432/postgres?sslmode=disable
+BITCOIN_RPC_USER=<YOUR_RPC_USER>
+BITCOIN_RPC_PASS=<YOUR_RPC_PASS>
+REPORTS_TIMEZONE=America/Sao_Paulo
+TERMINAL_ENABLED=1
+TERMINAL_CREDENTIAL=losop:<GENERATE_STRONG_PASSWORD>
+TERMINAL_OPERATOR_USER=losop
+TERMINAL_OPERATOR_PASSWORD=<SAME_AS_ABOVE>
+TERMINAL_PORT=7681
+EOF
+
+sudo chmod 660 /etc/lightningos/secrets.env
+sudo chown root:lightningos /etc/lightningos/secrets.env
+```
+
+Create `/etc/lightningos/config.yaml`:
+
+```bash
+sudo tee /etc/lightningos/config.yaml > /dev/null << 'EOF'
+server:
+  host: "0.0.0.0"
+  port: 8443
+  tls_cert: "/etc/lightningos/tls/server.crt"
+  tls_key: "/etc/lightningos/tls/server.key"
+
+lnd:
+  grpc_host: "127.0.0.1:10009"
+  tls_cert_path: "/data/lnd/tls.cert"
+  admin_macaroon_path: "/data/lnd/data/chain/bitcoin/mainnet/admin.macaroon"
+
+bitcoin_remote:
+  rpchost: "127.0.0.1:8332"
+  zmq_rawblock: "tcp://127.0.0.1:28332"
+  zmq_rawtx: "tcp://127.0.0.1:28333"
+
+postgres:
+  db_name: "lnd"
+
+ui:
+  static_dir: "/opt/lightningos/ui"
+
+features:
+  enable_login: false
+  enable_bitcoin_local_placeholder: true
+  enable_app_store_placeholder: true
+EOF
+```
+
+---
+
+### 5.6 Create LightningOS Manager systemd service
+
+Create `/etc/systemd/system/lightningos-manager.service`:
+
+```ini
+[Unit]
+Description=LightningOS Manager
+After=network-online.target lnd.service
+Wants=network-online.target
+
+[Service]
+User=lightningos
+Group=lightningos
+SupplementaryGroups=lnd systemd-journal docker
+Type=simple
+EnvironmentFile=/etc/lightningos/secrets.env
+ExecStart=/opt/lightningos/manager/lightningos-manager --config /etc/lightningos/config.yaml
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=65536
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/var/lib/lightningos /var/log/lightningos /etc/lightningos /data/lnd
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable lightningos-manager
+sudo systemctl start lightningos-manager
+```
+
+---
+
+## PHASE 6 — Validation and first access
+
+### 6.1 Verify all services
+
+```bash
+for svc in bitcoin lnd lightningos-manager; do
+  STATUS=$(systemctl is-active $svc 2>/dev/null || echo "not found")
+  echo "$svc: $STATUS"
+done
+sudo docker ps --format "{{.Names}}: {{.Status}}" | grep postgres
+```
+
+Expected:
+```
+bitcoin: active
+lnd: active
+lightningos-manager: active
+lightningos-postgres: Up ...
+```
+
+Test the API:
+```bash
+curl -sk https://127.0.0.1:8443/api/health | python3 -m json.tool
+```
+
+---
+
+### 6.2 Access the UI
+
+Find your IP:
+```bash
+hostname -I | awk '{print $1}'
+```
+
+Open in a browser on the same network:
+```
+https://<YOUR_IP>:8443
+```
+
+> The browser will show a self-signed certificate warning. Click "Advanced" → "Proceed anyway".
+> This is expected and safe on your local network.
+
+---
+
+### 6.3 Complete the wizard and create the wallet
+
+1. **Bitcoin Remote:** enter your Bitcoin Core RPC credentials
+2. **Create wallet:** the system generates 24 seed words
+3. **Write down your seed:** on paper only — never take a photo or save digitally
+4. **Unlock:** create a strong wallet password
+
+> 🔐 **The 24 seed words are the only way to recover your funds.**
+> Store them physically in a secure location. Never photograph or digitally store them.
+
+---
+
+### 6.4 Configure auto-unlock (optional)
+
+After creating the wallet:
+
+```bash
+echo "YOUR_WALLET_PASSWORD" | sudo tee /data/lnd/password.txt
+sudo chmod 600 /data/lnd/password.txt
+sudo chown lnd:lnd /data/lnd/password.txt
+```
+
+Uncomment in `/mnt/ssd/lnd/lnd.conf`:
+```
+wallet-unlock-password-file=/data/lnd/password.txt
+wallet-unlock-allow-create=true
+```
+
+Restart LND:
+```bash
+sudo systemctl restart lnd
+```
+
+---
+
+## 🎉 Your node is up and running!
+
+Congratulations — you now have a fully operational Lightning node on Raspberry Pi 5 with Debian 12!
+
+Your node is connected to the Bitcoin mainnet, LND is running, and LightningOS Light is
+managing everything through a clean web interface at `https://<YOUR_IP>:8443`.
+
+**What to do next:**
+- Open channels with well-connected peers (500k+ sats recommended for routing)
+- Enable **Autofee** in Lightning Ops to automate fee management
+- Set up **Telegram notifications** for on-chain and Lightning events
+- Explore the **App Store** to install LNDg for advanced monitoring
+
+---
+
+## ⚡ Enjoyed this guide? Send some sats!
+
+This guide was written by the Brazilian Lightning Network community based on real hands-on
+experience installing and running LightningOS Light on a Raspberry Pi 5 with Debian 12.
+
+Hours of trial, error, and troubleshooting went into documenting every quirk so you
+wouldn't have to find them the hard way. If it saved you time, consider sending a small
+donation to the node that made it possible!
+
+```
+⚡ Node:   RaspNode-BR
+   Pubkey: 025b2f2679168c49dc72b6ac93ba8b9b7f782113eef613b7bc09bcf53ea05b792c
+```
+
+> Connect via [Amboss](https://amboss.space/node/025b2f2679168c49dc72b6ac93ba8b9b7f782113eef613b7bc09bcf53ea05b792c)
+> or open a channel directly — every sat helps the Brazilian Lightning community grow! 🇧🇷
+
+
+---
+
+## Troubleshooting
+
+| Problem | Likely cause | Solution |
+|---|---|---|
+| `Exec format error` on LND or GoTTY | `amd64` binary on `arm64` system | Download `linux-arm64` version explicitly |
+| LightningOS not accessible on port 8443 | Manager failed to start | `journalctl -u lightningos-manager -n 50 --no-pager` |
+| LND cannot connect to Tor | `lnd` user not in `debian-tor` group | `sudo usermod -aG debian-tor lnd && sudo systemctl restart lnd` |
+| PostgreSQL unreachable | Docker container stopped | `cd /opt/lightningos-postgres && sudo docker compose up -d` |
+| `log read failed: journalctl failed` in UI | Debian permission limitation | Cosmetic warning only — no functional impact |
+| Port 8080 conflict | Another service (e.g. Nominatim) | Use `restlisten=127.0.0.1:8082` in `lnd.conf` |
+| Go build fails with module errors | Module cache issue | Run `sudo /usr/local/go/bin/go mod download` first |
+
+---
+
+## Reference — Key file paths
+
+| What | Path |
+|---|---|
+| Bitcoin Core config | `/etc/bitcoin/bitcoin.conf` |
+| Bitcoin data | `/mnt/ssd/bitcoin` → symlink `/data/bitcoin` |
+| LND config | `/mnt/ssd/lnd/lnd.conf` |
+| LND data | `/mnt/ssd/lnd` → symlink `/data/lnd` |
+| LightningOS config | `/etc/lightningos/config.yaml` |
+| LightningOS secrets | `/etc/lightningos/secrets.env` |
+| Manager binary | `/opt/lightningos/manager/lightningos-manager` |
+| UI files | `/opt/lightningos/ui/` |
+| PostgreSQL data | `/mnt/ssd/postgres/data` |
+| Repository | `/opt/brln-os-light/lightningos-light` |
+
+---
+
+## Tested service status after full installation
+
+| Service | Status |
+|---|---|
+| Bitcoin Core | ✅ `systemctl status bitcoin` |
+| LND | ✅ `systemctl status lnd` |
+| LightningOS Manager | ✅ `systemctl status lightningos-manager` |
+| PostgreSQL (Docker) | ✅ `docker ps \| grep postgres` |
+| Tor | ✅ `systemctl status tor` |
+| Web Terminal (GoTTY) | ✅ `systemctl status lightningos-terminal` |
+
+---
+
+## Useful links
+
+- Original project: [github.com/jvxis/brln-os-light](https://github.com/jvxis/brln-os-light)
+- This fork: [github.com/MarcosJRcwb/brln-os-light](https://github.com/MarcosJRcwb/brln-os-light)
+- BR⚡LN Community: [services.br-ln.com](https://services.br-ln.com)
+- LND documentation: [docs.lightning.engineering](https://docs.lightning.engineering)
+- Check your node: [amboss.space](https://amboss.space)
+- LND releases: [github.com/lightningnetwork/lnd/releases](https://github.com/lightningnetwork/lnd/releases)
+
+---
+
+*Community guide — March 2026 — Brazilian Lightning Network*

--- a/docs/17_INSTALL_RASPBERRYPI5_DEBIAN12_PT_BR.md
+++ b/docs/17_INSTALL_RASPBERRYPI5_DEBIAN12_PT_BR.md
@@ -1,0 +1,814 @@
+# Instalando o LightningOS Light no Raspberry Pi 5 — Debian 12 (Bookworm)
+
+> **Guia comunitário** — Adaptação do instalador oficial do LightningOS Light para
+> **Raspberry Pi 5 (8 GB RAM)** rodando **Debian 12 Bookworm (aarch64)** com Bitcoin Core já instalado.
+>
+> Projeto original: [https://github.com/jvxis/brln-os-light](https://github.com/jvxis/brln-os-light)
+> Este fork: [https://github.com/MarcosJRcwb/brln-os-light](https://github.com/MarcosJRcwb/brln-os-light)
+
+---
+
+[Read in English](16_INSTALL_RASPBERRYPI5_DEBIAN12.md)
+
+---
+
+## Por que um guia separado?
+
+O instalador oficial `install.sh` e `install_existing_pi.sh` foram desenvolvidos para
+**Ubuntu Server 22.04/24.04**. O Debian 12 tem diferenças importantes que causam falhas
+silenciosas se não forem tratadas:
+
+| Problema | Detalhe |
+|---|---|
+| Nome do grupo do Tor | Debian usa `debian-tor`, não `tor` |
+| Arquitetura do binário Go | O instalador pode baixar `amd64` — precisa forçar `arm64` |
+| Arquitetura do GoTTY | Binário bundled é `amd64` — precisa substituir |
+| Conflito de porta | Porta 8080 pode estar em uso — use 8082 |
+| Método de instalação do PostgreSQL | APT (PGDG) pode falhar — use Docker |
+| Logs do journalctl na UI | Mostra aviso de permissão — apenas cosmético, sem impacto |
+
+---
+
+## Pré-requisitos
+
+| Item | Requisito |
+|---|---|
+| Hardware | Raspberry Pi 5, 8 GB RAM |
+| Sistema Operacional | Debian 12 Bookworm, aarch64 |
+| Armazenamento | SSD externo, mínimo 1 TB (2 TB recomendado) |
+| Bitcoin Core | Já instalado e **completamente sincronizado** |
+| Acesso | SSH (PuTTY ou qualquer terminal) ou terminal local |
+| Internet | Conexão estável durante toda a instalação |
+
+> ⚠️ **Não inicie até que o Bitcoin Core esteja 100% sincronizado.**
+> Verifique com: `bitcoin-cli getblockchaininfo | grep verificationprogress`
+> O valor precisa ser `0.9999...` ou `1`.
+
+---
+
+## Visão geral da instalação
+
+```
+FASE 1: Preparação do ambiente
+  1.1  Verificar SO e arquitetura
+  1.2  Confirmar que o Bitcoin Core está rodando e sincronizado
+  1.3  Adicionar ZMQ ao bitcoin.conf
+  1.4  Criar symlinks em /data
+       ↓
+FASE 2: Dependências
+  2.1  Instalar Go 1.24 (linux-arm64 — obrigatório)
+  2.2  Instalar Node.js 20.x
+  2.3  Instalar PostgreSQL via Docker
+       ↓
+FASE 3: Instalação do LightningOS
+  3.1  Clonar repositório
+  3.2  Criar usuários e diretórios
+  3.3  Compilar o manager (Go build)
+  3.4  Compilar a UI (npm build)
+  3.5  Gerar certificado TLS
+       ↓
+FASE 4: Instalação do LND
+  4.1  Baixar LND v0.20.0 (linux-arm64)
+  4.2  Criar serviço systemd
+       ↓
+FASE 5: Ajustes específicos do Debian
+  5.1  Verificar conflito na porta 8080
+  5.2  Configurar Tor com grupo debian-tor
+  5.3  Substituir GoTTY pelo binário arm64 correto
+  5.4  Configurar permissões de grupos
+  5.5  Criar secrets.env e config.yaml
+  5.6  Criar serviço systemd do LightningOS
+       ↓
+FASE 6: Validação
+  6.1  Verificar todos os serviços
+  6.2  Acessar a UI e executar o wizard
+  6.3  Criar carteira — anotar a seed em papel físico
+```
+
+> **Um comando por vez.** Verifique a saída antes de prosseguir para o próximo passo.
+
+---
+
+## FASE 1 — Preparação do ambiente
+
+### 1.1 Verificar o sistema operacional
+
+```bash
+uname -a
+```
+
+Saída esperada (deve conter `aarch64` e `Debian`):
+```
+Linux raspnode 6.12.62+rpt-rpi-2712 #1 SMP PREEMPT Debian aarch64 GNU/Linux
+```
+
+> ❌ Se `aarch64` não aparecer: este guia não se aplica ao seu hardware.
+
+---
+
+### 1.2 Verificar o Bitcoin Core
+
+```bash
+systemctl status bitcoin --no-pager | head -10
+```
+
+Esperado: `Active: active (running)`
+
+> ⏳ Se estiver sincronizando: aguarde `verificationprogress` chegar em `1` antes de continuar.
+
+---
+
+### 1.3 Adicionar ZMQ ao bitcoin.conf
+
+O LND precisa do ZMQ para receber notificações em tempo real de blocos e transações.
+
+Verifique se já está configurado:
+```bash
+sudo grep zmq /etc/bitcoin/bitcoin.conf
+```
+
+Se as linhas abaixo já estiverem presentes, pule para o passo 1.4:
+```
+zmqpubrawblock=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:28333
+```
+
+Se não estiverem, adicione e reinicie:
+```bash
+sudo bash -c 'printf "\n# ZMQ para o LND\nzmqpubrawblock=tcp://127.0.0.1:28332\nzmqpubrawtx=tcp://127.0.0.1:28333\n" >> /etc/bitcoin/bitcoin.conf'
+sudo systemctl restart bitcoin
+sleep 30 && systemctl status bitcoin --no-pager | grep Active
+```
+
+---
+
+### 1.4 Criar symlinks em /data
+
+O LightningOS espera encontrar dados em `/data/bitcoin` e `/data/lnd`.
+Adapte os caminhos abaixo para o ponto de montagem real do seu SSD.
+
+```bash
+sudo mkdir -p /data
+sudo ln -sf /mnt/ssd/bitcoin /data/bitcoin
+sudo mkdir -p /mnt/ssd/lnd
+sudo ln -sf /mnt/ssd/lnd /data/lnd
+sudo ln -sf /etc/bitcoin/bitcoin.conf /mnt/ssd/bitcoin/bitcoin.conf
+```
+
+Verifique:
+```bash
+ls -la /data/
+```
+
+Esperado:
+```
+bitcoin -> /mnt/ssd/bitcoin
+lnd -> /mnt/ssd/lnd
+```
+
+---
+
+## FASE 2 — Dependências
+
+### 2.1 Instalar Go 1.24 (linux-arm64 — CRÍTICO)
+
+> ⚠️ **Ponto de falha comum:** scripts automáticos podem baixar o binário `amd64`.
+> No Raspberry Pi, sempre instale `linux-arm64` manualmente.
+
+```bash
+cd /tmp && curl -LO https://go.dev/dl/go1.24.0.linux-arm64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.0.linux-arm64.tar.gz
+```
+
+Verifique (deve mostrar `linux/arm64`):
+```bash
+/usr/local/go/bin/go version
+```
+
+Esperado:
+```
+go version go1.24.0 linux/arm64
+```
+
+> ❌ Se mostrar `amd64`: apague e reinstale usando o arquivo correto acima.
+
+---
+
+### 2.2 Instalar Node.js 20.x
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+node --version
+```
+
+Esperado: `v20.x.x`
+
+---
+
+### 2.3 Instalar PostgreSQL via Docker
+
+Verifique se o Docker está instalado:
+```bash
+docker --version
+```
+
+Se não estiver:
+```bash
+sudo apt-get install -y docker.io docker-compose-plugin
+sudo systemctl enable --now docker
+```
+
+Crie o diretório de dados e o arquivo Docker Compose:
+
+```bash
+sudo mkdir -p /mnt/ssd/postgres/data /opt/lightningos-postgres
+```
+
+Crie `/opt/lightningos-postgres/docker-compose.yml` com o conteúdo abaixo.
+**Substitua todas as senhas de exemplo por valores fortes e anote em local seguro.**
+
+```yaml
+version: "3.8"
+services:
+  postgres:
+    image: postgres:16
+    container_name: lightningos-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: losadmin
+      POSTGRES_PASSWORD: <SENHA_ADMIN_FORTE>
+      POSTGRES_DB: postgres
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - /mnt/ssd/postgres/data:/var/lib/postgresql/data
+```
+
+Inicie o PostgreSQL:
+```bash
+cd /opt/lightningos-postgres && sudo docker compose up -d
+sleep 10 && sudo docker ps | grep postgres
+```
+
+Esperado: container com status `Up`.
+
+Crie os bancos de dados e usuários necessários (substitua as senhas pelas que você definiu):
+```bash
+sudo docker exec -it lightningos-postgres psql -U losadmin -c "
+CREATE USER lndpg WITH PASSWORD '<SENHA_LND_DB>';
+CREATE DATABASE lnd OWNER lndpg;
+CREATE USER losapp WITH PASSWORD '<SENHA_APP_DB>';
+CREATE DATABASE lightningos OWNER losapp;
+GRANT ALL PRIVILEGES ON DATABASE lnd TO lndpg;
+GRANT ALL PRIVILEGES ON DATABASE lightningos TO losapp;
+"
+```
+
+---
+
+## FASE 3 — Instalação do LightningOS
+
+### 3.1 Clonar o repositório
+
+```bash
+sudo git clone https://github.com/MarcosJRcwb/brln-os-light /opt/brln-os-light
+ls /opt/brln-os-light/lightningos-light/
+```
+
+---
+
+### 3.2 Criar usuários e diretórios
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin lightningos 2>/dev/null || echo "já existe"
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin lnd 2>/dev/null || echo "já existe"
+sudo mkdir -p /opt/lightningos/manager /opt/lightningos/ui
+sudo mkdir -p /etc/lightningos/tls
+sudo mkdir -p /var/lib/lightningos /var/log/lightningos
+```
+
+---
+
+### 3.3 Compilar o manager (backend Go)
+
+> ⏳ **Esta etapa pode demorar de 5 a 15 minutos.** Nenhuma saída é mostrada durante a compilação — isso é normal. Aguarde o prompt retornar.
+
+```bash
+cd /opt/brln-os-light/lightningos-light
+sudo GOFLAGS="-mod=mod" /usr/local/go/bin/go build -o dist/lightningos-manager ./cmd/lightningos-manager
+```
+
+Verifique se o binário foi criado (deve ter entre 20 e 40 MB):
+```bash
+ls -lh dist/lightningos-manager
+```
+
+Instale:
+```bash
+sudo install -m 0755 dist/lightningos-manager /opt/lightningos/manager/lightningos-manager
+```
+
+> ❌ Se aparecerem erros de módulos: execute `sudo /usr/local/go/bin/go mod download` antes de tentar novamente.
+
+---
+
+### 3.4 Compilar a interface web (UI)
+
+```bash
+cd /opt/brln-os-light/lightningos-light/ui
+sudo npm install
+```
+
+> ⏳ Aguarde a instalação dos pacotes npm (pode demorar ~5 minutos).
+
+```bash
+sudo npm run build
+sudo cp -a dist/. /opt/lightningos/ui/
+```
+
+Verifique:
+```bash
+ls /opt/lightningos/ui/ | head -5
+```
+
+Esperado: `index.html  assets/  ...`
+
+---
+
+### 3.5 Gerar certificado TLS autoassinado
+
+```bash
+sudo openssl req -x509 -newkey rsa:4096 \
+  -keyout /etc/lightningos/tls/server.key \
+  -out /etc/lightningos/tls/server.crt \
+  -days 3650 -nodes \
+  -subj "/CN=lightningos" \
+  -addext "subjectAltName=IP:127.0.0.1,IP:0.0.0.0"
+```
+
+---
+
+## FASE 4 — Instalação do LND
+
+### 4.1 Baixar LND v0.20.0 (linux-arm64)
+
+> ⚠️ Sempre use `linux-arm64`. O binário `amd64` retorna `Exec format error` no Raspberry Pi.
+
+```bash
+cd /tmp
+curl -LO https://github.com/lightningnetwork/lnd/releases/download/v0.20.0-beta/lnd-linux-arm64-v0.20.0-beta.tar.gz
+tar -xzf lnd-linux-arm64-v0.20.0-beta.tar.gz
+sudo install -m 0755 lnd-linux-arm64-v0.20.0-beta/lnd /usr/local/bin/lnd
+sudo install -m 0755 lnd-linux-arm64-v0.20.0-beta/lncli /usr/local/bin/lncli
+lnd --version
+```
+
+Esperado: `lnd version 0.20.0-beta`
+
+---
+
+### 4.2 Configurar lnd.conf
+
+Crie `/mnt/ssd/lnd/lnd.conf` com o conteúdo abaixo.
+
+> **Substitua:**
+> - `<SEU_RPC_USER>` e `<SEU_RPC_PASS>` pelas credenciais RPC do seu Bitcoin Core
+> - `<SENHA_LND_DB>` pela senha do PostgreSQL que você definiu na Fase 2
+> - Se a porta 8080 já estiver em uso, mantenha `restlisten=127.0.0.1:8082` (veja passo 5.1)
+
+```ini
+[Application Options]
+alias=MeuNode-BR
+color=#ff9900
+debuglevel=info
+restlisten=127.0.0.1:8082
+
+# Descomente após criar a carteira:
+# wallet-unlock-password-file=/data/lnd/password.txt
+# wallet-unlock-allow-create=true
+
+tlsautorefresh=true
+tlsextraip=127.0.0.1
+tlsdisableautofill=true
+
+accept-keysend=true
+accept-amp=true
+allow-circular-route=true
+
+[Bitcoin]
+bitcoin.mainnet=1
+bitcoin.node=bitcoind
+bitcoin.basefee=1000
+bitcoin.feerate=1
+bitcoin.timelockdelta=144
+
+[db]
+db.backend=postgres
+db.use-native-sql=true
+
+[postgres]
+db.postgres.dsn=postgres://lndpg:<SENHA_LND_DB>@127.0.0.1:5432/lnd?sslmode=disable
+db.postgres.timeout=0
+
+[Bitcoind]
+bitcoind.rpchost=127.0.0.1:8332
+bitcoind.rpcuser=<SEU_RPC_USER>
+bitcoind.rpcpass=<SEU_RPC_PASS>
+bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
+bitcoind.estimatemode=ECONOMICAL
+
+[tor]
+tor.active=true
+tor.v3=true
+tor.skip-proxy-for-clearnet-targets=false
+tor.streamisolation=true
+
+[rpcmiddleware]
+rpcmiddleware.enable=true
+```
+
+Configure as permissões:
+```bash
+sudo chown -R lnd:lnd /mnt/ssd/lnd
+sudo chmod 750 /mnt/ssd/lnd
+```
+
+---
+
+### 4.3 Criar serviço systemd do LND
+
+Crie `/etc/systemd/system/lnd.service`:
+
+```ini
+[Unit]
+Description=Lightning Network Daemon (LND)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/lnd --lnddir=/data/lnd
+ExecStop=/usr/local/bin/lncli --lnddir=/data/lnd stop
+Restart=on-failure
+RestartSec=60
+Type=notify
+TimeoutStartSec=1200
+TimeoutStopSec=3600
+User=lnd
+Group=lnd
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Habilite e inicie:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable lnd
+sudo systemctl start lnd
+sleep 30 && systemctl status lnd --no-pager | grep Active
+```
+
+Esperado: `Active: active (running)`
+
+> Mensagem "wallet locked" nos logs é normal antes de criar a carteira.
+
+---
+
+## FASE 5 — Ajustes específicos do Debian 12
+
+### 5.1 Verificar conflito na porta 8080
+
+```bash
+ss -tlnp | grep 8080
+```
+
+- Se algum serviço aparecer: use `restlisten=127.0.0.1:8082` no `lnd.conf` (já definido no template acima).
+- Se não aparecer nada: a porta padrão está livre, mas `8082` também funciona normalmente.
+
+---
+
+### 5.2 Configurar Tor — grupo debian-tor
+
+> ⚠️ **Diferença crítica Debian vs Ubuntu:** o grupo do cookie do Tor é `debian-tor`, não `tor`.
+> Ignorar este passo faz o LND falhar ao conectar no Tor silenciosamente.
+
+```bash
+sudo usermod -aG debian-tor lnd
+```
+
+Verifique se o Tor está rodando:
+```bash
+systemctl status tor --no-pager | head -5
+```
+
+Se não estiver instalado:
+```bash
+sudo apt-get install -y tor
+```
+
+Adicione a configuração necessária ao Tor se ainda não estiver presente:
+```bash
+sudo bash -c 'grep -q "ControlPort 9051" /etc/tor/torrc || cat >> /etc/tor/torrc << EOF
+
+# LightningOS LND
+ControlPort 9051
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+EOF'
+sudo systemctl restart tor
+```
+
+---
+
+### 5.3 Substituir GoTTY pelo binário arm64
+
+> ⚠️ **Problema frequente:** o GoTTY instalado pelo script é `amd64`.
+> No Raspberry Pi (arm64), ele retorna `Exec format error`. Substitua pelo binário correto.
+
+```bash
+curl -L https://github.com/sorenisanerd/gotty/releases/download/v1.5.0/gotty_v1.5.0_linux_arm64.tar.gz \
+  -o /tmp/gotty.tar.gz
+tar -xzf /tmp/gotty.tar.gz -C /tmp
+sudo install -m 0755 /tmp/gotty /usr/local/bin/gotty
+gotty --version
+```
+
+Esperado: `gotty version v1.5.0`
+
+---
+
+### 5.4 Configurar permissões de grupos
+
+```bash
+sudo usermod -aG lnd lightningos
+sudo usermod -aG docker lightningos
+```
+
+---
+
+### 5.5 Configurar secrets.env e config.yaml
+
+Crie `/etc/lightningos/secrets.env` — substitua todos os valores entre `< >`:
+
+```bash
+sudo tee /etc/lightningos/secrets.env > /dev/null << 'EOF'
+LND_PG_DSN=postgres://lndpg:<SENHA_LND_DB>@127.0.0.1:5432/lnd?sslmode=disable
+NOTIFICATIONS_PG_DSN=postgres://losapp:<SENHA_APP_DB>@127.0.0.1:5432/lightningos?sslmode=disable
+NOTIFICATIONS_PG_ADMIN_DSN=postgres://losadmin:<SENHA_ADMIN_DB>@127.0.0.1:5432/postgres?sslmode=disable
+BITCOIN_RPC_USER=<SEU_RPC_USER>
+BITCOIN_RPC_PASS=<SEU_RPC_PASS>
+REPORTS_TIMEZONE=America/Sao_Paulo
+TERMINAL_ENABLED=1
+TERMINAL_CREDENTIAL=losop:<GERE_UMA_SENHA_FORTE>
+TERMINAL_OPERATOR_USER=losop
+TERMINAL_OPERATOR_PASSWORD=<MESMA_SENHA_ACIMA>
+TERMINAL_PORT=7681
+EOF
+
+sudo chmod 660 /etc/lightningos/secrets.env
+sudo chown root:lightningos /etc/lightningos/secrets.env
+```
+
+Crie `/etc/lightningos/config.yaml`:
+
+```bash
+sudo tee /etc/lightningos/config.yaml > /dev/null << 'EOF'
+server:
+  host: "0.0.0.0"
+  port: 8443
+  tls_cert: "/etc/lightningos/tls/server.crt"
+  tls_key: "/etc/lightningos/tls/server.key"
+
+lnd:
+  grpc_host: "127.0.0.1:10009"
+  tls_cert_path: "/data/lnd/tls.cert"
+  admin_macaroon_path: "/data/lnd/data/chain/bitcoin/mainnet/admin.macaroon"
+
+bitcoin_remote:
+  rpchost: "127.0.0.1:8332"
+  zmq_rawblock: "tcp://127.0.0.1:28332"
+  zmq_rawtx: "tcp://127.0.0.1:28333"
+
+postgres:
+  db_name: "lnd"
+
+ui:
+  static_dir: "/opt/lightningos/ui"
+
+features:
+  enable_login: false
+  enable_bitcoin_local_placeholder: true
+  enable_app_store_placeholder: true
+EOF
+```
+
+---
+
+### 5.6 Criar serviço systemd do LightningOS Manager
+
+Crie `/etc/systemd/system/lightningos-manager.service`:
+
+```ini
+[Unit]
+Description=LightningOS Manager
+After=network-online.target lnd.service
+Wants=network-online.target
+
+[Service]
+User=lightningos
+Group=lightningos
+SupplementaryGroups=lnd systemd-journal docker
+Type=simple
+EnvironmentFile=/etc/lightningos/secrets.env
+ExecStart=/opt/lightningos/manager/lightningos-manager --config /etc/lightningos/config.yaml
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=65536
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/var/lib/lightningos /var/log/lightningos /etc/lightningos /data/lnd
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Habilite e inicie:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable lightningos-manager
+sudo systemctl start lightningos-manager
+```
+
+---
+
+## FASE 6 — Validação e primeiro acesso
+
+### 6.1 Verificar todos os serviços
+
+```bash
+for svc in bitcoin lnd lightningos-manager; do
+  STATUS=$(systemctl is-active $svc 2>/dev/null || echo "não encontrado")
+  echo "$svc: $STATUS"
+done
+sudo docker ps --format "{{.Names}}: {{.Status}}" | grep postgres
+```
+
+Esperado:
+```
+bitcoin: active
+lnd: active
+lightningos-manager: active
+lightningos-postgres: Up ...
+```
+
+Teste a API:
+```bash
+curl -sk https://127.0.0.1:8443/api/health | python3 -m json.tool
+```
+
+---
+
+### 6.2 Descobrir o IP e acessar a UI
+
+```bash
+hostname -I | awk '{print $1}'
+```
+
+Abra no navegador do seu computador (na mesma rede local):
+```
+https://SEU_IP_AQUI:8443
+```
+
+> O navegador vai mostrar um aviso de certificado autoassinado. Clique em
+> **"Avançado"** → **"Prosseguir mesmo assim"**. Isso é esperado e seguro na sua rede local.
+
+---
+
+### 6.3 Completar o Wizard e criar a carteira
+
+1. **Bitcoin Remote:** informe as credenciais RPC do seu Bitcoin Core
+2. **Criar carteira:** o sistema vai gerar 24 palavras (seed)
+3. **Anotar a seed:** escreva em papel físico — nunca em foto ou arquivo digital
+4. **Desbloquear:** crie uma senha forte para a carteira
+
+> 🔐 **As 24 palavras são a ÚNICA forma de recuperar seus fundos.**
+> Guarde em local seguro e físico. Nunca fotografe. Nunca salve no computador ou na nuvem.
+
+---
+
+### 6.4 Configurar desbloqueio automático (opcional)
+
+Após criar a carteira:
+
+```bash
+echo "SUA_SENHA_DA_CARTEIRA" | sudo tee /data/lnd/password.txt
+sudo chmod 600 /data/lnd/password.txt
+sudo chown lnd:lnd /data/lnd/password.txt
+```
+
+Descomente no `/mnt/ssd/lnd/lnd.conf`:
+```
+wallet-unlock-password-file=/data/lnd/password.txt
+wallet-unlock-allow-create=true
+```
+
+Reinicie o LND:
+```bash
+sudo systemctl restart lnd
+```
+
+---
+
+## 🎉 Seu nó está no ar!
+
+Parabéns — você agora tem um nó Lightning totalmente operacional no Raspberry Pi 5 com Debian 12!
+
+Seu nó está conectado à mainnet do Bitcoin, o LND está rodando e o LightningOS Light
+gerencia tudo através de uma interface web em `https://SEU_IP:8443`.
+
+**Próximos passos sugeridos:**
+- Abra canais com peers bem conectados (500k+ sats recomendado para roteamento)
+- Habilite o **Autofee** em Lightning Ops para gerenciar taxas automaticamente
+- Configure **notificações no Telegram** para eventos on-chain e Lightning
+- Explore a **App Store** para instalar o LNDg para monitoramento avançado
+
+---
+
+## ⚡ Gostou do guia? Manda uns sats!
+
+Este guia foi escrito pela comunidade brasileira de Lightning Network com base em
+experiência real — instalando e operando o LightningOS Light num Raspberry Pi 5 com Debian 12.
+
+Horas de tentativa, erro e troubleshooting foram documentadas aqui para que você
+não precisasse descobrir cada problema no caminho difícil. Se este guia te poupou
+tempo, considere enviar uma doação simbólica para o nó que tornou isso possível!
+
+```
+⚡ Node:   RaspNode-BR
+   Pubkey: 025b2f2679168c49dc72b6ac93ba8b9b7f782113eef613b7bc09bcf53ea05b792c
+```
+
+> Conecte via [Amboss](https://amboss.space/node/025b2f2679168c49dc72b6ac93ba8b9b7f782113eef613b7bc09bcf53ea05b792c)
+> ou abra um canal diretamente — cada satoshi ajuda a comunidade brasileira de Lightning Network crescer! 🇧🇷
+
+---
+
+## Troubleshooting
+
+| Problema | Causa provável | Solução |
+|---|---|---|
+| `Exec format error` no LND ou GoTTY | Binário `amd64` num sistema `arm64` | Baixe explicitamente a versão `linux-arm64` |
+| LightningOS não abre na porta 8443 | Manager não iniciou corretamente | `journalctl -u lightningos-manager -n 50 --no-pager` |
+| LND não conecta ao Tor | Usuário `lnd` não está no grupo `debian-tor` | `sudo usermod -aG debian-tor lnd && sudo systemctl restart lnd` |
+| PostgreSQL inacessível | Container Docker parado | `cd /opt/lightningos-postgres && sudo docker compose up -d` |
+| `log read failed: journalctl failed` na UI | Limitação de permissão do Debian | Aviso cosmético — nenhum impacto funcional |
+| Conflito na porta 8080 | Outro serviço (ex: Nominatim) | Use `restlisten=127.0.0.1:8082` no `lnd.conf` |
+| Erros de módulos no Go build | Cache de módulos corrompido | Execute `sudo /usr/local/go/bin/go mod download` antes |
+
+---
+
+## Referência — Caminhos importantes
+
+| O quê | Caminho |
+|---|---|
+| Bitcoin Core conf | `/etc/bitcoin/bitcoin.conf` |
+| Bitcoin dados | `/mnt/ssd/bitcoin` → symlink `/data/bitcoin` |
+| LND conf | `/mnt/ssd/lnd/lnd.conf` |
+| LND dados | `/mnt/ssd/lnd` → symlink `/data/lnd` |
+| LightningOS config | `/etc/lightningos/config.yaml` |
+| LightningOS secrets | `/etc/lightningos/secrets.env` |
+| Manager binary | `/opt/lightningos/manager/lightningos-manager` |
+| UI (interface web) | `/opt/lightningos/ui/` |
+| PostgreSQL dados | `/mnt/ssd/postgres/data` |
+| Repositório | `/opt/brln-os-light/lightningos-light` |
+
+---
+
+## Status esperado após instalação completa
+
+| Serviço | Verificação |
+|---|---|
+| Bitcoin Core | ✅ `systemctl status bitcoin` |
+| LND | ✅ `systemctl status lnd` |
+| LightningOS Manager | ✅ `systemctl status lightningos-manager` |
+| PostgreSQL (Docker) | ✅ `docker ps \| grep postgres` |
+| Tor | ✅ `systemctl status tor` |
+| Terminal Web (GoTTY) | ✅ `systemctl status lightningos-terminal` |
+
+---
+
+## Links úteis
+
+- Projeto original: [github.com/jvxis/brln-os-light](https://github.com/jvxis/brln-os-light)
+- Este fork: [github.com/MarcosJRcwb/brln-os-light](https://github.com/MarcosJRcwb/brln-os-light)
+- Comunidade BR⚡LN: [services.br-ln.com](https://services.br-ln.com)
+- Documentação LND: [docs.lightning.engineering](https://docs.lightning.engineering)
+- Verificar seu nó: [amboss.space](https://amboss.space)
+- Releases do LND: [github.com/lightningnetwork/lnd/releases](https://github.com/lightningnetwork/lnd/releases)
+
+---
+
+*Guia comunitário — Março 2026 — Comunidade Brasileira de Lightning Network*


### PR DESCRIPTION
## 📖 Contexto

Este PR adiciona documentação comunitária para rodar o LightningOS Light em **Raspberry Pi 5 (8 GB RAM)** com **Debian 12 Bookworm (aarch64)**, sobre um Bitcoin Core já instalado e sincronizado.

O instalador oficial (`install.sh` / `install_existing_pi.sh`) foi desenvolvido para Ubuntu Server 22.04/24.04. No Debian 12, existem diferenças importantes que causam falhas silenciosas se não forem tratadas. Este guia documenta todas elas com base em experiência real de instalação e operação.

---

## 🎯 Estratégia adotada

Após feedback do mantenedor, a abordagem foi ajustada para **não alterar nenhum arquivo existente do projeto**. A contribuição se limita exclusivamente à adição de novos arquivos de documentação na pasta `docs/`:

- ✅ `README.md` original preservado 100% — sem nenhuma alteração
- ✅ Novos arquivos adicionados apenas em `docs/`
- ✅ Zero impacto em código, instaladores ou configurações existentes

---

## 📄 Arquivos adicionados

### `docs/16_INSTALL_RASPBERRYPI5_DEBIAN12.md`
Guia completo de instalação em **inglês**, com:
- 6 fases de instalação com comandos isolados e saídas esperadas
- Tabela de diferenças críticas Debian 12 vs Ubuntu
- Seção de troubleshooting com os problemas mais comuns
- Tabela de referência de todos os caminhos importantes
- Checklist de serviços esperados após instalação completa

### `docs/17_INSTALL_RASPBERRYPI5_DEBIAN12_PT_BR.md`
Guia completo de instalação em **português (PT-BR)**, tradução e adaptação do guia EN para a comunidade brasileira.

---

## 🔧 Diferenças críticas documentadas

| Problema | Detalhe | Solução |
|---|---|---|
| Grupo do Tor | Debian usa `debian-tor`, não `tor` | `usermod -aG debian-tor lnd` |
| Binário Go | Instalador pode baixar `amd64` | Instalar `linux-arm64` manualmente |
| Binário GoTTY | Bundled é `amd64` | Substituir por sorenisanerd/gotty v1.5.0 arm64 |
| Porta 8080 | Pode estar em uso (ex: Nominatim) | Usar `restlisten=127.0.0.1:8082` |
| PostgreSQL | PGDG apt pode falhar no Debian | Usar Docker (postgres:16) |
| journalctl na UI | Aviso de permissão | Apenas cosmético, sem impacto funcional |

---

## ✅ Ambiente testado

| Componente | Versão |
|---|---|
| Hardware | Raspberry Pi 5 — 8 GB RAM |
| Sistema Operacional | Debian 12 Bookworm (`Linux 6.12.62+rpt-rpi-2712 aarch64`) |
| Armazenamento | SSD 1.8 TB em `/mnt/ssd` |
| Bitcoin Core | Sincronizado, dados em `/mnt/ssd/bitcoin` |
| LND | v0.20.0-beta |
| LightningOS | v0.3.0-beta |
| Go | 1.24.0 linux-arm64 |
| Node.js | 20.x |
| PostgreSQL | 16 (Docker) |

Nó Lightning ativo na mainnet com canal aberto: **RaspNode-BR** (`025b2f2679168c49dc72b6ac93ba8b9b7f782113eef613b7bc09bcf53ea05b792c`)

---

## 🇧🇷 Motivação

Esta documentação foi desenvolvida pela **comunidade brasileira de Lightning Network** para tornar o LightningOS Light acessível a operadores de Raspberry Pi com Debian 12 — uma combinação muito comum no Brasil e na comunidade BR⚡LN.

O guia em PT-BR é especialmente importante para reduzir a barreira de entrada para novos operadores brasileiros de nós Lightning.