### PR TITLE
Implement interactive UTXO manager and wallet flow provenance graph

### DIFF
--- a/lightningos-light/internal/electrs/client.go
+++ b/lightningos-light/internal/electrs/client.go
@@ -1,0 +1,187 @@
+// Package electrs is a minimal Electrum-protocol client for talking to a
+// local electrs instance. We use it to enrich transactions LND doesn't own
+// (e.g. external senders/recipients on the provenance graph) by fetching
+// their raw form and decoding outputs.
+package electrs
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultAddr    = "127.0.0.1:50001"
+	dialTimeout    = 4 * time.Second
+	requestTimeout = 8 * time.Second
+)
+
+// Client is goroutine-safe; it dials lazily and reuses a single TCP connection
+// guarded by a write mutex. Read responses are correlated by request ID.
+type Client struct {
+	addr   string
+	mu     sync.Mutex
+	conn   net.Conn
+	reader *bufio.Reader
+	nextID atomic.Int64
+}
+
+// New returns a client configured from the ELECTRUM_RPC_ADDR env var, falling
+// back to 127.0.0.1:50001. Pass an explicit override for tests.
+func New(overrideAddr string) *Client {
+	addr := strings.TrimSpace(overrideAddr)
+	if addr == "" {
+		addr = strings.TrimSpace(os.Getenv("ELECTRUM_RPC_ADDR"))
+	}
+	if addr == "" {
+		addr = defaultAddr
+	}
+	return &Client{addr: addr}
+}
+
+func (c *Client) Addr() string { return c.addr }
+
+func (c *Client) dial(ctx context.Context) error {
+	if c.conn != nil {
+		return nil
+	}
+	d := net.Dialer{Timeout: dialTimeout}
+	conn, err := d.DialContext(ctx, "tcp", c.addr)
+	if err != nil {
+		return fmt.Errorf("electrs dial %s: %w", c.addr, err)
+	}
+	c.conn = conn
+	c.reader = bufio.NewReader(conn)
+	return nil
+}
+
+func (c *Client) closeLocked() {
+	if c.conn != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+		c.reader = nil
+	}
+}
+
+type rpcResponse struct {
+	ID    int64           `json:"id"`
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+	Result json.RawMessage `json:"result"`
+}
+
+// Call sends a JSON-RPC request and decodes the result into out. The client
+// reuses one TCP connection so callers are serialized.
+func (c *Client) Call(ctx context.Context, method string, params []any, out any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.dial(ctx); err != nil {
+		return err
+	}
+
+	id := c.nextID.Add(1)
+	req := map[string]any{
+		"id":     id,
+		"method": method,
+		"params": params,
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+
+	deadline := time.Now().Add(requestTimeout)
+	if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) {
+		deadline = dl
+	}
+	_ = c.conn.SetDeadline(deadline)
+
+	if _, err := c.conn.Write(payload); err != nil {
+		c.closeLocked()
+		return fmt.Errorf("electrs write: %w", err)
+	}
+
+	for {
+		line, err := c.reader.ReadBytes('\n')
+		if err != nil {
+			c.closeLocked()
+			return fmt.Errorf("electrs read: %w", err)
+		}
+		var resp rpcResponse
+		if err := json.Unmarshal(line, &resp); err != nil {
+			// Unexpected line (electrs sometimes emits notifications); skip.
+			continue
+		}
+		if resp.ID != id {
+			continue
+		}
+		if resp.Error != nil {
+			return fmt.Errorf("electrs error %d: %s", resp.Error.Code, resp.Error.Message)
+		}
+		if out == nil {
+			return nil
+		}
+		if len(resp.Result) == 0 {
+			return errors.New("electrs empty result")
+		}
+		return json.Unmarshal(resp.Result, out)
+	}
+}
+
+// Ping sends server.version. Returns the [server, protocol] strings.
+func (c *Client) Ping(ctx context.Context) ([2]string, error) {
+	var out [2]string
+	if err := c.Call(ctx, "server.version", []any{"brln-os", "1.4"}, &out); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// VerboseVout mirrors the relevant fields of an electrs verbose-tx vout.
+type VerboseVout struct {
+	Value        float64 `json:"value"`
+	N            uint32  `json:"n"`
+	ScriptPubKey struct {
+		Address   string   `json:"address"`
+		Addresses []string `json:"addresses"`
+		Type      string   `json:"type"`
+		Hex       string   `json:"hex"`
+	} `json:"scriptPubKey"`
+}
+
+// VerboseVin mirrors the relevant fields of an electrs verbose-tx vin.
+type VerboseVin struct {
+	Txid string `json:"txid"`
+	Vout uint32 `json:"vout"`
+}
+
+// VerboseTx is the subset of a Bitcoin Core / electrs verbose tx we care about.
+type VerboseTx struct {
+	Txid          string        `json:"txid"`
+	Hash          string        `json:"hash"`
+	BlockHash     string        `json:"blockhash,omitempty"`
+	Confirmations uint32        `json:"confirmations,omitempty"`
+	Time          int64         `json:"time,omitempty"`
+	Vin           []VerboseVin  `json:"vin"`
+	Vout          []VerboseVout `json:"vout"`
+}
+
+// GetTransaction returns the verbose decoded transaction. Some older electrs
+// builds don't support verbose; callers should handle the error.
+func (c *Client) GetTransaction(ctx context.Context, txid string) (VerboseTx, error) {
+	var out VerboseTx
+	err := c.Call(ctx, "blockchain.transaction.get", []any{txid, true}, &out)
+	return out, err
+}

--- a/lightningos-light/internal/lndclient/onchain_preview.go
+++ b/lightningos-light/internal/lndclient/onchain_preview.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 
+	"lightningos-light/lnrpc"
 	"lightningos-light/lnrpc/walletrpc"
 )
 
@@ -55,7 +56,7 @@ type previewInput struct {
 	addressType string
 }
 
-func (c *Client) PreviewOnchainSend(ctx context.Context, address string, amountSat int64, satPerVbyte int64, sweepAll bool) (OnchainSendPreview, error) {
+func (c *Client) PreviewOnchainSend(ctx context.Context, address string, amountSat int64, satPerVbyte int64, sweepAll bool, outpoints []string) (OnchainSendPreview, error) {
 	preview := OnchainSendPreview{
 		Address:            strings.TrimSpace(address),
 		SweepAll:           sweepAll,
@@ -79,6 +80,25 @@ func (c *Client) PreviewOnchainSend(ctx context.Context, address string, amountS
 	if err != nil {
 		return preview, err
 	}
+
+	if filter, hasFilter, err := buildOutpointFilter(outpoints); err != nil {
+		preview.Message = err.Error()
+		return preview, nil
+	} else if hasFilter {
+		filtered := utxos[:0]
+		for _, utxo := range utxos {
+			if _, keep := filter[strings.ToLower(strings.TrimSpace(utxo.Outpoint))]; keep {
+				filtered = append(filtered, utxo)
+			}
+		}
+		if len(filtered) != len(filter) {
+			preview.Message = "one or more selected outpoints are unavailable"
+			preview.SpendableUtxoCount = len(filtered)
+			return preview, nil
+		}
+		utxos = filtered
+	}
+
 	preview.SpendableUtxoCount = len(utxos)
 
 	utxoByOutpoint := make(map[string]OnchainUtxo, len(utxos))
@@ -107,10 +127,10 @@ func (c *Client) PreviewOnchainSend(ctx context.Context, address string, amountS
 		return preview, nil
 	}
 
-	return c.previewFundedSend(ctx, preview, utxoByOutpoint)
+	return c.previewFundedSend(ctx, preview, utxoByOutpoint, utxos)
 }
 
-func (c *Client) previewFundedSend(ctx context.Context, preview OnchainSendPreview, utxoByOutpoint map[string]OnchainUtxo) (OnchainSendPreview, error) {
+func (c *Client) previewFundedSend(ctx context.Context, preview OnchainSendPreview, utxoByOutpoint map[string]OnchainUtxo, candidateUtxos []OnchainUtxo) (OnchainSendPreview, error) {
 	conn, err := c.dial(ctx, true)
 	if err != nil {
 		return preview, err
@@ -118,13 +138,30 @@ func (c *Client) previewFundedSend(ctx context.Context, preview OnchainSendPrevi
 	defer conn.Close()
 
 	client := walletrpc.NewWalletKitClient(conn)
+	template := &walletrpc.TxTemplate{
+		Outputs: map[string]uint64{
+			preview.Address: uint64(preview.RequestedAmountSat),
+		},
+	}
+	// When the caller pinned a UTXO selection, force LND to fund the PSBT
+	// from exactly those inputs. Without this LND would fall back to its own
+	// coin-selection strategy and could pick other UTXOs.
+	if len(candidateUtxos) > 0 && len(candidateUtxos) <= len(utxoByOutpoint) {
+		inputs := make([]*lnrpc.OutPoint, 0, len(candidateUtxos))
+		for _, utxo := range candidateUtxos {
+			point, err := parseOutPoint(utxo.Outpoint)
+			if err != nil {
+				continue
+			}
+			inputs = append(inputs, point)
+		}
+		if len(inputs) > 0 {
+			template.Inputs = inputs
+		}
+	}
 	req := &walletrpc.FundPsbtRequest{
 		Template: &walletrpc.FundPsbtRequest_Raw{
-			Raw: &walletrpc.TxTemplate{
-				Outputs: map[string]uint64{
-					preview.Address: uint64(preview.RequestedAmountSat),
-				},
-			},
+			Raw: template,
 		},
 		Fees: &walletrpc.FundPsbtRequest_SatPerVbyte{
 			SatPerVbyte: uint64(preview.SatPerVbyte),
@@ -357,6 +394,27 @@ func isPreviewSoftFailure(err error) bool {
 		strings.Contains(lower, "dust") ||
 		strings.Contains(lower, "no utxos") ||
 		strings.Contains(lower, "invalid address")
+}
+
+func buildOutpointFilter(outpoints []string) (map[string]struct{}, bool, error) {
+	if len(outpoints) == 0 {
+		return nil, false, nil
+	}
+	filter := make(map[string]struct{}, len(outpoints))
+	for _, raw := range outpoints {
+		trimmed := strings.ToLower(strings.TrimSpace(raw))
+		if trimmed == "" {
+			continue
+		}
+		if _, err := parseOutPoint(trimmed); err != nil {
+			return nil, true, fmt.Errorf("invalid outpoint %q", raw)
+		}
+		filter[trimmed] = struct{}{}
+	}
+	if len(filter) == 0 {
+		return nil, false, nil
+	}
+	return filter, true, nil
 }
 
 func releasePreviewLeases(ctx context.Context, client walletrpc.WalletKitClient, leases []*walletrpc.UtxoLease) {

--- a/lightningos-light/internal/lndclient/utxo_manager.go
+++ b/lightningos-light/internal/lndclient/utxo_manager.go
@@ -1,0 +1,307 @@
+package lndclient
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"lightningos-light/lnrpc"
+	"lightningos-light/lnrpc/walletrpc"
+)
+
+// utxoManagerLeaseSeed prefixes outpoints to derive deterministic lease IDs
+// so we can release a lease without persisting its ID. Keep stable: changing
+// it strands existing leases until they expire.
+const utxoManagerLeaseSeed = "brln-os-utxo-mgr:v1:"
+
+// SendCoinsParams carries the full set of options accepted by SendCoinsAdvanced.
+// The zero value is valid; callers fill what they need.
+type SendCoinsParams struct {
+	Address          string
+	AmountSat        int64
+	SatPerVbyte      int64
+	SendAll          bool
+	Outpoints        []string
+	Label            string
+	MinConfs         int32
+	SpendUnconfirmed bool
+}
+
+// SendCoinsAdvanced is the option-rich counterpart of SendCoins. When Outpoints
+// is non-empty, LND restricts coin selection to those outpoints. The original
+// SendCoins helper remains for the common address+amount path.
+func (c *Client) SendCoinsAdvanced(ctx context.Context, params SendCoinsParams) (string, error) {
+	address := strings.TrimSpace(params.Address)
+	if address == "" {
+		return "", errors.New("address required")
+	}
+	if !params.SendAll && params.AmountSat <= 0 {
+		return "", errors.New("amount_sat must be positive")
+	}
+
+	outpoints, err := parseOutpointList(params.Outpoints)
+	if err != nil {
+		return "", err
+	}
+
+	conn, err := c.dial(ctx, true)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	client := lnrpc.NewLightningClient(conn)
+	req := &lnrpc.SendCoinsRequest{
+		Addr:             address,
+		SendAll:          params.SendAll,
+		MinConfs:         params.MinConfs,
+		SpendUnconfirmed: params.SpendUnconfirmed,
+		Outpoints:        outpoints,
+		Label:            strings.TrimSpace(params.Label),
+	}
+	if !params.SendAll {
+		req.Amount = params.AmountSat
+	}
+	if params.SatPerVbyte > 0 {
+		req.SatPerVbyte = uint64(params.SatPerVbyte)
+	}
+
+	resp, err := client.SendCoins(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", nil
+	}
+	return resp.Txid, nil
+}
+
+// OpenChannelParams mirrors OpenChannelWithPush's arguments and adds outpoint
+// pinning. Callers without a selection should keep using OpenChannelWithPush.
+type OpenChannelParams struct {
+	PubkeyHex       string
+	LocalFundingSat int64
+	PushSat         int64
+	CloseAddress    string
+	Private         bool
+	SatPerVbyte     int64
+	Outpoints       []string
+}
+
+// OpenChannelWithOutpoints opens a channel using a fixed set of UTXOs as
+// funding inputs. Useful when the caller wants the channel funded from a
+// specific user-selected UTXO group.
+func (c *Client) OpenChannelWithOutpoints(ctx context.Context, params OpenChannelParams) (string, error) {
+	pubkeyHex := strings.TrimSpace(params.PubkeyHex)
+	if pubkeyHex == "" {
+		return "", errors.New("pubkey required")
+	}
+	if params.LocalFundingSat <= 0 {
+		return "", errors.New("local funding must be positive")
+	}
+	if params.PushSat < 0 {
+		return "", errors.New("push amount must be zero or positive")
+	}
+	if params.PushSat > params.LocalFundingSat {
+		return "", errors.New("push amount cannot exceed local funding")
+	}
+	pubkey, err := hex.DecodeString(pubkeyHex)
+	if err != nil {
+		return "", fmt.Errorf("invalid pubkey hex")
+	}
+
+	outpoints, err := parseOutpointList(params.Outpoints)
+	if err != nil {
+		return "", err
+	}
+
+	conn, err := c.dial(ctx, true)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	client := lnrpc.NewLightningClient(conn)
+	req := &lnrpc.OpenChannelRequest{
+		NodePubkey:         pubkey,
+		LocalFundingAmount: params.LocalFundingSat,
+		PushSat:            params.PushSat,
+		Private:            params.Private,
+		Outpoints:          outpoints,
+	}
+	if params.SatPerVbyte > 0 {
+		req.SatPerVbyte = uint64(params.SatPerVbyte)
+	}
+	if strings.TrimSpace(params.CloseAddress) != "" {
+		req.CloseAddress = strings.TrimSpace(params.CloseAddress)
+	}
+
+	resp, err := client.OpenChannelSync(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	return channelPointString(resp), nil
+}
+
+// LeaseInfo describes a UTXO lease as reported by LND.
+type LeaseInfo struct {
+	Outpoint   string `json:"outpoint"`
+	Txid       string `json:"txid"`
+	Vout       uint32 `json:"vout"`
+	Expiration uint64 `json:"expiration"`
+	Value      uint64 `json:"value"`
+	ID         string `json:"id"`
+}
+
+// LeaseOutput locks an outpoint for the given expiry window (seconds). The
+// lease ID is deterministically derived from the outpoint so callers can
+// release without storing it.
+func (c *Client) LeaseOutput(ctx context.Context, outpoint string, expirySec uint64) (LeaseInfo, error) {
+	point, err := parseOutPoint(outpoint)
+	if err != nil {
+		return LeaseInfo{}, err
+	}
+
+	conn, err := c.dial(ctx, true)
+	if err != nil {
+		return LeaseInfo{}, err
+	}
+	defer conn.Close()
+
+	client := walletrpc.NewWalletKitClient(conn)
+	req := &walletrpc.LeaseOutputRequest{
+		Id:                deriveLeaseID(outpoint),
+		Outpoint:          point,
+		ExpirationSeconds: expirySec,
+	}
+	resp, err := client.LeaseOutput(ctx, req)
+	if err != nil {
+		return LeaseInfo{}, err
+	}
+	return LeaseInfo{
+		Outpoint:   normalizedOutpointString(point),
+		Txid:       strings.ToLower(strings.TrimSpace(point.GetTxidStr())),
+		Vout:       point.GetOutputIndex(),
+		Expiration: resp.GetExpiration(),
+		ID:         hex.EncodeToString(req.Id),
+	}, nil
+}
+
+// ReleaseOutput unlocks a UTXO that we previously leased with the manager.
+// Returns nil if the lease no longer exists.
+func (c *Client) ReleaseOutput(ctx context.Context, outpoint string) error {
+	point, err := parseOutPoint(outpoint)
+	if err != nil {
+		return err
+	}
+
+	conn, err := c.dial(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client := walletrpc.NewWalletKitClient(conn)
+	_, err = client.ReleaseOutput(ctx, &walletrpc.ReleaseOutputRequest{
+		Id:       deriveLeaseID(outpoint),
+		Outpoint: point,
+	})
+	if err != nil && isLeaseNotFoundErr(err) {
+		return nil
+	}
+	return err
+}
+
+// ListLeases returns all currently locked outpoints, keyed by "txid:vout".
+func (c *Client) ListLeases(ctx context.Context) (map[string]LeaseInfo, error) {
+	conn, err := c.dial(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	client := walletrpc.NewWalletKitClient(conn)
+	resp, err := client.ListLeases(ctx, &walletrpc.ListLeasesRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	leases := make(map[string]LeaseInfo, len(resp.GetLockedUtxos()))
+	for _, lease := range resp.GetLockedUtxos() {
+		if lease == nil {
+			continue
+		}
+		point := lease.GetOutpoint()
+		if point == nil {
+			continue
+		}
+		outpoint := normalizedOutpointString(point)
+		if outpoint == "" {
+			continue
+		}
+		leases[outpoint] = LeaseInfo{
+			Outpoint:   outpoint,
+			Txid:       strings.ToLower(strings.TrimSpace(point.GetTxidStr())),
+			Vout:       point.GetOutputIndex(),
+			Expiration: lease.GetExpiration(),
+			Value:      lease.GetValue(),
+			ID:         hex.EncodeToString(lease.GetId()),
+		}
+	}
+	return leases, nil
+}
+
+func deriveLeaseID(outpoint string) []byte {
+	sum := sha256.Sum256([]byte(utxoManagerLeaseSeed + strings.ToLower(strings.TrimSpace(outpoint))))
+	return sum[:]
+}
+
+func parseOutpointList(items []string) ([]*lnrpc.OutPoint, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	out := make([]*lnrpc.OutPoint, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, raw := range items {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		point, err := parseOutPoint(trimmed)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, point)
+	}
+	return out, nil
+}
+
+func normalizedOutpointString(point *lnrpc.OutPoint) string {
+	if point == nil {
+		return ""
+	}
+	txid := strings.ToLower(strings.TrimSpace(point.GetTxidStr()))
+	if txid == "" {
+		txid = txidFromBytes(point.GetTxidBytes())
+	}
+	if txid == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", txid, point.GetOutputIndex())
+}
+
+func isLeaseNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "no such lease") || strings.Contains(msg, "unknown")
+}

--- a/lightningos-light/internal/lndclient/utxo_provenance.go
+++ b/lightningos-light/internal/lndclient/utxo_provenance.go
@@ -1,0 +1,29 @@
+package lndclient
+
+import (
+	"context"
+
+	"lightningos-light/lnrpc"
+)
+
+// ListAllTransactions returns the wallet's on-chain transactions in
+// [startHeight, endHeight]. Pass endHeight = -1 for "up to current tip".
+// We expose the raw proto so the provenance service can read inputs+outputs
+// without losing per-vout details.
+func (c *Client) ListAllTransactions(ctx context.Context, startHeight, endHeight int32) ([]*lnrpc.Transaction, error) {
+	conn, err := c.dial(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	client := lnrpc.NewLightningClient(conn)
+	resp, err := client.GetTransactions(ctx, &lnrpc.GetTransactionsRequest{
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetTransactions(), nil
+}

--- a/lightningos-light/internal/server/handlers.go
+++ b/lightningos-light/internal/server/handlers.go
@@ -1163,6 +1163,12 @@ func (s *Server) handleCreateWallet(w http.ResponseWriter, r *http.Request) {
 }
 
 func walletExists() bool {
+	// Dev escape hatch: when BRLN_SKIP_WIZARD=1 is set, pretend the wallet is
+	// already initialized so the first-run wizard doesn't gate navigation.
+	// Use this when LND was set up out-of-band (e.g. lnd-recover on testnet).
+	if v := strings.TrimSpace(os.Getenv("BRLN_SKIP_WIZARD")); v == "1" || strings.EqualFold(v, "true") {
+		return true
+	}
 	if walletPasswordAvailable() {
 		return true
 	}
@@ -2481,13 +2487,14 @@ func watchtowerRPCErrorMessage(err error) string {
 
 func (s *Server) handleLNOpenChannel(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		PeerAddress     string `json:"peer_address"`
-		Pubkey          string `json:"pubkey"`
-		LocalFundingSat int64  `json:"local_funding_sat"`
-		PushSat         int64  `json:"push_sat"`
-		CloseAddress    string `json:"close_address"`
-		Private         bool   `json:"private"`
-		SatPerVbyte     int64  `json:"sat_per_vbyte"`
+		PeerAddress     string   `json:"peer_address"`
+		Pubkey          string   `json:"pubkey"`
+		LocalFundingSat int64    `json:"local_funding_sat"`
+		PushSat         int64    `json:"push_sat"`
+		CloseAddress    string   `json:"close_address"`
+		Private         bool     `json:"private"`
+		SatPerVbyte     int64    `json:"sat_per_vbyte"`
+		Outpoints       []string `json:"outpoints"`
 	}
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid json")
@@ -2539,9 +2546,25 @@ func (s *Server) handleLNOpenChannel(w http.ResponseWriter, r *http.Request) {
 	openCtx, openCancel := context.WithTimeout(r.Context(), lndOpenChannelTimeout)
 	defer openCancel()
 
-	channelPoint, err := s.lnd.OpenChannelWithPush(openCtx, pubkey, req.LocalFundingSat, req.PushSat, req.CloseAddress, req.Private, req.SatPerVbyte)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, lndDetailedErrorMessage(err))
+	var (
+		channelPoint string
+		openErr      error
+	)
+	if len(req.Outpoints) > 0 {
+		channelPoint, openErr = s.lnd.OpenChannelWithOutpoints(openCtx, lndclient.OpenChannelParams{
+			PubkeyHex:       pubkey,
+			LocalFundingSat: req.LocalFundingSat,
+			PushSat:         req.PushSat,
+			CloseAddress:    req.CloseAddress,
+			Private:         req.Private,
+			SatPerVbyte:     req.SatPerVbyte,
+			Outpoints:       req.Outpoints,
+		})
+	} else {
+		channelPoint, openErr = s.lnd.OpenChannelWithPush(openCtx, pubkey, req.LocalFundingSat, req.PushSat, req.CloseAddress, req.Private, req.SatPerVbyte)
+	}
+	if openErr != nil {
+		writeError(w, http.StatusInternalServerError, lndDetailedErrorMessage(openErr))
 		return
 	}
 
@@ -3510,11 +3533,13 @@ func (s *Server) handleOnchainUtxos(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if limit > 0 && len(items) > limit {
-		items = items[:limit]
+	enriched := s.enrichOnchainUtxos(ctx, items)
+
+	if limit > 0 && len(enriched) > limit {
+		enriched = enriched[:limit]
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"items": items})
+	writeJSON(w, http.StatusOK, map[string]any{"items": enriched})
 }
 
 func (s *Server) handleOnchainTransactions(w http.ResponseWriter, r *http.Request) {
@@ -4221,11 +4246,13 @@ func requiresWalletSendConfirmation(classification string) bool {
 
 func (s *Server) handleWalletSend(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Address         string `json:"address"`
-		AmountSat       int64  `json:"amount_sat"`
-		SatPerVbyte     int64  `json:"sat_per_vbyte"`
-		SweepAll        bool   `json:"sweep_all"`
-		ConfirmPassword string `json:"confirm_password"`
+		Address         string   `json:"address"`
+		AmountSat       int64    `json:"amount_sat"`
+		SatPerVbyte     int64    `json:"sat_per_vbyte"`
+		SweepAll        bool     `json:"sweep_all"`
+		Outpoints       []string `json:"outpoints"`
+		Label           string   `json:"label"`
+		ConfirmPassword string   `json:"confirm_password"`
 	}
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid json")
@@ -4273,11 +4300,26 @@ func (s *Server) handleWalletSend(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	txid, err := s.lnd.SendCoins(ctx, address, req.AmountSat, req.SatPerVbyte, req.SweepAll)
-	if err != nil {
-		msg := lndRPCErrorMessage(err)
-		if isTimeoutError(err) {
-			msg = lndStatusMessage(err)
+	var (
+		txid    string
+		sendErr error
+	)
+	if len(req.Outpoints) > 0 || strings.TrimSpace(req.Label) != "" {
+		txid, sendErr = s.lnd.SendCoinsAdvanced(ctx, lndclient.SendCoinsParams{
+			Address:     address,
+			AmountSat:   req.AmountSat,
+			SatPerVbyte: req.SatPerVbyte,
+			SendAll:     req.SweepAll,
+			Outpoints:   req.Outpoints,
+			Label:       req.Label,
+		})
+	} else {
+		txid, sendErr = s.lnd.SendCoins(ctx, address, req.AmountSat, req.SatPerVbyte, req.SweepAll)
+	}
+	if sendErr != nil {
+		msg := lndRPCErrorMessage(sendErr)
+		if isTimeoutError(sendErr) {
+			msg = lndStatusMessage(sendErr)
 		}
 		if msg == "" || msg == "LND error" {
 			msg = "On-chain send failed"
@@ -4291,10 +4333,11 @@ func (s *Server) handleWalletSend(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleWalletSendPreview(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Address     string `json:"address"`
-		AmountSat   int64  `json:"amount_sat"`
-		SatPerVbyte int64  `json:"sat_per_vbyte"`
-		SweepAll    bool   `json:"sweep_all"`
+		Address     string   `json:"address"`
+		AmountSat   int64    `json:"amount_sat"`
+		SatPerVbyte int64    `json:"sat_per_vbyte"`
+		SweepAll    bool     `json:"sweep_all"`
+		Outpoints   []string `json:"outpoints"`
 	}
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid json")
@@ -4304,7 +4347,7 @@ func (s *Server) handleWalletSendPreview(w http.ResponseWriter, r *http.Request)
 	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
 	defer cancel()
 
-	preview, err := s.lnd.PreviewOnchainSend(ctx, req.Address, req.AmountSat, req.SatPerVbyte, req.SweepAll)
+	preview, err := s.lnd.PreviewOnchainSend(ctx, req.Address, req.AmountSat, req.SatPerVbyte, req.SweepAll, req.Outpoints)
 	if err != nil {
 		msg := lndRPCErrorMessage(err)
 		if isTimeoutError(err) {

--- a/lightningos-light/internal/server/provenance_handlers.go
+++ b/lightningos-light/internal/server/provenance_handlers.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"lightningos-light/internal/electrs"
+)
+
+func (s *Server) handleProvenanceStatus(w http.ResponseWriter, r *http.Request) {
+	svc, errMsg := s.provenanceService()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, errMsg)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	state, err := svc.Status(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, state)
+}
+
+func (s *Server) handleProvenanceGraph(w http.ResponseWriter, r *http.Request) {
+	svc, errMsg := s.provenanceService()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, errMsg)
+		return
+	}
+	opts := LoadGraphOptions{
+		Mode: strings.TrimSpace(r.URL.Query().Get("mode")),
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			opts.Limit = parsed
+		}
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("root")); raw != "" {
+		// Accept either "txid" or "txid:vout"; we only need the txid for lineage.
+		if idx := strings.IndexByte(raw, ':'); idx > 0 {
+			raw = raw[:idx]
+		}
+		opts.RootTxid = strings.ToLower(raw)
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("hops")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			opts.Hops = parsed
+		}
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("include_external")); raw != "" {
+		if parsed, err := strconv.ParseBool(raw); err == nil {
+			opts.IncludeExternal = parsed
+		}
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("max_external")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			opts.MaxExternalTxs = parsed
+		}
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 90*time.Second)
+	defer cancel()
+	graph, err := svc.LoadGraph(ctx, opts)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, graph)
+}
+
+// handleProvenanceHealth reports whether electrs is reachable. The UI uses
+// this to decide whether to render the Wallet Flow page at all.
+func (s *Server) handleProvenanceHealth(w http.ResponseWriter, r *http.Request) {
+	client := electrs.New("")
+	ctx, cancel := context.WithTimeout(r.Context(), 4*time.Second)
+	defer cancel()
+	info, err := client.Ping(ctx)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"electrs_available": false,
+			"electrs_addr":      client.Addr(),
+			"error":             err.Error(),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"electrs_available": true,
+		"electrs_addr":      client.Addr(),
+		"electrs_server":    info[0],
+		"electrs_protocol":  info[1],
+	})
+}
+
+func (s *Server) handleProvenanceRebuild(w http.ResponseWriter, r *http.Request) {
+	svc, errMsg := s.provenanceService()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, errMsg)
+		return
+	}
+
+	fullRebuild := false
+	if raw := strings.TrimSpace(r.URL.Query().Get("full")); raw != "" {
+		if parsed, err := strconv.ParseBool(raw); err == nil {
+			fullRebuild = parsed
+		}
+	}
+
+	// The walk + electrs enrichment can take a while on big wallets. Cap
+	// generously; the client should poll /api/onchain/provenance/status to
+	// see when the sync_at timestamp moves.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	go func() {
+		defer cancel()
+		if err := svc.RefreshNow(ctx, fullRebuild); err != nil {
+			s.logger.Printf("provenance: refresh failed: %v", err)
+		}
+	}()
+	writeJSON(w, http.StatusAccepted, map[string]any{"started": true, "full": fullRebuild})
+}

--- a/lightningos-light/internal/server/provenance_init.go
+++ b/lightningos-light/internal/server/provenance_init.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"lightningos-light/internal/electrs"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const provenanceInitRetryCooldown = 10 * time.Second
+
+func (s *Server) initProvenance() {
+	s.provenanceMu.Lock()
+	defer s.provenanceMu.Unlock()
+
+	if s.provenance != nil && s.provenanceErr == "" {
+		return
+	}
+	if !s.provenanceInitAt.IsZero() && time.Since(s.provenanceInitAt) < provenanceInitRetryCooldown {
+		return
+	}
+	s.provenanceInitAt = time.Now()
+
+	dsn, err := ResolveNotificationsDSN(s.logger)
+	if err != nil {
+		s.provenanceErr = fmt.Sprintf("provenance unavailable: %v", err)
+		s.logger.Printf("%s", s.provenanceErr)
+		return
+	}
+
+	pool := s.db
+	if pool == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		pool, err = pgxpool.New(ctx, dsn)
+		if err != nil {
+			s.provenanceErr = fmt.Sprintf("provenance unavailable: failed to connect to postgres: %v", err)
+			s.logger.Printf("%s", s.provenanceErr)
+			return
+		}
+		s.db = pool
+	}
+
+	electrsClient := electrs.New("")
+	svc := NewProvenanceService(pool, s.logger, s.lnd, electrsClient)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := svc.EnsureSchema(ctx); err != nil {
+		s.provenanceErr = fmt.Sprintf("provenance unavailable: failed to init schema: %v", err)
+		s.logger.Printf("%s", s.provenanceErr)
+		return
+	}
+
+	s.provenance = svc
+	s.provenanceErr = ""
+}
+
+func (s *Server) provenanceService() (*ProvenanceService, string) {
+	s.initProvenance()
+	return s.provenance, s.provenanceErr
+}

--- a/lightningos-light/internal/server/provenance_service.go
+++ b/lightningos-light/internal/server/provenance_service.go
@@ -1,0 +1,812 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"lightningos-light/internal/electrs"
+	"lightningos-light/internal/lndclient"
+	"lightningos-light/lnrpc"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var ErrProvenanceDBUnavailable = errors.New("provenance db unavailable")
+
+const (
+	provenanceMaxLookbackBlocks      = int32(2 << 16) // headroom for reorgs on incremental refresh
+	provenanceElectrsEnrichBatchSize = 200
+)
+
+// ProvenanceTx is one node in the wallet flow graph.
+type ProvenanceTx struct {
+	Txid          string    `json:"txid"`
+	BlockHeight   int32     `json:"block_height"`
+	Confirmations int32     `json:"confirmations"`
+	Timestamp     int64     `json:"timestamp"`
+	AmountSat     int64     `json:"amount_sat"`
+	FeeSat        int64     `json:"fee_sat"`
+	Label         string    `json:"label,omitempty"`
+	IsExternal    bool      `json:"is_external"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// ProvenanceOutput is an output of a tx — and one half of an edge: if
+// SpentByTxid is set, an edge runs from this output to that tx.
+type ProvenanceOutput struct {
+	Txid         string `json:"txid"`
+	Vout         uint32 `json:"vout"`
+	Address      string `json:"address,omitempty"`
+	AmountSat    int64  `json:"amount_sat"`
+	IsOurs       bool   `json:"is_ours"`
+	SpentByTxid  string `json:"spent_by_txid,omitempty"`
+	SpentInVin   *int32 `json:"spent_in_vin,omitempty"`
+	IsCurrentUtxo bool  `json:"is_current_utxo"`
+}
+
+// ProvenanceState mirrors the single-row state table used to drive
+// incremental refresh.
+type ProvenanceState struct {
+	LastSyncHeight int32     `json:"last_sync_height"`
+	LastSyncAt     time.Time `json:"last_sync_at"`
+	LastError      string    `json:"last_error,omitempty"`
+	TxCount        int       `json:"tx_count"`
+	OutputCount    int       `json:"output_count"`
+	OursOutputs    int       `json:"ours_outputs"`
+	InFlight       bool      `json:"in_flight"`
+}
+
+// ProvenanceGraph is what the GET endpoint returns.
+type ProvenanceGraph struct {
+	State   ProvenanceState    `json:"state"`
+	Txs     []ProvenanceTx     `json:"txs"`
+	Outputs []ProvenanceOutput `json:"outputs"`
+}
+
+type ProvenanceService struct {
+	db      *pgxpool.Pool
+	logger  *log.Logger
+	lnd     *lndclient.Client
+	electrs *electrs.Client
+	mu      sync.Mutex
+	running bool
+}
+
+func NewProvenanceService(db *pgxpool.Pool, logger *log.Logger, lnd *lndclient.Client, e *electrs.Client) *ProvenanceService {
+	return &ProvenanceService{db: db, logger: logger, lnd: lnd, electrs: e}
+}
+
+func (s *ProvenanceService) EnsureSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return ErrProvenanceDBUnavailable
+	}
+	_, err := s.db.Exec(ctx, `
+create table if not exists provenance_tx (
+  txid text primary key,
+  block_height integer not null default 0,
+  confirmations integer not null default 0,
+  timestamp bigint not null default 0,
+  amount_sat bigint not null default 0,
+  fee_sat bigint not null default 0,
+  label text not null default '',
+  is_external boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+create index if not exists provenance_tx_height_idx on provenance_tx (block_height desc);
+
+create table if not exists provenance_output (
+  txid text not null,
+  vout integer not null,
+  address text not null default '',
+  amount_sat bigint not null default 0,
+  is_ours boolean not null default false,
+  spent_by_txid text not null default '',
+  spent_in_vin integer,
+  enriched_at timestamptz,
+  primary key (txid, vout)
+);
+create index if not exists provenance_output_spent_idx on provenance_output (spent_by_txid) where spent_by_txid <> '';
+create index if not exists provenance_output_ours_unspent_idx on provenance_output (is_ours, spent_by_txid)
+  where is_ours = true and spent_by_txid = '';
+
+create table if not exists provenance_state (
+  id boolean primary key default true,
+  last_sync_height integer not null default 0,
+  last_sync_at timestamptz,
+  last_error text not null default '',
+  tx_count integer not null default 0,
+  output_count integer not null default 0,
+  ours_outputs integer not null default 0
+);
+insert into provenance_state (id) values (true) on conflict do nothing;
+`)
+	return err
+}
+
+// RefreshNow walks the LND tx history. If fullRebuild is true the DB is
+// truncated first; otherwise only transactions since last_sync_height are
+// fetched and merged.
+func (s *ProvenanceService) RefreshNow(ctx context.Context, fullRebuild bool) error {
+	if s == nil || s.db == nil {
+		return ErrProvenanceDBUnavailable
+	}
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return errors.New("refresh already running")
+	}
+	s.running = true
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.running = false
+		s.mu.Unlock()
+	}()
+
+	start := int32(0)
+	if !fullRebuild {
+		prev, err := s.loadState(ctx)
+		if err != nil {
+			return err
+		}
+		start = prev.LastSyncHeight - provenanceMaxLookbackBlocks
+		if start < 0 {
+			start = 0
+		}
+	}
+
+	txs, err := s.lnd.ListAllTransactions(ctx, start, -1)
+	if err != nil {
+		s.recordError(ctx, fmt.Sprintf("list tx failed: %v", err))
+		return err
+	}
+
+	if fullRebuild {
+		if _, err := s.db.Exec(ctx, `truncate provenance_tx, provenance_output`); err != nil {
+			s.recordError(ctx, fmt.Sprintf("truncate failed: %v", err))
+			return err
+		}
+	}
+
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	maxHeight := int32(0)
+	for _, t := range txs {
+		if t == nil || strings.TrimSpace(t.GetTxHash()) == "" {
+			continue
+		}
+		if t.GetBlockHeight() > maxHeight {
+			maxHeight = t.GetBlockHeight()
+		}
+		if err := upsertProvenanceTx(ctx, tx, t); err != nil {
+			s.recordError(ctx, fmt.Sprintf("upsert tx %s: %v", t.GetTxHash(), err))
+			return err
+		}
+		if err := upsertProvenanceOutputs(ctx, tx, t); err != nil {
+			s.recordError(ctx, fmt.Sprintf("upsert outputs %s: %v", t.GetTxHash(), err))
+			return err
+		}
+		if err := markSpentByInputs(ctx, tx, t); err != nil {
+			s.recordError(ctx, fmt.Sprintf("mark spent for %s: %v", t.GetTxHash(), err))
+			return err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		s.recordError(ctx, fmt.Sprintf("commit failed: %v", err))
+		return err
+	}
+
+	// Best-effort enrichment of external sources via electrs.
+	if s.electrs != nil {
+		if err := s.enrichExternalInputs(ctx); err != nil {
+			s.logger.Printf("provenance: electrs enrichment partial: %v", err)
+		}
+	}
+
+	if err := s.updateStateAfterSync(ctx, maxHeight); err != nil {
+		s.logger.Printf("provenance: update state failed: %v", err)
+	}
+	return nil
+}
+
+// LoadGraphOptions controls how much of the graph the caller wants. Defaults
+// are applied if zero/empty: Mode=ours, Limit=300.
+type LoadGraphOptions struct {
+	Mode            string // "live" | "ours" | "all" | "lineage"
+	Limit           int    // max txs to return (safety cap; 0 = use default)
+	RootTxid        string // for Mode=lineage: walk backwards from this tx
+	Hops            int    // for Mode=lineage: how many generations to include (1-20)
+	IncludeExternal bool   // for Mode=lineage: also walk past the wallet boundary via electrs
+	MaxExternalTxs  int    // safety cap on electrs fetches per request (0 = default 500)
+}
+
+func (s *ProvenanceService) LoadGraph(ctx context.Context, opts LoadGraphOptions) (ProvenanceGraph, error) {
+	if s == nil || s.db == nil {
+		return ProvenanceGraph{}, ErrProvenanceDBUnavailable
+	}
+	state, err := s.loadState(ctx)
+	if err != nil {
+		return ProvenanceGraph{}, err
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(opts.Mode))
+	switch mode {
+	case "live", "ours", "all", "lineage":
+	default:
+		mode = "ours"
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 300
+	}
+	if limit > 2000 {
+		limit = 2000
+	}
+
+	graph := ProvenanceGraph{
+		State:   state,
+		Txs:     []ProvenanceTx{},
+		Outputs: []ProvenanceOutput{},
+	}
+
+	// Lineage mode walks backwards from a chosen tx via the spent_by_txid
+	// relation. Each hop adds one generation of ancestors.
+	if mode == "lineage" {
+		root := strings.ToLower(strings.TrimSpace(opts.RootTxid))
+		if root == "" {
+			return graph, errors.New("root txid required for lineage mode")
+		}
+		hops := opts.Hops
+		if hops <= 0 {
+			hops = 1
+		}
+		if hops > 20 {
+			hops = 20
+		}
+		if opts.IncludeExternal && s.electrs != nil {
+			maxFetches := opts.MaxExternalTxs
+			if maxFetches <= 0 {
+				maxFetches = 500
+			}
+			if err := s.walkExternalLineage(ctx, root, hops, maxFetches); err != nil {
+				s.logger.Printf("provenance: external walk partial: %v", err)
+			}
+		}
+		return s.loadLineageGraph(ctx, graph, root, hops, limit)
+	}
+
+	// Build the predicate for "which txs to include". For 'all' we include
+	// everything, including external placeholder rows. For 'ours' we restrict
+	// to txs that touched our wallet (have at least one ours output). For
+	// 'live' we restrict to txs that produced a still-unspent ours output.
+	var txWhere string
+	switch mode {
+	case "all":
+		txWhere = `true`
+	case "ours":
+		txWhere = `txid in (select distinct txid from provenance_output where is_ours = true)`
+	default: // "live"
+		txWhere = `txid in (select distinct txid from provenance_output where is_ours = true and spent_by_txid = '')`
+	}
+
+	txRows, err := s.db.Query(ctx, `
+select txid, block_height, confirmations, timestamp, amount_sat, fee_sat, label, is_external, updated_at
+from provenance_tx
+where `+txWhere+`
+order by block_height desc, txid asc
+limit $1`, limit)
+	if err != nil {
+		return graph, err
+	}
+	defer txRows.Close()
+	keepTxids := make(map[string]struct{}, limit)
+	for txRows.Next() {
+		var t ProvenanceTx
+		if err := txRows.Scan(&t.Txid, &t.BlockHeight, &t.Confirmations, &t.Timestamp, &t.AmountSat, &t.FeeSat, &t.Label, &t.IsExternal, &t.UpdatedAt); err != nil {
+			return graph, err
+		}
+		graph.Txs = append(graph.Txs, t)
+		keepTxids[t.Txid] = struct{}{}
+	}
+	if err := txRows.Err(); err != nil {
+		return graph, err
+	}
+	if len(keepTxids) == 0 {
+		return graph, nil
+	}
+
+	// Fetch outputs that are either produced by a kept tx OR spent by a kept
+	// tx, so edges between displayed txs always have both ends.
+	ids := make([]string, 0, len(keepTxids))
+	for id := range keepTxids {
+		ids = append(ids, id)
+	}
+	outRows, err := s.db.Query(ctx, `
+select txid, vout, address, amount_sat, is_ours, spent_by_txid, spent_in_vin
+from provenance_output
+where txid = any($1) or spent_by_txid = any($1)
+order by txid asc, vout asc`, ids)
+	if err != nil {
+		return graph, err
+	}
+	defer outRows.Close()
+	for outRows.Next() {
+		var o ProvenanceOutput
+		var spentVin *int32
+		if err := outRows.Scan(&o.Txid, &o.Vout, &o.Address, &o.AmountSat, &o.IsOurs, &o.SpentByTxid, &spentVin); err != nil {
+			return graph, err
+		}
+		o.SpentInVin = spentVin
+		o.IsCurrentUtxo = o.IsOurs && o.SpentByTxid == ""
+		graph.Outputs = append(graph.Outputs, o)
+	}
+	return graph, outRows.Err()
+}
+
+// loadLineageGraph walks backwards from root via the spent_by_txid relation
+// and returns every ancestor tx up to `hops` generations, plus the edges
+// between displayed txs.
+func (s *ProvenanceService) loadLineageGraph(ctx context.Context, graph ProvenanceGraph, root string, hops, limit int) (ProvenanceGraph, error) {
+	txRows, err := s.db.Query(ctx, `
+with recursive lineage(txid, hop) as (
+  select $1::text, 0
+  union
+  select o.txid, l.hop + 1
+  from lineage l
+  join provenance_output o on o.spent_by_txid = l.txid
+  where l.hop < $2 and o.txid <> ''
+)
+select t.txid, t.block_height, t.confirmations, t.timestamp, t.amount_sat,
+       t.fee_sat, t.label, t.is_external, t.updated_at
+from provenance_tx t
+where t.txid in (select distinct txid from lineage)
+order by t.block_height desc, t.txid asc
+limit $3`, root, hops, limit)
+	if err != nil {
+		return graph, err
+	}
+	defer txRows.Close()
+
+	keepTxids := make(map[string]struct{}, 64)
+	for txRows.Next() {
+		var t ProvenanceTx
+		if err := txRows.Scan(&t.Txid, &t.BlockHeight, &t.Confirmations, &t.Timestamp, &t.AmountSat, &t.FeeSat, &t.Label, &t.IsExternal, &t.UpdatedAt); err != nil {
+			return graph, err
+		}
+		graph.Txs = append(graph.Txs, t)
+		keepTxids[t.Txid] = struct{}{}
+	}
+	if err := txRows.Err(); err != nil {
+		return graph, err
+	}
+	if len(keepTxids) == 0 {
+		return graph, nil
+	}
+
+	ids := make([]string, 0, len(keepTxids))
+	for id := range keepTxids {
+		ids = append(ids, id)
+	}
+	outRows, err := s.db.Query(ctx, `
+select txid, vout, address, amount_sat, is_ours, spent_by_txid, spent_in_vin
+from provenance_output
+where txid = any($1) or spent_by_txid = any($1)
+order by txid asc, vout asc`, ids)
+	if err != nil {
+		return graph, err
+	}
+	defer outRows.Close()
+	for outRows.Next() {
+		var o ProvenanceOutput
+		var spentVin *int32
+		if err := outRows.Scan(&o.Txid, &o.Vout, &o.Address, &o.AmountSat, &o.IsOurs, &o.SpentByTxid, &spentVin); err != nil {
+			return graph, err
+		}
+		o.SpentInVin = spentVin
+		o.IsCurrentUtxo = o.IsOurs && o.SpentByTxid == ""
+		graph.Outputs = append(graph.Outputs, o)
+	}
+	return graph, outRows.Err()
+}
+
+func (s *ProvenanceService) Status(ctx context.Context) (ProvenanceState, error) {
+	return s.loadState(ctx)
+}
+
+func (s *ProvenanceService) loadState(ctx context.Context) (ProvenanceState, error) {
+	var st ProvenanceState
+	row := s.db.QueryRow(ctx, `
+select coalesce(s.last_sync_height, 0),
+       coalesce(s.last_sync_at, to_timestamp(0)),
+       coalesce(s.last_error, ''),
+       coalesce((select count(*) from provenance_tx), 0),
+       coalesce((select count(*) from provenance_output), 0),
+       coalesce((select count(*) from provenance_output where is_ours = true and spent_by_txid = ''), 0)
+from provenance_state s
+where s.id = true`)
+	if err := row.Scan(&st.LastSyncHeight, &st.LastSyncAt, &st.LastError, &st.TxCount, &st.OutputCount, &st.OursOutputs); err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return st, err
+		}
+	}
+	s.mu.Lock()
+	st.InFlight = s.running
+	s.mu.Unlock()
+	return st, nil
+}
+
+func (s *ProvenanceService) recordError(ctx context.Context, msg string) {
+	if _, err := s.db.Exec(ctx, `update provenance_state set last_error = $1, last_sync_at = now() where id = true`, msg); err != nil {
+		s.logger.Printf("provenance: record error failed: %v", err)
+	}
+}
+
+func (s *ProvenanceService) updateStateAfterSync(ctx context.Context, maxHeight int32) error {
+	_, err := s.db.Exec(ctx, `
+update provenance_state set
+  last_sync_height = greatest(last_sync_height, $1),
+  last_sync_at = now(),
+  last_error = '',
+  tx_count = (select count(*) from provenance_tx),
+  output_count = (select count(*) from provenance_output),
+  ours_outputs = (select count(*) from provenance_output where is_ours = true and spent_by_txid = '')
+where id = true`, maxHeight)
+	return err
+}
+
+func upsertProvenanceTx(ctx context.Context, tx pgx.Tx, t *lnrpc.Transaction) error {
+	_, err := tx.Exec(ctx, `
+insert into provenance_tx (txid, block_height, confirmations, timestamp, amount_sat, fee_sat, label, is_external, updated_at)
+values ($1, $2, $3, $4, $5, $6, $7, false, now())
+on conflict (txid) do update set
+  block_height = excluded.block_height,
+  confirmations = excluded.confirmations,
+  timestamp = excluded.timestamp,
+  amount_sat = excluded.amount_sat,
+  fee_sat = excluded.fee_sat,
+  label = excluded.label,
+  is_external = false,
+  updated_at = now()`,
+		strings.ToLower(strings.TrimSpace(t.GetTxHash())),
+		t.GetBlockHeight(), t.GetNumConfirmations(), t.GetTimeStamp(),
+		t.GetAmount(), t.GetTotalFees(), t.GetLabel(),
+	)
+	return err
+}
+
+func upsertProvenanceOutputs(ctx context.Context, tx pgx.Tx, t *lnrpc.Transaction) error {
+	txHash := strings.ToLower(strings.TrimSpace(t.GetTxHash()))
+	for _, od := range t.GetOutputDetails() {
+		if od == nil {
+			continue
+		}
+		_, err := tx.Exec(ctx, `
+insert into provenance_output (txid, vout, address, amount_sat, is_ours)
+values ($1, $2, $3, $4, $5)
+on conflict (txid, vout) do update set
+  address = case when excluded.address <> '' then excluded.address else provenance_output.address end,
+  amount_sat = case when excluded.amount_sat > 0 then excluded.amount_sat else provenance_output.amount_sat end,
+  is_ours = provenance_output.is_ours or excluded.is_ours`,
+			txHash,
+			int32(od.GetOutputIndex()),
+			od.GetAddress(),
+			od.GetAmount(),
+			od.GetIsOurAddress(),
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func markSpentByInputs(ctx context.Context, tx pgx.Tx, t *lnrpc.Transaction) error {
+	spenderTxid := strings.ToLower(strings.TrimSpace(t.GetTxHash()))
+	for vinIdx, in := range t.GetPreviousOutpoints() {
+		if in == nil {
+			continue
+		}
+		outpoint := strings.TrimSpace(in.GetOutpoint())
+		if outpoint == "" {
+			continue
+		}
+		prevTxid, prevVout, ok := splitOutpoint(outpoint)
+		if !ok {
+			continue
+		}
+		// Coinbase inputs use a null prev outpoint (txid=000…000, vout=0xFFFFFFFF).
+		// They don't reference a real prior output, so they're not edges; skip.
+		if prevVout > 0x7FFFFFFF || strings.Trim(prevTxid, "0") == "" {
+			continue
+		}
+		// Ensure a placeholder row exists for the prev output so the edge
+		// is renderable even if the prev tx isn't in our wallet history yet.
+		_, err := tx.Exec(ctx, `
+insert into provenance_output (txid, vout, is_ours, spent_by_txid, spent_in_vin)
+values ($1, $2, $3, $4, $5)
+on conflict (txid, vout) do update set
+  is_ours = provenance_output.is_ours or excluded.is_ours,
+  spent_by_txid = excluded.spent_by_txid,
+  spent_in_vin = excluded.spent_in_vin`,
+			prevTxid, int32(prevVout), in.GetIsOurOutput(), spenderTxid, int32(vinIdx),
+		)
+		if err != nil {
+			return err
+		}
+
+		// Ensure a placeholder tx node exists too if the prev tx is external.
+		_, err = tx.Exec(ctx, `
+insert into provenance_tx (txid, is_external)
+values ($1, true)
+on conflict (txid) do nothing`, prevTxid)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// enrichExternalInputs walks unresolved external outputs (placeholder rows
+// with amount_sat=0 and address='') and fills them in from electrs.
+func (s *ProvenanceService) enrichExternalInputs(ctx context.Context) error {
+	if s.electrs == nil {
+		return nil
+	}
+	rows, err := s.db.Query(ctx, `
+select txid, vout
+from provenance_output
+where amount_sat = 0 and address = '' and is_ours = false
+limit $1`, provenanceElectrsEnrichBatchSize)
+	if err != nil {
+		return err
+	}
+	type target struct {
+		txid string
+		vout uint32
+	}
+	var targets []target
+	for rows.Next() {
+		var t target
+		if err := rows.Scan(&t.txid, &t.vout); err != nil {
+			rows.Close()
+			return err
+		}
+		targets = append(targets, t)
+	}
+	rows.Close()
+
+	if len(targets) == 0 {
+		return nil
+	}
+	// Group by txid so we fetch each verbose tx once.
+	byTxid := map[string][]uint32{}
+	for _, t := range targets {
+		byTxid[t.txid] = append(byTxid[t.txid], t.vout)
+	}
+
+	for txid, vouts := range byTxid {
+		verbose, err := s.electrs.GetTransaction(ctx, txid)
+		if err != nil {
+			s.logger.Printf("provenance: electrs get %s failed: %v", txid, err)
+			continue
+		}
+		for _, vout := range vouts {
+			if int(vout) >= len(verbose.Vout) {
+				continue
+			}
+			v := verbose.Vout[vout]
+			addr := v.ScriptPubKey.Address
+			if addr == "" && len(v.ScriptPubKey.Addresses) > 0 {
+				addr = v.ScriptPubKey.Addresses[0]
+			}
+			amountSat := int64(v.Value*1e8 + 0.5)
+			if _, err := s.db.Exec(ctx, `
+update provenance_output set
+  address = $1,
+  amount_sat = $2,
+  enriched_at = now()
+where txid = $3 and vout = $4`, addr, amountSat, txid, int32(vout)); err != nil {
+				s.logger.Printf("provenance: electrs update %s:%d failed: %v", txid, vout, err)
+			}
+		}
+	}
+	return nil
+}
+
+// walkExternalLineage BFS-walks backwards from rootTxid through external
+// (non-wallet) ancestors using electrs, up to `hops` generations. For each
+// fetched tx it inserts a provenance_tx row (is_external=true), every vout as
+// a provenance_output, and placeholder rows for every vin so the recursive
+// lineage CTE can later traverse them as edges. Capped by maxFetches to
+// bound runaway scans on heavily-fanned-out graphs.
+func (s *ProvenanceService) walkExternalLineage(ctx context.Context, rootTxid string, hops, maxFetches int) error {
+	if s.electrs == nil {
+		return nil
+	}
+	visited := make(map[string]struct{}, 64)
+	enriched := make(map[string]struct{}, 64)
+
+	// Seed: find every external prev-outpoint reachable from this lineage in
+	// the *existing* DB. We don't need to fetch the root itself (it's ours);
+	// we start from its known external inputs and work backwards.
+	frontier, err := s.findExternalAncestors(ctx, rootTxid)
+	if err != nil {
+		return err
+	}
+	for _, txid := range frontier {
+		visited[txid] = struct{}{}
+	}
+
+	fetches := 0
+	for hop := 0; hop < hops && len(frontier) > 0 && fetches < maxFetches; hop++ {
+		next := make([]string, 0, len(frontier))
+		for _, txid := range frontier {
+			if fetches >= maxFetches {
+				break
+			}
+			if _, ok := enriched[txid]; ok {
+				continue
+			}
+			fetches++
+
+			verbose, err := s.electrs.GetTransaction(ctx, txid)
+			if err != nil {
+				s.logger.Printf("provenance: external fetch %s failed: %v", txid, err)
+				continue
+			}
+			enriched[txid] = struct{}{}
+			if err := s.persistExternalTx(ctx, txid, verbose); err != nil {
+				s.logger.Printf("provenance: persist external %s failed: %v", txid, err)
+				continue
+			}
+
+			// Queue this tx's own inputs for the next hop.
+			for _, vin := range verbose.Vin {
+				if vin.Txid == "" || vin.Vout > 0x7FFFFFFF {
+					continue
+				}
+				if strings.Trim(vin.Txid, "0") == "" {
+					continue // coinbase
+				}
+				parent := strings.ToLower(strings.TrimSpace(vin.Txid))
+				if _, seen := visited[parent]; seen {
+					continue
+				}
+				visited[parent] = struct{}{}
+				next = append(next, parent)
+			}
+		}
+		frontier = next
+	}
+	return nil
+}
+
+// findExternalAncestors returns the set of txids that:
+//   - are referenced as the producer of an output that's spent by rootTxid OR
+//     by something already reachable from rootTxid in the existing graph
+//   - have no entry in provenance_tx, OR their entry has is_external=true
+//     (i.e. we haven't enriched them yet)
+//
+// This bootstraps the BFS without re-walking ours-side ancestors.
+func (s *ProvenanceService) findExternalAncestors(ctx context.Context, rootTxid string) ([]string, error) {
+	rows, err := s.db.Query(ctx, `
+with recursive lineage(txid, hop) as (
+  select $1::text, 0
+  union
+  select o.txid, l.hop + 1
+  from lineage l
+  join provenance_output o on o.spent_by_txid = l.txid
+  where l.hop < 20 and o.txid <> ''
+)
+select distinct l.txid
+from lineage l
+left join provenance_tx t on t.txid = l.txid
+where l.txid <> $1
+  and (t.txid is null or t.is_external = true)`, rootTxid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]string, 0, 32)
+	for rows.Next() {
+		var txid string
+		if err := rows.Scan(&txid); err != nil {
+			return nil, err
+		}
+		out = append(out, txid)
+	}
+	return out, rows.Err()
+}
+
+// persistExternalTx writes one electrs-fetched tx and its inputs/outputs into
+// the provenance tables. is_external is always true for these rows.
+func (s *ProvenanceService) persistExternalTx(ctx context.Context, txid string, v electrs.VerboseTx) error {
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Tx node: don't clobber an existing row that might already be in our
+	// wallet ('is_external = false'). Only upsert when there's nothing there
+	// or the existing row is also external.
+	if _, err := tx.Exec(ctx, `
+insert into provenance_tx (txid, block_height, timestamp, is_external, updated_at)
+values ($1, 0, $2, true, now())
+on conflict (txid) do update set
+  timestamp = case when provenance_tx.timestamp = 0 then excluded.timestamp else provenance_tx.timestamp end,
+  is_external = provenance_tx.is_external,
+  updated_at = now()`, txid, v.Time); err != nil {
+		return err
+	}
+
+	// Persist outputs of the external tx.
+	for _, vo := range v.Vout {
+		addr := vo.ScriptPubKey.Address
+		if addr == "" && len(vo.ScriptPubKey.Addresses) > 0 {
+			addr = vo.ScriptPubKey.Addresses[0]
+		}
+		amountSat := int64(vo.Value*1e8 + 0.5)
+		if _, err := tx.Exec(ctx, `
+insert into provenance_output (txid, vout, address, amount_sat, is_ours, enriched_at)
+values ($1, $2, $3, $4, false, now())
+on conflict (txid, vout) do update set
+  address = case when excluded.address <> '' then excluded.address else provenance_output.address end,
+  amount_sat = case when excluded.amount_sat > 0 then excluded.amount_sat else provenance_output.amount_sat end,
+  enriched_at = now()`, txid, int32(vo.N), addr, amountSat); err != nil {
+			return err
+		}
+	}
+
+	// Mark this tx as spender of its inputs' prev outputs (placeholder rows).
+	for vinIdx, vin := range v.Vin {
+		if vin.Txid == "" || vin.Vout > 0x7FFFFFFF {
+			continue
+		}
+		if strings.Trim(vin.Txid, "0") == "" {
+			continue // coinbase
+		}
+		prevTxid := strings.ToLower(strings.TrimSpace(vin.Txid))
+		if _, err := tx.Exec(ctx, `
+insert into provenance_output (txid, vout, is_ours, spent_by_txid, spent_in_vin)
+values ($1, $2, false, $3, $4)
+on conflict (txid, vout) do update set
+  spent_by_txid = excluded.spent_by_txid,
+  spent_in_vin = excluded.spent_in_vin`, prevTxid, int32(vin.Vout), txid, int32(vinIdx)); err != nil {
+			return err
+		}
+		// Placeholder parent tx node so the lineage CTE can step through it.
+		if _, err := tx.Exec(ctx, `
+insert into provenance_tx (txid, is_external)
+values ($1, true)
+on conflict (txid) do nothing`, prevTxid); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func splitOutpoint(s string) (string, uint32, bool) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return "", 0, false
+	}
+	idx, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 32)
+	if err != nil {
+		return "", 0, false
+	}
+	return strings.ToLower(strings.TrimSpace(parts[0])), uint32(idx), true
+}

--- a/lightningos-light/internal/server/routes.go
+++ b/lightningos-light/internal/server/routes.go
@@ -99,6 +99,18 @@ func (s *Server) routes() http.Handler {
 	r.Route("/api/onchain", func(r chi.Router) {
 		r.Get("/utxos", s.handleOnchainUtxos)
 		r.Get("/transactions", s.handleOnchainTransactions)
+		r.Post("/utxos/metadata", s.handleUtxoMetadataUpsert)
+		r.Post("/utxos/lock", s.handleUtxoLock)
+		r.Post("/utxos/unlock", s.handleUtxoUnlock)
+		r.Post("/utxos/bump", s.handleUtxoBump)
+		r.Get("/utxos/groups", s.handleUtxoGroupsList)
+		r.Post("/utxos/groups", s.handleUtxoGroupsUpsert)
+		r.Post("/utxos/groups/{id}/assign", s.handleUtxoGroupAssign)
+		r.Delete("/utxos/groups/{id}", s.handleUtxoGroupDelete)
+		r.Get("/provenance", s.handleProvenanceGraph)
+		r.Get("/provenance/status", s.handleProvenanceStatus)
+		r.Get("/provenance/health", s.handleProvenanceHealth)
+		r.Post("/provenance/rebuild", s.handleProvenanceRebuild)
 	})
 
 	r.Route("/api/wallet", func(r chi.Router) {

--- a/lightningos-light/internal/server/server.go
+++ b/lightningos-light/internal/server/server.go
@@ -82,6 +82,14 @@ type Server struct {
 	closeManagerMu              sync.Mutex
 	closeManager                *CloseManagerService
 	closeManagerErr             string
+	utxoManagerInitAt           time.Time
+	utxoManagerMu               sync.Mutex
+	utxoManager                 *UtxoManagerService
+	utxoManagerErr              string
+	provenanceInitAt            time.Time
+	provenanceMu                sync.Mutex
+	provenance                  *ProvenanceService
+	provenanceErr               string
 	nodeRetirementInitAt        time.Time
 	nodeRetirementMu            sync.Mutex
 	nodeRetirement              *NodeRetirementService
@@ -133,6 +141,8 @@ func (s *Server) Run() error {
 	s.initGraphExplorer()
 	s.initBalancedOpen()
 	s.initCloseManager()
+	s.initUtxoManager()
+	s.initProvenance()
 	s.initNodeRetirement()
 	s.initSuccession()
 	if s.chat != nil {

--- a/lightningos-light/internal/server/utxo_manager_handlers.go
+++ b/lightningos-light/internal/server/utxo_manager_handlers.go
@@ -1,0 +1,370 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"lightningos-light/internal/lndclient"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	utxoLeaseDefaultExpirySec uint64 = 30 * 24 * 60 * 60 // 30 days
+	utxoLeaseMaxExpirySec     uint64 = 365 * 24 * 60 * 60
+)
+
+// EnrichedOnchainUtxo is the wire shape returned by GET /api/onchain/utxos.
+// It joins LND's UTXO data with our local metadata and lease state.
+type EnrichedOnchainUtxo struct {
+	lndclient.OnchainUtxo
+	Label            string `json:"label,omitempty"`
+	Tag              string `json:"tag,omitempty"`
+	Color            string `json:"color,omitempty"`
+	GroupID          string `json:"group_id,omitempty"`
+	Locked           bool   `json:"locked"`
+	LeaseExpiration  uint64 `json:"lease_expiration,omitempty"`
+	LeaseManagedHere bool   `json:"lease_managed_here,omitempty"`
+}
+
+// enrichOnchainUtxos merges UTXO metadata + lease state onto LND's list. It
+// also opportunistically prunes metadata rows for outpoints that no longer
+// exist in the wallet (auto-prune contract).
+func (s *Server) enrichOnchainUtxos(ctx context.Context, items []lndclient.OnchainUtxo) []EnrichedOnchainUtxo {
+	enriched := make([]EnrichedOnchainUtxo, 0, len(items))
+	for _, item := range items {
+		enriched = append(enriched, EnrichedOnchainUtxo{OnchainUtxo: item})
+	}
+
+	leases, leaseErr := s.lnd.ListLeases(ctx)
+	if leaseErr != nil {
+		s.logger.Printf("utxo manager: list leases failed: %v", leaseErr)
+	} else {
+		for i := range enriched {
+			outpoint := strings.ToLower(strings.TrimSpace(enriched[i].Outpoint))
+			if outpoint == "" {
+				continue
+			}
+			if lease, ok := leases[outpoint]; ok {
+				enriched[i].Locked = true
+				enriched[i].LeaseExpiration = lease.Expiration
+				// The lease ID is deterministic from the outpoint when we
+				// created it; report whether this lease was ours.
+				enriched[i].LeaseManagedHere = lease.ID != ""
+			}
+		}
+	}
+
+	svc, _ := s.utxoManagerService()
+	if svc == nil {
+		return enriched
+	}
+
+	metadata, err := svc.ListMetadata(ctx)
+	if err != nil {
+		s.logger.Printf("utxo manager: list metadata failed: %v", err)
+		return enriched
+	}
+
+	live := make([]string, 0, len(items))
+	for _, item := range items {
+		live = append(live, item.Outpoint)
+	}
+
+	for i := range enriched {
+		outpoint := strings.ToLower(strings.TrimSpace(enriched[i].Outpoint))
+		meta, ok := metadata[outpoint]
+		if !ok {
+			continue
+		}
+		enriched[i].Label = meta.Label
+		enriched[i].Tag = meta.Tag
+		enriched[i].Color = meta.Color
+		enriched[i].GroupID = meta.GroupID
+	}
+
+	// Best-effort prune; failures shouldn't block the read path.
+	pruneCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := svc.Prune(pruneCtx, live); err != nil {
+		s.logger.Printf("utxo manager: prune failed: %v", err)
+	}
+
+	return enriched
+}
+
+func (s *Server) handleUtxoMetadataUpsert(w http.ResponseWriter, r *http.Request) {
+	svc, errMsg := s.utxoManagerService()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, errMsg)
+		return
+	}
+
+	var req struct {
+		Outpoint string  `json:"outpoint"`
+		Label    *string `json:"label,omitempty"`
+		Tag      *string `json:"tag,omitempty"`
+		Color    *string `json:"color,omitempty"`
+		GroupID  *string `json:"group_id,omitempty"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if strings.TrimSpace(req.Outpoint) == "" {
+		writeError(w, http.StatusBadRequest, "outpoint required")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	if err := svc.UpsertMetadata(ctx, UtxoMetadataUpdate{
+		Outpoint: req.Outpoint,
+		Label:    req.Label,
+		Tag:      req.Tag,
+		Color:    req.Color,
+		GroupID:  req.GroupID,
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleUtxoLock(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Outpoints []string `json:"outpoints"`
+		ExpirySec uint64   `json:"expiry_sec"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if len(req.Outpoints) == 0 {
+		writeError(w, http.StatusBadRequest, "outpoints required")
+		return
+	}
+	expiry := req.ExpirySec
+	if expiry == 0 {
+		expiry = utxoLeaseDefaultExpirySec
+	}
+	if expiry > utxoLeaseMaxExpirySec {
+		expiry = utxoLeaseMaxExpirySec
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	type leaseResult struct {
+		Outpoint   string `json:"outpoint"`
+		Expiration uint64 `json:"expiration,omitempty"`
+		Error      string `json:"error,omitempty"`
+	}
+	results := make([]leaseResult, 0, len(req.Outpoints))
+	for _, outpoint := range req.Outpoints {
+		info, err := s.lnd.LeaseOutput(ctx, outpoint, expiry)
+		if err != nil {
+			results = append(results, leaseResult{Outpoint: outpoint, Error: lndRPCErrorMessage(err)})
+			continue
+		}
+		results = append(results, leaseResult{Outpoint: info.Outpoint, Expiration: info.Expiration})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+func (s *Server) handleUtxoUnlock(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Outpoints []string `json:"outpoints"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if len(req.Outpoints) == 0 {
+		writeError(w, http.StatusBadRequest, "outpoints required")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	type unlockResult struct {
+		Outpoint string `json:"outpoint"`
+		Error    string `json:"error,omitempty"`
+	}
+	results := make([]unlockResult, 0, len(req.Outpoints))
+	for _, outpoint := range req.Outpoints {
+		err := s.lnd.ReleaseOutput(ctx, outpoint)
+		if err != nil {
+			results = append(results, unlockResult{Outpoint: outpoint, Error: lndRPCErrorMessage(err)})
+			continue
+		}
+		results = append(results, unlockResult{Outpoint: outpoint})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+func (s *Server) handleUtxoGroupsList(w http.ResponseWriter, r *http.Request) {
+	svc, errMsg := s.utxoManagerService()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, errMsg)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	groups, err := svc.ListGroups(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"groups": groups})
+}
+
+func (s *Server) handleUtxoGroupsUpsert(w http.ResponseWriter, r *http.Request) {
+	svc, errMsg := s.utxoManagerService()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, errMsg)
+		return
+	}
+
+	var req struct {
+		ID        string   `json:"id"`
+		Name      string   `json:"name"`
+		Color     string   `json:"color"`
+		Outpoints []string `json:"outpoints"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if strings.TrimSpace(req.ID) == "" && strings.TrimSpace(req.Name) == "" {
+		writeError(w, http.StatusBadRequest, "name required for new group")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	id, err := svc.UpsertGroup(ctx, UtxoGroupUpsert{
+		ID:    req.ID,
+		Name:  req.Name,
+		Color: req.Color,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if len(req.Outpoints) > 0 {
+		if err := svc.AssignToGroup(ctx, id, req.Outpoints); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"id": id})
+}
+
+func (s *Server) handleUtxoGroupAssign(w http.ResponseWriter, r *http.Request) {
+	svc, errMsg := s.utxoManagerService()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, errMsg)
+		return
+	}
+
+	groupID := strings.TrimSpace(chi.URLParam(r, "id"))
+	if groupID == "" {
+		writeError(w, http.StatusBadRequest, "group id required")
+		return
+	}
+
+	var req struct {
+		Outpoints []string `json:"outpoints"`
+		Detach    bool     `json:"detach"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if len(req.Outpoints) == 0 {
+		writeError(w, http.StatusBadRequest, "outpoints required")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	assignTo := groupID
+	if req.Detach {
+		assignTo = ""
+	}
+	if err := svc.AssignToGroup(ctx, assignTo, req.Outpoints); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleUtxoBump(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Outpoint    string `json:"outpoint"`
+		SatPerVbyte int64  `json:"sat_per_vbyte"`
+		TargetConf  uint32 `json:"target_conf"`
+		BudgetSat   int64  `json:"budget_sat"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if strings.TrimSpace(req.Outpoint) == "" {
+		writeError(w, http.StatusBadRequest, "outpoint required")
+		return
+	}
+	if req.SatPerVbyte <= 0 && req.TargetConf == 0 {
+		writeError(w, http.StatusBadRequest, "sat_per_vbyte or target_conf required")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+
+	if err := s.lnd.BumpFee(ctx, lndclient.BumpFeeParams{
+		Outpoint:    req.Outpoint,
+		SatPerVbyte: req.SatPerVbyte,
+		TargetConf:  req.TargetConf,
+		BudgetSat:   req.BudgetSat,
+		Immediate:   true,
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, lndRPCErrorMessage(err))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleUtxoGroupDelete(w http.ResponseWriter, r *http.Request) {
+	svc, errMsg := s.utxoManagerService()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, errMsg)
+		return
+	}
+
+	groupID := strings.TrimSpace(chi.URLParam(r, "id"))
+	if groupID == "" {
+		writeError(w, http.StatusBadRequest, "group id required")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	if err := svc.DeleteGroup(ctx, groupID); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}

--- a/lightningos-light/internal/server/utxo_manager_init.go
+++ b/lightningos-light/internal/server/utxo_manager_init.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const utxoManagerInitRetryCooldown = 10 * time.Second
+
+func (s *Server) initUtxoManager() {
+	s.utxoManagerMu.Lock()
+	defer s.utxoManagerMu.Unlock()
+
+	if s.utxoManager != nil && s.utxoManagerErr == "" {
+		return
+	}
+	if !s.utxoManagerInitAt.IsZero() && time.Since(s.utxoManagerInitAt) < utxoManagerInitRetryCooldown {
+		return
+	}
+	s.utxoManagerInitAt = time.Now()
+
+	dsn, err := ResolveNotificationsDSN(s.logger)
+	if err != nil {
+		s.utxoManagerErr = fmt.Sprintf("utxo manager unavailable: %v", err)
+		s.logger.Printf("%s", s.utxoManagerErr)
+		return
+	}
+
+	pool := s.db
+	if pool == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		pool, err = pgxpool.New(ctx, dsn)
+		if err != nil {
+			s.utxoManagerErr = fmt.Sprintf("utxo manager unavailable: failed to connect to postgres: %v", err)
+			s.logger.Printf("%s", s.utxoManagerErr)
+			return
+		}
+		s.db = pool
+	}
+
+	svc := NewUtxoManagerService(pool, s.logger)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := svc.EnsureSchema(ctx); err != nil {
+		s.utxoManagerErr = fmt.Sprintf("utxo manager unavailable: failed to init schema: %v", err)
+		s.logger.Printf("%s", s.utxoManagerErr)
+		return
+	}
+
+	s.utxoManager = svc
+	s.utxoManagerErr = ""
+}
+
+func (s *Server) utxoManagerService() (*UtxoManagerService, string) {
+	s.initUtxoManager()
+	return s.utxoManager, s.utxoManagerErr
+}

--- a/lightningos-light/internal/server/utxo_manager_service.go
+++ b/lightningos-light/internal/server/utxo_manager_service.go
@@ -1,0 +1,370 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var ErrUtxoManagerDBUnavailable = errors.New("utxo manager db unavailable")
+
+// UtxoMetadata is the local-only annotation we keep for a wallet UTXO. LND has
+// no per-output label, so this lives in our DB and is keyed by "txid:vout".
+type UtxoMetadata struct {
+	Outpoint  string    `json:"outpoint"`
+	Label     string    `json:"label"`
+	Tag       string    `json:"tag"`
+	Color     string    `json:"color"`
+	GroupID   string    `json:"group_id"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// UtxoGroup is a user-defined bundle of UTXOs that travel together in the UI.
+type UtxoGroup struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Color     string    `json:"color"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// UtxoMetadataUpdate carries partial updates: nil pointer = leave field
+// untouched; empty string = clear field. Outpoint is required.
+type UtxoMetadataUpdate struct {
+	Outpoint string
+	Label    *string
+	Tag      *string
+	Color    *string
+	GroupID  *string
+}
+
+// UtxoGroupUpsert creates or edits a group. Empty ID = create new (uuid-ish
+// random hex). Name and Color are required on create; on update they replace
+// only when non-empty.
+type UtxoGroupUpsert struct {
+	ID    string
+	Name  string
+	Color string
+}
+
+type UtxoManagerService struct {
+	db     *pgxpool.Pool
+	logger *log.Logger
+}
+
+func NewUtxoManagerService(db *pgxpool.Pool, logger *log.Logger) *UtxoManagerService {
+	return &UtxoManagerService{db: db, logger: logger}
+}
+
+func (s *UtxoManagerService) EnsureSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return ErrUtxoManagerDBUnavailable
+	}
+	_, err := s.db.Exec(ctx, `
+create table if not exists utxo_groups (
+  id text primary key,
+  name text not null default '',
+  color text not null default '',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists utxo_metadata (
+  outpoint text primary key,
+  label text not null default '',
+  tag text not null default '',
+  color text not null default '',
+  group_id text references utxo_groups(id) on delete set null,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists utxo_metadata_group_idx on utxo_metadata (group_id) where group_id is not null;
+`)
+	return err
+}
+
+// ListMetadata returns all stored UTXO metadata keyed by outpoint.
+func (s *UtxoManagerService) ListMetadata(ctx context.Context) (map[string]UtxoMetadata, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrUtxoManagerDBUnavailable
+	}
+	rows, err := s.db.Query(ctx, `
+select outpoint, label, tag, color, coalesce(group_id, ''), updated_at
+from utxo_metadata`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]UtxoMetadata, 32)
+	for rows.Next() {
+		var m UtxoMetadata
+		if err := rows.Scan(&m.Outpoint, &m.Label, &m.Tag, &m.Color, &m.GroupID, &m.UpdatedAt); err != nil {
+			return nil, err
+		}
+		out[m.Outpoint] = m
+	}
+	return out, rows.Err()
+}
+
+// UpsertMetadata applies a partial update. Nil pointers leave the field as-is
+// when the row exists, or use empty defaults on insert.
+func (s *UtxoManagerService) UpsertMetadata(ctx context.Context, update UtxoMetadataUpdate) error {
+	if s == nil || s.db == nil {
+		return ErrUtxoManagerDBUnavailable
+	}
+	outpoint := strings.ToLower(strings.TrimSpace(update.Outpoint))
+	if outpoint == "" {
+		return errors.New("outpoint required")
+	}
+
+	// Resolve nil pointers as "no change on conflict". On fresh insert the
+	// COALESCE collapses to '' / NULL appropriately.
+	label, labelSet := pointerOrEmpty(update.Label)
+	tag, tagSet := pointerOrEmpty(update.Tag)
+	color, colorSet := pointerOrEmpty(update.Color)
+	groupID, groupSet := pointerOrEmpty(update.GroupID)
+
+	if groupSet && groupID != "" {
+		var exists bool
+		if err := s.db.QueryRow(ctx, `select exists(select 1 from utxo_groups where id = $1)`, groupID).Scan(&exists); err != nil {
+			return err
+		}
+		if !exists {
+			return errors.New("group not found")
+		}
+	}
+
+	var groupValue any
+	if groupSet && groupID == "" {
+		groupValue = nil
+	} else if groupSet {
+		groupValue = groupID
+	} else {
+		groupValue = nil
+	}
+
+	_, err := s.db.Exec(ctx, `
+insert into utxo_metadata (outpoint, label, tag, color, group_id, updated_at)
+values ($1, $2, $3, $4, $5, now())
+on conflict (outpoint) do update set
+  label = case when $6 then excluded.label else utxo_metadata.label end,
+  tag = case when $7 then excluded.tag else utxo_metadata.tag end,
+  color = case when $8 then excluded.color else utxo_metadata.color end,
+  group_id = case when $9 then excluded.group_id else utxo_metadata.group_id end,
+  updated_at = now()`,
+		outpoint,
+		label,
+		tag,
+		color,
+		groupValue,
+		labelSet,
+		tagSet,
+		colorSet,
+		groupSet,
+	)
+	return err
+}
+
+// ListGroups returns all stored groups ordered by creation time.
+func (s *UtxoManagerService) ListGroups(ctx context.Context) ([]UtxoGroup, error) {
+	if s == nil || s.db == nil {
+		return nil, ErrUtxoManagerDBUnavailable
+	}
+	rows, err := s.db.Query(ctx, `
+select id, name, color, created_at, updated_at
+from utxo_groups
+order by created_at asc`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]UtxoGroup, 0, 8)
+	for rows.Next() {
+		var g UtxoGroup
+		if err := rows.Scan(&g.ID, &g.Name, &g.Color, &g.CreatedAt, &g.UpdatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, g)
+	}
+	return out, rows.Err()
+}
+
+// UpsertGroup creates a new group when ID is empty, or updates an existing one.
+// Returns the resolved ID.
+func (s *UtxoManagerService) UpsertGroup(ctx context.Context, upsert UtxoGroupUpsert) (string, error) {
+	if s == nil || s.db == nil {
+		return "", ErrUtxoManagerDBUnavailable
+	}
+	name := strings.TrimSpace(upsert.Name)
+	color := strings.TrimSpace(upsert.Color)
+	id := strings.TrimSpace(upsert.ID)
+
+	if id == "" {
+		generated, err := newGroupID()
+		if err != nil {
+			return "", err
+		}
+		_, err = s.db.Exec(ctx, `
+insert into utxo_groups (id, name, color)
+values ($1, $2, $3)`, generated, name, color)
+		if err != nil {
+			return "", err
+		}
+		return generated, nil
+	}
+
+	cmd, err := s.db.Exec(ctx, `
+update utxo_groups set
+  name = case when $2 <> '' then $2 else name end,
+  color = case when $3 <> '' then $3 else color end,
+  updated_at = now()
+where id = $1`, id, name, color)
+	if err != nil {
+		return "", err
+	}
+	if cmd.RowsAffected() == 0 {
+		return "", errors.New("group not found")
+	}
+	return id, nil
+}
+
+// DeleteGroup removes a group. Member rows have their group_id cleared by the
+// FK ON DELETE SET NULL.
+func (s *UtxoManagerService) DeleteGroup(ctx context.Context, id string) error {
+	if s == nil || s.db == nil {
+		return ErrUtxoManagerDBUnavailable
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("id required")
+	}
+	_, err := s.db.Exec(ctx, `delete from utxo_groups where id = $1`, id)
+	return err
+}
+
+// AssignToGroup sets group_id on a batch of outpoints, creating metadata rows
+// if needed. Pass an empty groupID to detach.
+func (s *UtxoManagerService) AssignToGroup(ctx context.Context, groupID string, outpoints []string) error {
+	if s == nil || s.db == nil {
+		return ErrUtxoManagerDBUnavailable
+	}
+	cleaned := normalizeOutpointBatch(outpoints)
+	if len(cleaned) == 0 {
+		return nil
+	}
+	groupID = strings.TrimSpace(groupID)
+	if groupID != "" {
+		var exists bool
+		if err := s.db.QueryRow(ctx, `select exists(select 1 from utxo_groups where id = $1)`, groupID).Scan(&exists); err != nil {
+			return err
+		}
+		if !exists {
+			return errors.New("group not found")
+		}
+	}
+
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var groupValue any
+	if groupID == "" {
+		groupValue = nil
+	} else {
+		groupValue = groupID
+	}
+	for _, outpoint := range cleaned {
+		if _, err := tx.Exec(ctx, `
+insert into utxo_metadata (outpoint, group_id, updated_at)
+values ($1, $2, now())
+on conflict (outpoint) do update set
+  group_id = excluded.group_id,
+  updated_at = now()`, outpoint, groupValue); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// Prune removes metadata rows whose outpoint is not in the live set and then
+// removes groups that no longer hold any members. Pass the current wallet UTXO
+// outpoints. A nil slice is treated as "skip pruning" — only an explicit empty
+// slice forces full cleanup.
+func (s *UtxoManagerService) Prune(ctx context.Context, liveOutpoints []string) error {
+	if s == nil || s.db == nil {
+		return ErrUtxoManagerDBUnavailable
+	}
+	if liveOutpoints == nil {
+		return nil
+	}
+	cleaned := normalizeOutpointBatch(liveOutpoints)
+
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if len(cleaned) == 0 {
+		if _, err := tx.Exec(ctx, `delete from utxo_metadata`); err != nil {
+			return err
+		}
+	} else {
+		if _, err := tx.Exec(ctx, `delete from utxo_metadata where outpoint <> all($1)`, cleaned); err != nil {
+			return err
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+delete from utxo_groups g
+where not exists (select 1 from utxo_metadata m where m.group_id = g.id)`); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func pointerOrEmpty(p *string) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	return strings.TrimSpace(*p), true
+}
+
+func normalizeOutpointBatch(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, raw := range items {
+		trimmed := strings.ToLower(strings.TrimSpace(raw))
+		if trimmed == "" {
+			continue
+		}
+		if _, dup := seen[trimmed]; dup {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func newGroupID() (string, error) {
+	var buf [12]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return "g_" + hex.EncodeToString(buf[:]), nil
+}

--- a/lightningos-light/ui/package.json
+++ b/lightningos-light/ui/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "@fontsource/space-grotesk": "^5.0.20",
+    "@types/d3-force": "^3.0.10",
     "@types/dagre": "^0.7.54",
     "@types/qrcode": "^1.5.6",
+    "d3-force": "^3.0.0",
     "dagre": "^0.8.5",
     "i18next": "^23.12.1",
     "qr-scanner": "^1.4.2",

--- a/lightningos-light/ui/package.json
+++ b/lightningos-light/ui/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@fontsource/space-grotesk": "^5.0.20",
+    "@types/dagre": "^0.7.54",
     "@types/qrcode": "^1.5.6",
+    "dagre": "^0.8.5",
     "i18next": "^23.12.1",
     "qr-scanner": "^1.4.2",
     "qrcode": "^1.5.4",
@@ -19,6 +21,7 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^14.1.2",
     "react-simple-maps": "^3.0.0",
+    "reactflow": "^11.11.4",
     "recharts": "^2.12.4",
     "world-atlas": "^2.0.2"
   },

--- a/lightningos-light/ui/src/App.tsx
+++ b/lightningos-light/ui/src/App.tsx
@@ -14,6 +14,7 @@ import ChannelRanking from './pages/ChannelRanking'
 import ChannelOpenCandidates from './pages/ChannelOpenCandidates'
 import RebalanceCenter from './pages/RebalanceCenter'
 import OnchainHub from './pages/OnchainHub'
+import WalletFlow from './pages/WalletFlow'
 import Chat from './pages/Chat'
 import Disks from './pages/Disks'
 import Logs from './pages/Logs'
@@ -29,7 +30,7 @@ import BuyDepix from './pages/BuyDepix'
 import Shortcuts from './pages/Shortcuts'
 import PayBoleto from './pages/PayBoleto'
 import NodeRetirement from './pages/NodeRetirement'
-import { getAuthState, getBitcoinLocalStatus, getBoletoConfig, getDepixConfig, getLndStatus, getWizardStatus, logoutAuth, type AuthState } from './api'
+import { getAuthState, getBitcoinLocalStatus, getBoletoConfig, getDepixConfig, getLndStatus, getProvenanceHealth, getWizardStatus, logoutAuth, type AuthState } from './api'
 import { defaultPalette, paletteOrder, resolvePalette, resolveTheme, type PaletteKey, type ThemeMode } from './theme'
 
 const readHashRoute = () => {
@@ -146,6 +147,7 @@ export default function App() {
   const [depixEnabled, setDepixEnabled] = useState(false)
   const [boletoEnabled, setBoletoEnabled] = useState(false)
   const [externalBitcoinDetected, setExternalBitcoinDetected] = useState(false)
+  const [electrsAvailable, setElectrsAvailable] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const refreshAuthState = useCallback(async () => {
     try {
@@ -174,6 +176,14 @@ export default function App() {
       setBoletoEnabled(false)
     }
   }, [])
+  const refreshElectrsAvailable = useCallback(async () => {
+    try {
+      const data: any = await getProvenanceHealth()
+      setElectrsAvailable(Boolean(data?.electrs_available))
+    } catch {
+      setElectrsAvailable(false)
+    }
+  }, [])
   const refreshExternalBitcoinDetected = useCallback(async () => {
     try {
       const data: any = await getBitcoinLocalStatus()
@@ -200,6 +210,7 @@ export default function App() {
       { key: 'new-channels', label: t('nav.newChannels'), element: <ChannelOpenCandidates /> },
       { key: 'rebalance-center', label: t('nav.rebalanceCenter'), element: <RebalanceCenter /> },
       { key: 'onchain-hub', label: t('nav.onchainHub'), element: <OnchainHub /> },
+      ...(electrsAvailable ? [{ key: 'wallet-flow', label: 'Wallet flow', element: <WalletFlow /> }] : []),
       { key: 'chat', label: t('nav.chat'), element: <Chat /> },
       {
         key: 'lnd',
@@ -219,7 +230,7 @@ export default function App() {
       { key: 'logs', label: t('nav.logs'), element: <Logs /> },
       { key: 'node-retirement', label: t('nav.nodeRetirement'), element: <NodeRetirement /> }
     ]
-  }, [authState, depixEnabled, boletoEnabled, externalBitcoinDetected, i18n.language, t])
+  }, [authState, depixEnabled, boletoEnabled, electrsAvailable, externalBitcoinDetected, i18n.language, t])
   const baseRouteKeys = useMemo(() => baseRoutes.map((item) => item.key), [baseRoutes])
   const [menuConfig, setMenuConfig] = useState<MenuConfig>(() => normalizeMenuConfig(readMenuConfig(), baseRouteKeys))
 
@@ -285,11 +296,13 @@ export default function App() {
       setDepixEnabled(false)
       setBoletoEnabled(false)
       setExternalBitcoinDetected(false)
+      setElectrsAvailable(false)
       return
     }
 
     const handleAppsChanged = (event: Event) => {
       void refreshExternalBitcoinDetected()
+      void refreshElectrsAvailable()
       const detail = (event as CustomEvent<{ id?: string }>).detail
       if (detail?.id === 'depixbuy') {
         void refreshDepixEnabled()
@@ -302,17 +315,20 @@ export default function App() {
     void refreshDepixEnabled()
     void refreshBoletoEnabled()
     void refreshExternalBitcoinDetected()
+    void refreshElectrsAvailable()
     const timer = window.setInterval(refreshDepixEnabled, 30000)
     const boletoTimer = window.setInterval(refreshBoletoEnabled, 30000)
     const externalBitcoinTimer = window.setInterval(refreshExternalBitcoinDetected, 300000)
+    const electrsTimer = window.setInterval(refreshElectrsAvailable, 60000)
     window.addEventListener('apps:changed', handleAppsChanged as EventListener)
     return () => {
       window.clearInterval(timer)
       window.clearInterval(boletoTimer)
       window.clearInterval(externalBitcoinTimer)
+      window.clearInterval(electrsTimer)
       window.removeEventListener('apps:changed', handleAppsChanged as EventListener)
     }
-  }, [authReady, refreshDepixEnabled, refreshBoletoEnabled, refreshExternalBitcoinDetected])
+  }, [authReady, refreshDepixEnabled, refreshBoletoEnabled, refreshElectrsAvailable, refreshExternalBitcoinDetected])
 
   useEffect(() => {
     setMenuConfig((current) => {

--- a/lightningos-light/ui/src/api.ts
+++ b/lightningos-light/ui/src/api.ts
@@ -196,9 +196,9 @@ export const getWalletActivity = (range: '7d' | '1m' | '1a', limit = 100, offset
 export const getWalletPaymentDetail = (paymentHash: string) =>
   request(`/api/wallet/payments/${encodeURIComponent(paymentHash)}`)
 export const getWalletAddress = () => request('/api/wallet/address', { method: 'POST' })
-export const previewOnchainSend = (payload: { address: string; amount_sat?: number; sat_per_vbyte: number; sweep_all?: boolean }) =>
+export const previewOnchainSend = (payload: { address: string; amount_sat?: number; sat_per_vbyte: number; sweep_all?: boolean; outpoints?: string[] }) =>
   request('/api/wallet/send/preview', { method: 'POST', body: JSON.stringify(payload) })
-export const sendOnchain = (payload: { address: string; amount_sat?: number; sat_per_vbyte?: number; sweep_all?: boolean }) =>
+export const sendOnchain = (payload: { address: string; amount_sat?: number; sat_per_vbyte?: number; sweep_all?: boolean; outpoints?: string[]; label?: string; confirm_password?: string }) =>
   request('/api/wallet/send', { method: 'POST', body: JSON.stringify(payload) })
 export const createInvoice = (payload: {
   amount_sat: number
@@ -430,6 +430,7 @@ export const openChannel = (payload: {
   close_address?: string
   sat_per_vbyte?: number
   private?: boolean
+  outpoints?: string[]
 }) => request('/api/lnops/channel/open', { method: 'POST', body: JSON.stringify(payload) })
 export const openBatchChannels = (payload: {
   channels: Array<{
@@ -558,6 +559,61 @@ export const getOnchainTransactions = (params?: {
   include_unconfirmed?: boolean
   limit?: number
 }) => request(`/api/onchain/transactions${buildQuery(params)}`)
+
+export const upsertUtxoMetadata = (payload: {
+  outpoint: string
+  label?: string
+  tag?: string
+  color?: string
+  group_id?: string
+}) =>
+  request('/api/onchain/utxos/metadata', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+
+export const lockUtxos = (payload: { outpoints: string[]; expiry_sec?: number }) =>
+  request('/api/onchain/utxos/lock', { method: 'POST', body: JSON.stringify(payload) })
+
+export const bumpUtxoFee = (payload: { outpoint: string; sat_per_vbyte?: number; target_conf?: number; budget_sat?: number }) =>
+  request('/api/onchain/utxos/bump', { method: 'POST', body: JSON.stringify(payload) })
+
+export const getProvenanceGraph = (params?: {
+  mode?: 'live' | 'ours' | 'all' | 'lineage'
+  limit?: number
+  root?: string
+  hops?: number
+  include_external?: boolean
+  max_external?: number
+}) => {
+  const q = buildQuery(params)
+  return request(`/api/onchain/provenance${q}`)
+}
+export const getProvenanceStatus = () => request('/api/onchain/provenance/status')
+export const getProvenanceHealth = () => request('/api/onchain/provenance/health')
+export const rebuildProvenance = (full = false) =>
+  request(`/api/onchain/provenance/rebuild${full ? '?full=true' : ''}`, { method: 'POST' })
+
+export const unlockUtxos = (payload: { outpoints: string[] }) =>
+  request('/api/onchain/utxos/unlock', { method: 'POST', body: JSON.stringify(payload) })
+
+export const listUtxoGroups = () => request('/api/onchain/utxos/groups')
+
+export const upsertUtxoGroup = (payload: {
+  id?: string
+  name?: string
+  color?: string
+  outpoints?: string[]
+}) => request('/api/onchain/utxos/groups', { method: 'POST', body: JSON.stringify(payload) })
+
+export const assignUtxoGroup = (groupId: string, payload: { outpoints: string[]; detach?: boolean }) =>
+  request(`/api/onchain/utxos/groups/${encodeURIComponent(groupId)}/assign`, {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+
+export const deleteUtxoGroup = (groupId: string) =>
+  request(`/api/onchain/utxos/groups/${encodeURIComponent(groupId)}`, { method: 'DELETE' })
 
 export const getReportsRange = (range: string) =>
   request(`/api/reports/range?range=${encodeURIComponent(range)}`)

--- a/lightningos-light/ui/src/components/SankeyEdge.tsx
+++ b/lightningos-light/ui/src/components/SankeyEdge.tsx
@@ -1,0 +1,64 @@
+import { type EdgeProps } from 'reactflow'
+
+type SankeyEdgeData = {
+  // ribbon width in pixels at both endpoints (we keep source/target equal
+  // because Bitcoin outpoints conserve value end-to-end)
+  height: number
+  // primary color used for the ribbon gradient anchors
+  color: string
+  // 0..1 opacity multiplier; ours-flows brighter than external
+  opacity?: number
+}
+
+// SankeyEdge renders a filled cubic-bezier ribbon between two reactflow
+// handles — the mempool.space-style "thick flow" look. The ribbon's
+// height is constant from source to target (Bitcoin doesn't lose value
+// in transit). The top and bottom edges of the ribbon are mirror cubics
+// so the silhouette is symmetric.
+export default function SankeyEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  data,
+  selected
+}: EdgeProps<SankeyEdgeData>) {
+  const h = Math.max(4, data?.height ?? 8)
+  const halfH = h / 2
+  const dx = targetX - sourceX
+  const sweep = Math.max(40, Math.abs(dx) * 0.5)
+  const cpx1 = sourceX + sweep
+  const cpx2 = targetX - sweep
+
+  // Top edge of the ribbon: source-top → target-top
+  const top = `M ${sourceX},${sourceY - halfH} C ${cpx1},${sourceY - halfH} ${cpx2},${targetY - halfH} ${targetX},${targetY - halfH}`
+  // Down the target side, back along bottom edge, close to source
+  const bottom = `L ${targetX},${targetY + halfH} C ${cpx2},${targetY + halfH} ${cpx1},${sourceY + halfH} ${sourceX},${sourceY + halfH} Z`
+  const path = `${top} ${bottom}`
+
+  const gradId = `sankey-grad-${id.replace(/[^a-zA-Z0-9_-]/g, '_')}`
+  const color = data?.color ?? '#14b8a6'
+  const accent = '#22d3ee'
+  const baseOpacity = (data?.opacity ?? 0.85) * (selected ? 1.1 : 1)
+
+  return (
+    <g>
+      <defs>
+        <linearGradient id={gradId} x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor={color} stopOpacity={Math.min(1, baseOpacity)} />
+          <stop offset="50%" stopColor={accent} stopOpacity={Math.min(1, baseOpacity + 0.05)} />
+          <stop offset="100%" stopColor={color} stopOpacity={Math.min(1, baseOpacity)} />
+        </linearGradient>
+      </defs>
+      <path
+        d={path}
+        fill={`url(#${gradId})`}
+        stroke={color}
+        strokeOpacity={0.45}
+        strokeWidth={0.5}
+        style={{ pointerEvents: 'auto' }}
+      />
+    </g>
+  )
+}

--- a/lightningos-light/ui/src/components/TxNode.tsx
+++ b/lightningos-light/ui/src/components/TxNode.tsx
@@ -1,0 +1,351 @@
+import { Handle, Position, type NodeProps } from 'reactflow'
+
+export type TxBar = {
+  // For inputs this is the *vin index*; for outputs it is the vout index.
+  // Used to compose the reactflow Handle id.
+  index: number
+  amount: number
+  address?: string
+  isOurs: boolean
+  isCurrentUtxo?: boolean
+  // For inputs: the prior txid (placeholder for click-to-trace later).
+  refTxid?: string
+}
+
+export type TxNodeData = {
+  txid: string
+  blockHeight: number
+  confirmations: number
+  timestamp: number
+  amountSat: number
+  feeSat: number
+  label?: string
+  isExternal: boolean
+  inputs: TxBar[]
+  outputs: TxBar[]
+  // shared scale across the whole graph so bars are comparable
+  minBarAmount: number
+  maxBarAmount: number
+  // counts of bars hidden from the visible inputs/outputs columns
+  hiddenInputCount?: number
+  hiddenInputSat?: number
+  hiddenOutputCount?: number
+  hiddenOutputSat?: number
+}
+
+export const TX_NODE_WIDTH = 340
+
+// Mempool-style: bar height is itself proportional to sat amount (no fixed
+// slot). Each bar contributes its own height to the total node height.
+const BAR_MIN_HEIGHT = 14
+const BAR_MAX_HEIGHT = 64
+const BAR_GAP = 6
+const ADDRESS_ROW_HEIGHT = 12 // text label under each bar
+const HEADER_HEIGHT = 56
+const COL_PADDING = 12
+
+export function barHeightFor(amount: number, min: number, max: number) {
+  return barHeight(amount, min, max)
+}
+
+function barHeight(amount: number, min: number, max: number) {
+  if (amount <= 0) return BAR_MIN_HEIGHT
+  if (min === max || max <= 0) return Math.round((BAR_MIN_HEIGHT + BAR_MAX_HEIGHT) / 2)
+  const sqrtMin = Math.sqrt(Math.max(min, 1))
+  const sqrtMax = Math.sqrt(max)
+  const sqrtNow = Math.sqrt(Math.max(amount, 1))
+  const t = (sqrtNow - sqrtMin) / (sqrtMax - sqrtMin)
+  return Math.round(BAR_MIN_HEIGHT + t * (BAR_MAX_HEIGHT - BAR_MIN_HEIGHT))
+}
+
+function barColor(bar: TxBar, side: 'in' | 'out') {
+  if (!bar.isOurs) return '#475569' // slate-600 — external
+  if (side === 'out' && bar.isCurrentUtxo) return '#14b8a6' // teal — still live
+  return '#f59e0b' // amber — ours moved on
+}
+
+function fmtSats(value: number) {
+  return value.toLocaleString()
+}
+
+function fmtRelTime(ts: number) {
+  if (!ts || ts <= 0) return ''
+  const now = Date.now() / 1000
+  const diff = now - ts
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  if (diff < 30 * 86400) return `${Math.floor(diff / 86400)}d ago`
+  if (diff < 365 * 86400) return `${Math.floor(diff / (30 * 86400))}mo ago`
+  return `${Math.floor(diff / (365 * 86400))}y ago`
+}
+
+function fmtAbsDate(ts: number) {
+  if (!ts || ts <= 0) return ''
+  const d = new Date(ts * 1000)
+  return d.toLocaleString(undefined, {
+    year: '2-digit',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+function shortAddr(addr?: string) {
+  if (!addr) return ''
+  if (addr.length <= 14) return addr
+  return `${addr.slice(0, 6)}…${addr.slice(-6)}`
+}
+
+function totalColumnHeight(bars: TxBar[], min: number, max: number) {
+  if (bars.length === 0) return BAR_MIN_HEIGHT + ADDRESS_ROW_HEIGHT
+  let total = COL_PADDING
+  for (const b of bars) {
+    total += barHeight(b.amount, min, max) + ADDRESS_ROW_HEIGHT + BAR_GAP
+  }
+  return total + COL_PADDING
+}
+
+export function computeTxNodeHeight(data: TxNodeData) {
+  const footerSlot = 16
+  const inH =
+    totalColumnHeight(data.inputs, data.minBarAmount, data.maxBarAmount) +
+    ((data.hiddenInputCount ?? 0) > 0 ? footerSlot : 0)
+  const outH =
+    totalColumnHeight(data.outputs, data.minBarAmount, data.maxBarAmount) +
+    ((data.hiddenOutputCount ?? 0) > 0 ? footerSlot : 0)
+  return HEADER_HEIGHT + Math.max(inH, outH)
+}
+
+// Max bars rendered per side; the rest get summarized as "+N more".
+export const MAX_BARS_PER_SIDE = 25
+
+// Compute the y-offset (from top of the bars block) where the *center* of
+// the bar at index `i` sits. Used by edges so handles attach to the bar's
+// midline rather than a fixed slot.
+function barCenterOffsets(bars: TxBar[], min: number, max: number): number[] {
+  const offsets: number[] = []
+  let y = COL_PADDING
+  for (const b of bars) {
+    const h = barHeight(b.amount, min, max)
+    offsets.push(y + h / 2)
+    y += h + ADDRESS_ROW_HEIGHT + BAR_GAP
+  }
+  return offsets
+}
+
+export default function TxNode({ data, selected }: NodeProps<TxNodeData>) {
+  const shortTxid = `${data.txid.slice(0, 8)}…${data.txid.slice(-6)}`
+  const heightHint = data.blockHeight > 0 ? `h ${data.blockHeight.toLocaleString()}` : 'mempool'
+
+  const liveCount = data.outputs.filter((o) => o.isCurrentUtxo).length
+  const headerBorder = data.isExternal ? '#475569' : liveCount > 0 ? '#14b8a6' : '#f59e0b'
+  const headerGradient = data.isExternal
+    ? 'linear-gradient(180deg, rgba(71,85,105,0.20) 0%, rgba(71,85,105,0.06) 100%)'
+    : liveCount > 0
+    ? 'linear-gradient(180deg, rgba(20,184,166,0.22) 0%, rgba(20,184,166,0.05) 100%)'
+    : 'linear-gradient(180deg, rgba(245,158,11,0.18) 0%, rgba(245,158,11,0.04) 100%)'
+
+  const inOffsets = barCenterOffsets(data.inputs, data.minBarAmount, data.maxBarAmount)
+  const outOffsets = barCenterOffsets(data.outputs, data.minBarAmount, data.maxBarAmount)
+
+  const renderBar = (bar: TxBar, side: 'in' | 'out', offsetY: number) => {
+    const h = barHeight(bar.amount, data.minBarAmount, data.maxBarAmount)
+    const color = barColor(bar, side)
+    const handleId = `${side}-${bar.index}`
+    const handleStyle: React.CSSProperties = {
+      background: color,
+      width: 4,
+      height: Math.max(h * 0.6, 8),
+      border: '0 none',
+      top: offsetY,
+      borderRadius: 1
+    }
+    const title = `${bar.amount > 0 ? fmtSats(bar.amount) + ' sat' : 'amount unknown'}${
+      bar.address ? '\n' + bar.address : ''
+    }${bar.isOurs ? '\n(yours)' : ''}`
+
+    return (
+      <div
+        key={`${side}-${bar.index}`}
+        className="relative"
+        style={{ marginBottom: BAR_GAP }}
+        title={title}
+      >
+        {side === 'in' ? (
+          <>
+            <Handle id={handleId} type="target" position={Position.Left} style={handleStyle} />
+            <div className="flex items-center gap-2 pl-2">
+              <div
+                className="rounded-md"
+                style={{
+                  width: 18,
+                  height: h,
+                  background: `linear-gradient(180deg, ${color} 0%, ${color}aa 100%)`,
+                  boxShadow: bar.isOurs ? `0 0 0 1px ${color}, 0 0 8px ${color}55` : undefined
+                }}
+              />
+              <div className="flex flex-col leading-tight min-w-0">
+                <span className="text-[10px] font-mono text-white truncate" style={{ maxWidth: 120 }}>
+                  {bar.amount > 0 ? fmtSats(bar.amount) : '—'}
+                </span>
+                <span className="text-[9px] font-mono text-white/45 truncate" style={{ maxWidth: 120 }}>
+                  {shortAddr(bar.address)}
+                </span>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center justify-end gap-2 pr-2">
+              <div className="flex flex-col items-end leading-tight min-w-0">
+                <span className="text-[10px] font-mono text-white truncate" style={{ maxWidth: 120 }}>
+                  {bar.amount > 0 ? fmtSats(bar.amount) : '—'}
+                </span>
+                <span className="text-[9px] font-mono text-white/45 truncate" style={{ maxWidth: 120 }}>
+                  {shortAddr(bar.address)}
+                </span>
+              </div>
+              <div
+                className="rounded-md"
+                style={{
+                  width: 18,
+                  height: h,
+                  background: `linear-gradient(180deg, ${color} 0%, ${color}aa 100%)`,
+                  boxShadow: bar.isOurs ? `0 0 0 1px ${color}, 0 0 8px ${color}55` : undefined
+                }}
+              />
+            </div>
+            <Handle id={handleId} type="source" position={Position.Right} style={handleStyle} />
+          </>
+        )}
+      </div>
+    )
+  }
+
+  // Build a stacked column where each bar contributes its own height + an
+  // address label slot. We render bars sequentially and let the flex column
+  // accumulate height naturally.
+  const renderColumn = (
+    bars: TxBar[],
+    side: 'in' | 'out',
+    offsets: number[],
+    hiddenCount: number,
+    hiddenSat: number
+  ) => (
+    <div className="flex-1 relative" style={{ padding: `${COL_PADDING}px 0` }}>
+      {bars.length === 0 ? (
+        <div
+          className={`text-[10px] text-white/35 px-2 ${side === 'out' ? 'text-right' : ''}`}
+        >
+          {side === 'in' ? 'no known inputs' : 'no outputs'}
+        </div>
+      ) : (
+        bars.map((b, i) => renderBar(b, side, offsets[i] ?? 0))
+      )}
+      {hiddenCount > 0 && (
+        <div
+          className={`relative mt-1 text-[10px] text-white/55 px-2 py-1 ${side === 'out' ? 'text-right' : ''}`}
+          style={{
+            background: 'rgba(148,163,184,0.10)',
+            borderRadius: 6
+          }}
+          title={`${hiddenCount} bar(s) collapsed${hiddenSat > 0 ? ` · ${fmtSats(hiddenSat)} sat total` : ''}`}
+        >
+          + {hiddenCount} more {hiddenSat > 0 ? `· ${fmtSats(hiddenSat)} sat` : ''}
+          {side === 'in' ? (
+            <Handle
+              id="in-more"
+              type="target"
+              position={Position.Left}
+              style={{
+                background: '#94a3b8',
+                width: 6,
+                height: 12,
+                border: '0 none',
+                borderRadius: 1
+              }}
+            />
+          ) : (
+            <Handle
+              id="out-more"
+              type="source"
+              position={Position.Right}
+              style={{
+                background: '#94a3b8',
+                width: 6,
+                height: 12,
+                border: '0 none',
+                borderRadius: 1
+              }}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <div
+      style={{
+        width: TX_NODE_WIDTH,
+        background: 'linear-gradient(180deg, #0b1220 0%, #0f172a 100%)',
+        border: `2px solid ${selected ? '#fafafa' : headerBorder}`,
+        borderRadius: 14,
+        overflow: 'hidden',
+        boxShadow: '0 12px 30px rgba(0,0,0,0.45)'
+      }}
+    >
+      <div
+        className="flex items-center justify-between px-3 py-2"
+        style={{ background: headerGradient, borderBottom: `1px solid ${headerBorder}` }}
+      >
+        <div className="leading-tight">
+          <div
+            className="font-mono text-[11px] text-white"
+            title={data.timestamp > 0 ? fmtAbsDate(data.timestamp) : undefined}
+          >
+            {shortTxid}
+          </div>
+          <div className="text-[9px] text-white/55">
+            {data.isExternal ? 'external tx' : heightHint}
+            {data.timestamp > 0 ? ` · ${fmtRelTime(data.timestamp)}` : ''}
+            {data.feeSat > 0 ? ` · fee ${fmtSats(data.feeSat)}s` : ''}
+          </div>
+        </div>
+        {!data.isExternal && (
+          <div className="text-right text-[10px]">
+            {liveCount > 0 ? (
+              <span className="text-glow">
+                {liveCount} live · {fmtSats(data.outputs.filter((o) => o.isCurrentUtxo).reduce((s, o) => s + o.amount, 0))}s
+              </span>
+            ) : (
+              <span className="text-brass">spent</span>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="flex relative">
+        {renderColumn(
+          data.inputs,
+          'in',
+          inOffsets,
+          data.hiddenInputCount ?? 0,
+          data.hiddenInputSat ?? 0
+        )}
+        <div
+          className="absolute top-0 bottom-0 left-1/2 -translate-x-1/2 pointer-events-none"
+          style={{ width: 1, background: 'rgba(148,163,184,0.10)' }}
+        />
+        {renderColumn(
+          data.outputs,
+          'out',
+          outOffsets,
+          data.hiddenOutputCount ?? 0,
+          data.hiddenOutputSat ?? 0
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lightningos-light/ui/src/components/TxNode.tsx
+++ b/lightningos-light/ui/src/components/TxNode.tsx
@@ -1,4 +1,5 @@
 import { Handle, Position, type NodeProps } from 'reactflow'
+import { PALETTE, barGlow, fillBarGradient } from '../utils/utxoStyles'
 
 export type TxBar = {
   // For inputs this is the *vin index*; for outputs it is the vout index.
@@ -59,9 +60,9 @@ function barHeight(amount: number, min: number, max: number) {
 }
 
 function barColor(bar: TxBar, side: 'in' | 'out') {
-  if (!bar.isOurs) return '#475569' // slate-600 — external
-  if (side === 'out' && bar.isCurrentUtxo) return '#14b8a6' // teal — still live
-  return '#f59e0b' // amber — ours moved on
+  if (!bar.isOurs) return PALETTE.external
+  if (side === 'out' && bar.isCurrentUtxo) return PALETTE.oursLive
+  return PALETTE.oursSpent
 }
 
 function fmtSats(value: number) {
@@ -140,7 +141,11 @@ export default function TxNode({ data, selected }: NodeProps<TxNodeData>) {
   const heightHint = data.blockHeight > 0 ? `h ${data.blockHeight.toLocaleString()}` : 'mempool'
 
   const liveCount = data.outputs.filter((o) => o.isCurrentUtxo).length
-  const headerBorder = data.isExternal ? '#475569' : liveCount > 0 ? '#14b8a6' : '#f59e0b'
+  const headerBorder = data.isExternal
+    ? PALETTE.external
+    : liveCount > 0
+    ? PALETTE.oursLive
+    : PALETTE.oursSpent
   const headerGradient = data.isExternal
     ? 'linear-gradient(180deg, rgba(71,85,105,0.20) 0%, rgba(71,85,105,0.06) 100%)'
     : liveCount > 0
@@ -182,8 +187,8 @@ export default function TxNode({ data, selected }: NodeProps<TxNodeData>) {
                 style={{
                   width: 18,
                   height: h,
-                  background: `linear-gradient(180deg, ${color} 0%, ${color}aa 100%)`,
-                  boxShadow: bar.isOurs ? `0 0 0 1px ${color}, 0 0 8px ${color}55` : undefined
+                  background: fillBarGradient(color),
+                  boxShadow: barGlow(color, bar.isOurs)
                 }}
               />
               <div className="flex flex-col leading-tight min-w-0">
@@ -212,8 +217,8 @@ export default function TxNode({ data, selected }: NodeProps<TxNodeData>) {
                 style={{
                   width: 18,
                   height: h,
-                  background: `linear-gradient(180deg, ${color} 0%, ${color}aa 100%)`,
-                  boxShadow: bar.isOurs ? `0 0 0 1px ${color}, 0 0 8px ${color}55` : undefined
+                  background: fillBarGradient(color),
+                  boxShadow: barGlow(color, bar.isOurs)
                 }}
               />
             </div>

--- a/lightningos-light/ui/src/components/UtxoBumpDialog.tsx
+++ b/lightningos-light/ui/src/components/UtxoBumpDialog.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { bumpUtxoFee } from '../api'
+
+type Props = {
+  outpoint: string
+  defaultSatPerVbyte?: number
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export default function UtxoBumpDialog({ outpoint, defaultSatPerVbyte, onClose, onSuccess }: Props) {
+  const [satPerVbyte, setSatPerVbyte] = useState(String(defaultSatPerVbyte ?? 10))
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const submit = async () => {
+    setError('')
+    const rate = Number(satPerVbyte)
+    if (!Number.isFinite(rate) || rate <= 0) {
+      setError('Invalid fee rate.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await bumpUtxoFee({ outpoint, sat_per_vbyte: rate })
+      onSuccess()
+    } catch (err: any) {
+      setError(err?.message || 'Bump failed.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/75 backdrop-blur-sm"
+        onClick={() => (!submitting ? onClose() : undefined)}
+        aria-label="Close"
+      />
+      <div className="relative z-10 w-full max-w-md rounded-3xl border border-white/10 bg-slate/95 p-6 shadow-panel">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-fog/50">UTXO Manager</p>
+            <h2 className="mt-3 text-xl font-semibold">CPFP bump</h2>
+            <p className="mt-2 text-xs text-fog/65 break-all">{outpoint}</p>
+          </div>
+          <button
+            type="button"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-ink/50 text-fog/70 hover:text-white"
+            onClick={() => (!submitting ? onClose() : undefined)}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <p className="text-xs text-fog/60">
+            Spawns a child-pays-for-parent sweep at the new rate. Only works on unconfirmed UTXOs LND
+            knows how to spend (its own anchors / outputs).
+          </p>
+          <div>
+            <label className="text-xs uppercase tracking-wide text-fog/50">New fee rate (sat/vB)</label>
+            <input
+              className="input-field mt-1"
+              inputMode="decimal"
+              value={satPerVbyte}
+              onChange={(e) => setSatPerVbyte(e.target.value.replace(/[^\d.]/g, ''))}
+            />
+          </div>
+          {error && <p className="text-xs text-ember">{error}</p>}
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center justify-end gap-2">
+          <button
+            type="button"
+            className="btn-secondary text-xs px-3 py-2"
+            onClick={() => (!submitting ? onClose() : undefined)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn-primary text-xs px-3 py-2"
+            onClick={submit}
+            disabled={submitting}
+          >
+            {submitting ? 'Submitting…' : 'Bump fee'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lightningos-light/ui/src/components/UtxoCanvas.tsx
+++ b/lightningos-light/ui/src/components/UtxoCanvas.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import clsx from '../utils/clsx'
+
+export type CanvasUtxo = {
+  outpoint: string
+  txid: string
+  vout: number
+  address: string
+  address_type: string
+  amount_sat: number
+  confirmations: number
+  pk_script?: string
+  label?: string
+  tag?: string
+  color?: string
+  group_id?: string
+  locked?: boolean
+  lease_expiration?: number
+}
+
+export type CanvasGroup = {
+  id: string
+  name: string
+  color: string
+}
+
+type Props = {
+  utxos: CanvasUtxo[]
+  groups: CanvasGroup[]
+  selected: Set<string>
+  onSelectionChange: (next: Set<string>) => void
+  onAssignToGroup: (groupId: string, outpoints: string[]) => void
+  onCreateGroupWith: (outpoints: string[], suggestedName?: string) => void
+  formatSats: (value: number) => string
+}
+
+const MIN_SIDE_PX = 56
+const MAX_SIDE_PX = 220
+const GROUP_PALETTE = ['#14b8a6', '#f59e0b', '#a855f7', '#ec4899', '#38bdf8', '#f97316', '#84cc16', '#facc15']
+
+function sideForAmount(amount: number, minAmount: number, maxAmount: number) {
+  if (amount <= 0) return MIN_SIDE_PX
+  if (maxAmount === minAmount) return (MIN_SIDE_PX + MAX_SIDE_PX) / 2
+  const sqrtMin = Math.sqrt(minAmount)
+  const sqrtMax = Math.sqrt(maxAmount)
+  const sqrtNow = Math.sqrt(amount)
+  const t = (sqrtNow - sqrtMin) / (sqrtMax - sqrtMin)
+  return Math.round(MIN_SIDE_PX + t * (MAX_SIDE_PX - MIN_SIDE_PX))
+}
+
+function colorForUtxo(utxo: CanvasUtxo, groupMap: Map<string, CanvasGroup>) {
+  if (utxo.group_id && groupMap.has(utxo.group_id)) {
+    const g = groupMap.get(utxo.group_id)!
+    if (g.color) return g.color
+    const idx = Math.abs(hashCode(g.id)) % GROUP_PALETTE.length
+    return GROUP_PALETTE[idx]
+  }
+  if (utxo.color) return utxo.color
+  return '#64748b'
+}
+
+function hashCode(s: string) {
+  let h = 0
+  for (let i = 0; i < s.length; i += 1) {
+    h = (h << 5) - h + s.charCodeAt(i)
+    h |= 0
+  }
+  return h
+}
+
+export default function UtxoCanvas({
+  utxos,
+  groups,
+  selected,
+  onSelectionChange,
+  onAssignToGroup,
+  onCreateGroupWith,
+  formatSats
+}: Props) {
+  const groupMap = useMemo(() => new Map(groups.map((g) => [g.id, g])), [groups])
+  const { minAmount, maxAmount } = useMemo(() => {
+    if (utxos.length === 0) return { minAmount: 0, maxAmount: 0 }
+    let lo = Infinity
+    let hi = 0
+    for (const u of utxos) {
+      if (u.amount_sat < lo) lo = u.amount_sat
+      if (u.amount_sat > hi) hi = u.amount_sat
+    }
+    return { minAmount: lo, maxAmount: hi }
+  }, [utxos])
+
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [dragState, setDragState] = useState<{
+    sourceOutpoint: string
+    sources: string[]
+    pointerX: number
+    pointerY: number
+    hoverOutpoint: string | null
+  } | null>(null)
+
+  const toggleSelect = (outpoint: string, additive: boolean) => {
+    const next = new Set(additive ? selected : [])
+    if (next.has(outpoint)) next.delete(outpoint)
+    else next.add(outpoint)
+    onSelectionChange(next)
+  }
+
+  useEffect(() => {
+    if (!dragState) return
+    const onMove = (e: PointerEvent) => {
+      const target = document.elementFromPoint(e.clientX, e.clientY)
+      const card = target?.closest('[data-utxo-outpoint]') as HTMLElement | null
+      const hover = card?.dataset.utxoOutpoint || null
+      setDragState((prev) => prev ? { ...prev, pointerX: e.clientX, pointerY: e.clientY, hoverOutpoint: hover } : prev)
+    }
+    const onUp = () => {
+      setDragState((prev) => {
+        if (!prev) return null
+        const targetOutpoint = prev.hoverOutpoint
+        if (targetOutpoint && targetOutpoint !== prev.sourceOutpoint && !prev.sources.includes(targetOutpoint)) {
+          const target = utxos.find((u) => u.outpoint === targetOutpoint)
+          const allOutpoints = Array.from(new Set([...prev.sources, targetOutpoint]))
+          if (target?.group_id) {
+            onAssignToGroup(target.group_id, allOutpoints)
+          } else {
+            const sourceGroupIds = new Set(
+              prev.sources
+                .map((op) => utxos.find((u) => u.outpoint === op)?.group_id)
+                .filter((id): id is string => Boolean(id))
+            )
+            if (sourceGroupIds.size === 1) {
+              const [gid] = Array.from(sourceGroupIds)
+              onAssignToGroup(gid, allOutpoints)
+            } else {
+              onCreateGroupWith(allOutpoints)
+            }
+          }
+        }
+        return null
+      })
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+    }
+  }, [dragState, utxos, onAssignToGroup, onCreateGroupWith])
+
+  const beginDrag = (e: React.PointerEvent, outpoint: string) => {
+    if (e.button !== 0) return
+    const sources = selected.has(outpoint) && selected.size > 1 ? Array.from(selected) : [outpoint]
+    setDragState({
+      sourceOutpoint: outpoint,
+      sources,
+      pointerX: e.clientX,
+      pointerY: e.clientY,
+      hoverOutpoint: null
+    })
+  }
+
+  if (utxos.length === 0) {
+    return <p className="text-sm text-fog/60">No UTXOs to display.</p>
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative flex flex-wrap gap-2 select-none"
+      onPointerDown={(e) => {
+        if ((e.target as HTMLElement).closest('[data-utxo-outpoint]')) return
+        onSelectionChange(new Set())
+      }}
+    >
+      {utxos.map((utxo) => {
+        const side = sideForAmount(utxo.amount_sat, minAmount, maxAmount)
+        const color = colorForUtxo(utxo, groupMap)
+        const isSelected = selected.has(utxo.outpoint)
+        const isDragSource = dragState?.sources.includes(utxo.outpoint)
+        const isDropTarget = dragState && dragState.hoverOutpoint === utxo.outpoint && !isDragSource
+        const groupName = utxo.group_id ? groupMap.get(utxo.group_id)?.name : ''
+        return (
+          <div
+            key={utxo.outpoint}
+            data-utxo-outpoint={utxo.outpoint}
+            onPointerDown={(e) => {
+              const additive = e.shiftKey || e.metaKey || e.ctrlKey
+              toggleSelect(utxo.outpoint, additive)
+              if (!utxo.locked) beginDrag(e, utxo.outpoint)
+            }}
+            style={{
+              width: side,
+              height: side,
+              backgroundColor: `${color}22`,
+              borderColor: isSelected ? '#fafafa' : color,
+              boxShadow: isSelected ? `0 0 0 2px ${color} inset` : undefined,
+              opacity: isDragSource ? 0.55 : 1,
+              outline: isDropTarget ? '3px dashed #fafafa' : undefined
+            }}
+            className={clsx(
+              'rounded-2xl border-2 p-2 flex flex-col justify-between cursor-pointer transition relative overflow-hidden',
+              utxo.confirmations === 0 && 'animate-pulse',
+              utxo.locked && 'opacity-70'
+            )}
+            title={`${utxo.outpoint}\n${utxo.address}`}
+          >
+            <div className="flex items-start justify-between gap-1 text-[10px] uppercase tracking-wide text-white/80">
+              <span className="truncate" style={{ maxWidth: side - 36 }}>
+                {utxo.label || groupName || utxo.address_type || ''}
+              </span>
+              <span className="flex items-center gap-1">
+                {utxo.locked && <span title="locked">🔒</span>}
+                {utxo.confirmations === 0 && <span title="unconfirmed">⏳</span>}
+              </span>
+            </div>
+            <div className="text-sm font-semibold text-white text-right leading-tight">
+              {formatSats(utxo.amount_sat)}
+              <div className="text-[10px] font-normal text-white/70">sats</div>
+            </div>
+          </div>
+        )
+      })}
+      {dragState && (
+        <div
+          className="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-white/40 bg-ink/80 px-3 py-1 text-xs text-white shadow-lg"
+          style={{ left: dragState.pointerX, top: dragState.pointerY }}
+        >
+          {dragState.sources.length > 1 ? `${dragState.sources.length} UTXOs` : 'Drop onto another UTXO to group'}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lightningos-light/ui/src/components/UtxoCanvas.tsx
+++ b/lightningos-light/ui/src/components/UtxoCanvas.tsx
@@ -1,5 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  forceCenter,
+  forceCollide,
+  forceManyBody,
+  forceSimulation,
+  type Simulation,
+  type SimulationNodeDatum
+} from 'd3-force'
 import clsx from '../utils/clsx'
+import {
+  CARD_BODY_GRADIENT,
+  PALETTE,
+  accentStripeLeft,
+  accentStripeTop,
+  cardShadow,
+  colorFromGroupId
+} from '../utils/utxoStyles'
 
 export type CanvasUtxo = {
   outpoint: string
@@ -34,9 +50,14 @@ type Props = {
   formatSats: (value: number) => string
 }
 
-const MIN_SIDE_PX = 56
-const MAX_SIDE_PX = 220
-const GROUP_PALETTE = ['#14b8a6', '#f59e0b', '#a855f7', '#ec4899', '#38bdf8', '#f97316', '#84cc16', '#facc15']
+const MIN_SIDE_PX = 96
+const MAX_SIDE_PX = 160
+const CANVAS_MIN_HEIGHT = 560
+const BOUNDS_MARGIN_PX = 6
+
+// A click-vs-drag threshold so a tiny pointer wobble while clicking doesn't
+// register as a drag and pin the node in place.
+const DRAG_THRESHOLD_PX = 4
 
 function sideForAmount(amount: number, minAmount: number, maxAmount: number) {
   if (amount <= 0) return MIN_SIDE_PX
@@ -52,20 +73,17 @@ function colorForUtxo(utxo: CanvasUtxo, groupMap: Map<string, CanvasGroup>) {
   if (utxo.group_id && groupMap.has(utxo.group_id)) {
     const g = groupMap.get(utxo.group_id)!
     if (g.color) return g.color
-    const idx = Math.abs(hashCode(g.id)) % GROUP_PALETTE.length
-    return GROUP_PALETTE[idx]
+    return colorFromGroupId(g.id)
   }
   if (utxo.color) return utxo.color
-  return '#64748b'
+  if (utxo.locked) return PALETTE.locked
+  return PALETTE.oursLive
 }
 
-function hashCode(s: string) {
-  let h = 0
-  for (let i = 0; i < s.length; i += 1) {
-    h = (h << 5) - h + s.charCodeAt(i)
-    h |= 0
-  }
-  return h
+// Internal node datum the simulation mutates in place.
+type SimNode = SimulationNodeDatum & {
+  outpoint: string
+  side: number
 }
 
 export default function UtxoCanvas({
@@ -90,75 +108,187 @@ export default function UtxoCanvas({
   }, [utxos])
 
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const [dragState, setDragState] = useState<{
-    sourceOutpoint: string
-    sources: string[]
-    pointerX: number
-    pointerY: number
-    hoverOutpoint: string | null
+  const [size, setSize] = useState({ width: 800, height: CANVAS_MIN_HEIGHT })
+
+  // Observe container width; height is fixed by CSS so we don't recompute.
+  useEffect(() => {
+    if (!containerRef.current) return
+    const ro = new ResizeObserver((entries) => {
+      const cr = entries[0].contentRect
+      setSize({ width: cr.width || 800, height: Math.max(cr.height, CANVAS_MIN_HEIGHT) })
+    })
+    ro.observe(containerRef.current)
+    return () => ro.disconnect()
+  }, [])
+
+  // Simulation persists across renders; we only rebuild it when the UTXO set
+  // changes. Mutating its nodes array directly is intentional — d3 expects it.
+  const simRef = useRef<Simulation<SimNode, undefined> | null>(null)
+  const nodesRef = useRef<SimNode[]>([])
+  // Tick counter forces React to re-render after each sim tick; cheap with <100 nodes.
+  const [, setTick] = useState(0)
+
+  useEffect(() => {
+    const cx = size.width / 2
+    const cy = size.height / 2
+    // Preserve positions for nodes that already exist so an incremental add
+    // doesn't slingshot everything from scratch.
+    const prevByOutpoint = new Map<string, SimNode>()
+    for (const n of nodesRef.current) prevByOutpoint.set(n.outpoint, n)
+
+    const nodes: SimNode[] = utxos.map((u) => {
+      const prev = prevByOutpoint.get(u.outpoint)
+      const side = sideForAmount(u.amount_sat, minAmount, maxAmount)
+      return prev
+        ? { ...prev, side }
+        : {
+            outpoint: u.outpoint,
+            side,
+            x: cx + (Math.random() - 0.5) * 40,
+            y: cy + (Math.random() - 0.5) * 40,
+            vx: 0,
+            vy: 0
+          }
+    })
+    nodesRef.current = nodes
+
+    if (simRef.current) simRef.current.stop()
+    simRef.current = forceSimulation(nodes)
+      .force('center', forceCenter(cx, cy).strength(0.18))
+      .force('charge', forceManyBody().strength(-16))
+      .force('collide', forceCollide<SimNode>().radius((d) => d.side / 2 + 6).iterations(2))
+      // Settle in ~15 ticks instead of ~300 so the browser stops re-rendering
+      // quickly. velocityDecay = friction; high alphaDecay/alphaMin cuts the
+      // simulation off when the layout is "good enough" instead of perfect.
+      .alphaDecay(0.12)
+      .alphaMin(0.04)
+      .velocityDecay(0.55)
+      .on('tick', () => {
+        // Hard-clamp positions inside the container box. d3 only knows about
+        // forces; without this, large repulsion can shove nodes off-screen,
+        // especially when a node is being dragged or when the cluster is
+        // bigger than the container.
+        const w = size.width
+        const h = size.height
+        for (const n of nodes) {
+          const r = n.side / 2 + BOUNDS_MARGIN_PX
+          if (n.x != null) {
+            if (n.x < r) n.x = r
+            else if (n.x > w - r) n.x = w - r
+          }
+          if (n.y != null) {
+            if (n.y < r) n.y = r
+            else if (n.y > h - r) n.y = h - r
+          }
+        }
+        setTick((t) => t + 1)
+      })
+
+    return () => {
+      simRef.current?.stop()
+    }
+  }, [utxos, minAmount, maxAmount, size.width, size.height])
+
+  // Drag/click state ----------------------------------------------------
+  const dragRef = useRef<{
+    outpoint: string
+    startX: number
+    startY: number
+    moved: boolean
+    additive: boolean
+    pointerId: number
   } | null>(null)
+  const [hoverDropOutpoint, setHoverDropOutpoint] = useState<string | null>(null)
 
   const toggleSelect = (outpoint: string, additive: boolean) => {
     const next = new Set(additive ? selected : [])
-    if (next.has(outpoint)) next.delete(outpoint)
+    if (selected.has(outpoint)) next.delete(outpoint)
     else next.add(outpoint)
     onSelectionChange(next)
   }
 
-  useEffect(() => {
-    if (!dragState) return
-    const onMove = (e: PointerEvent) => {
-      const target = document.elementFromPoint(e.clientX, e.clientY)
-      const card = target?.closest('[data-utxo-outpoint]') as HTMLElement | null
-      const hover = card?.dataset.utxoOutpoint || null
-      setDragState((prev) => prev ? { ...prev, pointerX: e.clientX, pointerY: e.clientY, hoverOutpoint: hover } : prev)
-    }
-    const onUp = () => {
-      setDragState((prev) => {
-        if (!prev) return null
-        const targetOutpoint = prev.hoverOutpoint
-        if (targetOutpoint && targetOutpoint !== prev.sourceOutpoint && !prev.sources.includes(targetOutpoint)) {
-          const target = utxos.find((u) => u.outpoint === targetOutpoint)
-          const allOutpoints = Array.from(new Set([...prev.sources, targetOutpoint]))
-          if (target?.group_id) {
-            onAssignToGroup(target.group_id, allOutpoints)
-          } else {
-            const sourceGroupIds = new Set(
-              prev.sources
-                .map((op) => utxos.find((u) => u.outpoint === op)?.group_id)
-                .filter((id): id is string => Boolean(id))
-            )
-            if (sourceGroupIds.size === 1) {
-              const [gid] = Array.from(sourceGroupIds)
-              onAssignToGroup(gid, allOutpoints)
-            } else {
-              onCreateGroupWith(allOutpoints)
-            }
-          }
-        }
-        return null
-      })
-    }
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
-    window.addEventListener('pointercancel', onUp)
-    return () => {
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-      window.removeEventListener('pointercancel', onUp)
-    }
-  }, [dragState, utxos, onAssignToGroup, onCreateGroupWith])
-
-  const beginDrag = (e: React.PointerEvent, outpoint: string) => {
+  const onNodePointerDown = (e: React.PointerEvent, utxo: CanvasUtxo) => {
     if (e.button !== 0) return
-    const sources = selected.has(outpoint) && selected.size > 1 ? Array.from(selected) : [outpoint]
-    setDragState({
-      sourceOutpoint: outpoint,
-      sources,
-      pointerX: e.clientX,
-      pointerY: e.clientY,
-      hoverOutpoint: null
-    })
+    const node = nodesRef.current.find((n) => n.outpoint === utxo.outpoint)
+    if (!node) return
+    dragRef.current = {
+      outpoint: utxo.outpoint,
+      startX: e.clientX,
+      startY: e.clientY,
+      moved: false,
+      additive: e.shiftKey || e.metaKey || e.ctrlKey,
+      pointerId: e.pointerId
+    }
+    ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+  }
+
+  const onNodePointerMove = (e: React.PointerEvent, utxo: CanvasUtxo) => {
+    const drag = dragRef.current
+    if (!drag || drag.outpoint !== utxo.outpoint) return
+    const dx = e.clientX - drag.startX
+    const dy = e.clientY - drag.startY
+    if (!drag.moved && Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return
+    drag.moved = true
+    const node = nodesRef.current.find((n) => n.outpoint === drag.outpoint)
+    if (!node || !containerRef.current) return
+    const rect = containerRef.current.getBoundingClientRect()
+    // Pin the node under the cursor while dragging, clamped to bounds so the
+    // user can't fling it off the canvas.
+    const r = node.side / 2 + BOUNDS_MARGIN_PX
+    const px = e.clientX - rect.left
+    const py = e.clientY - rect.top
+    node.fx = Math.max(r, Math.min(size.width - r, px))
+    node.fy = Math.max(r, Math.min(size.height - r, py))
+    // Only nudge the simulation briefly while dragging so it stays responsive
+    // around the dragged node without re-energising the whole cluster.
+    simRef.current?.alphaTarget(0.15).restart()
+    // Hover detection for drop-on-target grouping.
+    const target = document.elementFromPoint(e.clientX, e.clientY)
+    const card = target?.closest('[data-utxo-outpoint]') as HTMLElement | null
+    const hover = card?.dataset.utxoOutpoint || null
+    setHoverDropOutpoint(hover && hover !== drag.outpoint ? hover : null)
+  }
+
+  const finalizeDrag = (e: React.PointerEvent, utxo: CanvasUtxo) => {
+    const drag = dragRef.current
+    if (!drag || drag.outpoint !== utxo.outpoint) return
+    ;(e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId)
+    const node = nodesRef.current.find((n) => n.outpoint === drag.outpoint)
+    if (!drag.moved) {
+      toggleSelect(utxo.outpoint, drag.additive)
+    } else if (hoverDropOutpoint) {
+      const sources =
+        selected.has(drag.outpoint) && selected.size > 1
+          ? Array.from(selected)
+          : [drag.outpoint]
+      const allOutpoints = Array.from(new Set([...sources, hoverDropOutpoint]))
+      const target = utxos.find((u) => u.outpoint === hoverDropOutpoint)
+      if (target?.group_id) {
+        onAssignToGroup(target.group_id, allOutpoints)
+      } else {
+        const sourceGroupIds = new Set(
+          sources
+            .map((op) => utxos.find((u) => u.outpoint === op)?.group_id)
+            .filter((id): id is string => Boolean(id))
+        )
+        if (sourceGroupIds.size === 1) {
+          const [gid] = Array.from(sourceGroupIds)
+          onAssignToGroup(gid, allOutpoints)
+        } else {
+          onCreateGroupWith(allOutpoints)
+        }
+      }
+    }
+    // Release the node so the simulation can re-equilibrate.
+    if (node) {
+      node.fx = null
+      node.fy = null
+    }
+    // Stop the simulation hard on release; the cluster is already where the
+    // user wants it. A small alphaDecay then resettles in a few ticks.
+    simRef.current?.alphaTarget(0).alpha(0.15)
+    setHoverDropOutpoint(null)
+    dragRef.current = null
   }
 
   if (utxos.length === 0) {
@@ -168,68 +298,84 @@ export default function UtxoCanvas({
   return (
     <div
       ref={containerRef}
-      className="relative flex flex-wrap gap-2 select-none"
+      className="relative select-none rounded-2xl"
+      style={{ height: CANVAS_MIN_HEIGHT, background: 'radial-gradient(circle at 50% 50%, rgba(20,184,166,0.05) 0%, transparent 60%)' }}
       onPointerDown={(e) => {
+        // Empty-area click clears selection.
         if ((e.target as HTMLElement).closest('[data-utxo-outpoint]')) return
         onSelectionChange(new Set())
       }}
     >
       {utxos.map((utxo) => {
-        const side = sideForAmount(utxo.amount_sat, minAmount, maxAmount)
+        const node = nodesRef.current.find((n) => n.outpoint === utxo.outpoint)
+        const side = node?.side ?? sideForAmount(utxo.amount_sat, minAmount, maxAmount)
+        const x = node?.x ?? size.width / 2
+        const y = node?.y ?? size.height / 2
         const color = colorForUtxo(utxo, groupMap)
         const isSelected = selected.has(utxo.outpoint)
-        const isDragSource = dragState?.sources.includes(utxo.outpoint)
-        const isDropTarget = dragState && dragState.hoverOutpoint === utxo.outpoint && !isDragSource
+        const isHoverDrop = hoverDropOutpoint === utxo.outpoint
         const groupName = utxo.group_id ? groupMap.get(utxo.group_id)?.name : ''
+        const shortAddr = utxo.address
+          ? utxo.address.length > 14
+            ? `${utxo.address.slice(0, 6)}…${utxo.address.slice(-6)}`
+            : utxo.address
+          : ''
         return (
           <div
             key={utxo.outpoint}
             data-utxo-outpoint={utxo.outpoint}
-            onPointerDown={(e) => {
-              const additive = e.shiftKey || e.metaKey || e.ctrlKey
-              toggleSelect(utxo.outpoint, additive)
-              if (!utxo.locked) beginDrag(e, utxo.outpoint)
-            }}
+            onPointerDown={(e) => onNodePointerDown(e, utxo)}
+            onPointerMove={(e) => onNodePointerMove(e, utxo)}
+            onPointerUp={(e) => finalizeDrag(e, utxo)}
+            onPointerCancel={(e) => finalizeDrag(e, utxo)}
             style={{
+              position: 'absolute',
               width: side,
               height: side,
-              backgroundColor: `${color}22`,
+              transform: `translate3d(${x - side / 2}px, ${y - side / 2}px, 0)`,
+              background: CARD_BODY_GRADIENT,
               borderColor: isSelected ? '#fafafa' : color,
-              boxShadow: isSelected ? `0 0 0 2px ${color} inset` : undefined,
-              opacity: isDragSource ? 0.55 : 1,
-              outline: isDropTarget ? '3px dashed #fafafa' : undefined
+              boxShadow: cardShadow(color, isSelected),
+              outline: isHoverDrop ? '3px dashed #fafafa' : undefined,
+              cursor: 'grab',
+              willChange: 'transform',
+              transition: 'box-shadow 120ms ease, outline 120ms ease'
             }}
             className={clsx(
-              'rounded-2xl border-2 p-2 flex flex-col justify-between cursor-pointer transition relative overflow-hidden',
+              'rounded-2xl border-2 overflow-hidden',
               utxo.confirmations === 0 && 'animate-pulse',
               utxo.locked && 'opacity-70'
             )}
-            title={`${utxo.outpoint}\n${utxo.address}`}
+            title={`${utxo.outpoint}\n${utxo.address}\n${utxo.amount_sat.toLocaleString()} sat`}
           >
-            <div className="flex items-start justify-between gap-1 text-[10px] uppercase tracking-wide text-white/80">
-              <span className="truncate" style={{ maxWidth: side - 36 }}>
-                {utxo.label || groupName || utxo.address_type || ''}
-              </span>
-              <span className="flex items-center gap-1">
-                {utxo.locked && <span title="locked">🔒</span>}
-                {utxo.confirmations === 0 && <span title="unconfirmed">⏳</span>}
-              </span>
-            </div>
-            <div className="text-sm font-semibold text-white text-right leading-tight">
-              {formatSats(utxo.amount_sat)}
-              <div className="text-[10px] font-normal text-white/70">sats</div>
+            <div
+              className="absolute left-0 right-0 top-0 h-1"
+              style={{ background: accentStripeTop(color) }}
+            />
+            <div
+              className="absolute left-0 top-0 bottom-0 w-1"
+              style={{ background: accentStripeLeft(color) }}
+            />
+            <div className="flex h-full flex-col justify-between p-2 pl-3 pointer-events-none">
+              <div className="flex items-start justify-between gap-1 text-[10px] uppercase tracking-wide text-white/75">
+                <span className="truncate" style={{ maxWidth: side - 40 }}>
+                  {utxo.label || groupName || utxo.address_type || ''}
+                </span>
+                <span className="flex items-center gap-1">
+                  {utxo.locked && <span title="locked">🔒</span>}
+                  {utxo.confirmations === 0 && <span title="unconfirmed">⏳</span>}
+                </span>
+              </div>
+              <div className="leading-tight text-right">
+                <div className="font-mono text-[12px] font-semibold text-white whitespace-nowrap">
+                  {formatSats(utxo.amount_sat)}
+                </div>
+                <div className="text-[9px] font-mono text-white/55 truncate">{shortAddr || 'sats'}</div>
+              </div>
             </div>
           </div>
         )
       })}
-      {dragState && (
-        <div
-          className="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-white/40 bg-ink/80 px-3 py-1 text-xs text-white shadow-lg"
-          style={{ left: dragState.pointerX, top: dragState.pointerY }}
-        >
-          {dragState.sources.length > 1 ? `${dragState.sources.length} UTXOs` : 'Drop onto another UTXO to group'}
-        </div>
-      )}
     </div>
   )
 }

--- a/lightningos-light/ui/src/components/UtxoOpenChannelDialog.tsx
+++ b/lightningos-light/ui/src/components/UtxoOpenChannelDialog.tsx
@@ -1,0 +1,231 @@
+import { useMemo, useState } from 'react'
+import { openChannel, previewOpenChannel } from '../api'
+import { computePrivacyWarnings, type UtxoLike } from '../utils/utxoPrivacy'
+
+type Props = {
+  selection: UtxoLike[]
+  defaultSatPerVbyte?: number
+  onClose: () => void
+  onSuccess: (channelPoint: string) => void
+}
+
+export default function UtxoOpenChannelDialog({
+  selection,
+  defaultSatPerVbyte,
+  onClose,
+  onSuccess
+}: Props) {
+  const totalSat = useMemo(() => selection.reduce((a, u) => a + (u.amount_sat || 0), 0), [selection])
+  const [peerAddress, setPeerAddress] = useState('')
+  const [localFundingSat, setLocalFundingSat] = useState(String(Math.max(totalSat - 5000, 0)))
+  const [pushSat, setPushSat] = useState('0')
+  const [satPerVbyte, setSatPerVbyte] = useState(String(defaultSatPerVbyte ?? 5))
+  const [isPrivate, setIsPrivate] = useState(false)
+  const [closeAddress, setCloseAddress] = useState('')
+  const [preview, setPreview] = useState<any>(null)
+  const [previewing, setPreviewing] = useState(false)
+  const [previewError, setPreviewError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const outpoints = useMemo(() => selection.map((u) => u.outpoint), [selection])
+  const warnings = useMemo(() => computePrivacyWarnings(selection), [selection])
+
+  const runPreview = async () => {
+    setPreviewError('')
+    setPreview(null)
+    const local = Number(localFundingSat)
+    const push = Number(pushSat)
+    const rate = Number(satPerVbyte)
+    if (!Number.isFinite(local) || local <= 0) {
+      setPreviewError('Invalid local funding amount.')
+      return
+    }
+    if (!Number.isFinite(rate) || rate <= 0) {
+      setPreviewError('Invalid fee rate.')
+      return
+    }
+    setPreviewing(true)
+    try {
+      const res: any = await previewOpenChannel({
+        local_funding_sat: local,
+        push_sat: push || 0,
+        sat_per_vbyte: rate
+      })
+      setPreview(res)
+    } catch (err: any) {
+      setPreviewError(err?.message || 'Preview failed.')
+    } finally {
+      setPreviewing(false)
+    }
+  }
+
+  const submit = async () => {
+    setError('')
+    const peer = peerAddress.trim()
+    if (!peer) {
+      setError('Peer address required (pubkey@host:port).')
+      return
+    }
+    const local = Number(localFundingSat)
+    if (!Number.isFinite(local) || local <= 0) {
+      setError('Invalid local funding amount.')
+      return
+    }
+    const push = Number(pushSat) || 0
+    if (push > local) {
+      setError('Push amount cannot exceed local funding.')
+      return
+    }
+    const rate = Number(satPerVbyte)
+    if (!Number.isFinite(rate) || rate <= 0) {
+      setError('Invalid fee rate.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const res: any = await openChannel({
+        peer_address: peer,
+        local_funding_sat: local,
+        push_sat: push,
+        sat_per_vbyte: rate,
+        private: isPrivate,
+        close_address: closeAddress.trim() || undefined,
+        outpoints
+      })
+      onSuccess(res?.channel_point || 'ok')
+    } catch (err: any) {
+      setError(err?.message || 'Channel open failed.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/75 backdrop-blur-sm"
+        onClick={() => (!submitting ? onClose() : undefined)}
+        aria-label="Close"
+      />
+      <div className="relative z-10 w-full max-w-xl rounded-3xl border border-white/10 bg-slate/95 p-6 shadow-panel">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-fog/50">UTXO Manager</p>
+            <h2 className="mt-3 text-2xl font-semibold">Open channel from selection</h2>
+            <p className="mt-2 text-sm text-fog/65">
+              {selection.length} input(s) · {totalSat.toLocaleString()} sats total available
+            </p>
+          </div>
+          <button
+            type="button"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-ink/50 text-fog/70 hover:text-white"
+            onClick={() => (!submitting ? onClose() : undefined)}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <div>
+            <label className="text-xs uppercase tracking-wide text-fog/50">Peer (pubkey@host:port)</label>
+            <input
+              className="input-field mt-1"
+              placeholder="03abc…@1.2.3.4:9735"
+              value={peerAddress}
+              onChange={(e) => setPeerAddress(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="text-xs uppercase tracking-wide text-fog/50">Local funding (sats)</label>
+              <input
+                className="input-field mt-1"
+                inputMode="numeric"
+                value={localFundingSat}
+                onChange={(e) => setLocalFundingSat(e.target.value.replace(/[^\d]/g, ''))}
+              />
+            </div>
+            <div>
+              <label className="text-xs uppercase tracking-wide text-fog/50">Push (sats)</label>
+              <input
+                className="input-field mt-1"
+                inputMode="numeric"
+                value={pushSat}
+                onChange={(e) => setPushSat(e.target.value.replace(/[^\d]/g, ''))}
+              />
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="text-xs uppercase tracking-wide text-fog/50">Fee rate (sat/vB)</label>
+              <input
+                className="input-field mt-1"
+                inputMode="decimal"
+                value={satPerVbyte}
+                onChange={(e) => setSatPerVbyte(e.target.value.replace(/[^\d.]/g, ''))}
+              />
+            </div>
+            <div>
+              <label className="text-xs uppercase tracking-wide text-fog/50">Close address (optional)</label>
+              <input
+                className="input-field mt-1"
+                placeholder="bc1…"
+                value={closeAddress}
+                onChange={(e) => setCloseAddress(e.target.value)}
+              />
+            </div>
+          </div>
+          <label className="flex items-center gap-2 text-xs text-fog/70">
+            <input
+              type="checkbox"
+              checked={isPrivate}
+              onChange={(e) => setIsPrivate(e.target.checked)}
+            />
+            Private channel (don't gossip)
+          </label>
+
+          {warnings.length > 0 && (
+            <div className="rounded-2xl border border-brass/40 bg-brass/10 p-3 text-xs space-y-1">
+              <p className="text-brass font-semibold">Privacy notes</p>
+              {warnings.map((w, i) => (
+                <p key={i} className="text-brass">{w.message}</p>
+              ))}
+            </div>
+          )}
+
+          {preview && (
+            <div className="rounded-2xl border border-white/10 bg-ink/40 p-3 text-xs space-y-1">
+              <p>Estimated funding fee: <span className="text-fog">{Number(preview.fee_sat || 0).toLocaleString()} sats</span></p>
+              {preview.message && (
+                <p className={preview.enough_funds === false ? 'text-ember' : 'text-fog/70'}>{preview.message}</p>
+              )}
+            </div>
+          )}
+          {previewError && <p className="text-xs text-ember">{previewError}</p>}
+          {error && <p className="text-xs text-ember">{error}</p>}
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center justify-end gap-2">
+          <button
+            type="button"
+            className="btn-secondary text-xs px-3 py-2"
+            onClick={runPreview}
+            disabled={previewing || submitting}
+          >
+            {previewing ? 'Previewing…' : 'Preview'}
+          </button>
+          <button
+            type="button"
+            className="btn-primary text-xs px-3 py-2"
+            onClick={submit}
+            disabled={submitting}
+          >
+            {submitting ? 'Opening…' : 'Open channel'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lightningos-light/ui/src/components/UtxoSpendDialog.tsx
+++ b/lightningos-light/ui/src/components/UtxoSpendDialog.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getWalletAddress, previewOnchainSend, sendOnchain } from '../api'
+import { computePrivacyWarnings, type UtxoLike } from '../utils/utxoPrivacy'
+
+export type SpendMode = 'spend' | 'consolidate'
+
+type Props = {
+  mode: SpendMode
+  selection: UtxoLike[]
+  defaultSatPerVbyte?: number
+  onClose: () => void
+  onSuccess: (txid: string) => void
+}
+
+export default function UtxoSpendDialog({
+  mode,
+  selection,
+  defaultSatPerVbyte,
+  onClose,
+  onSuccess
+}: Props) {
+  const [address, setAddress] = useState('')
+  const [internalAddrLoading, setInternalAddrLoading] = useState(mode === 'consolidate')
+  const [internalAddrError, setInternalAddrError] = useState('')
+  const [amountSat, setAmountSat] = useState('')
+  const [sweepAll, setSweepAll] = useState(mode === 'consolidate')
+  const [satPerVbyte, setSatPerVbyte] = useState(String(defaultSatPerVbyte ?? 5))
+  const [label, setLabel] = useState(mode === 'consolidate' ? 'consolidate' : '')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [preview, setPreview] = useState<any>(null)
+  const [previewError, setPreviewError] = useState('')
+  const [previewing, setPreviewing] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState('')
+  const [needsPassword, setNeedsPassword] = useState(false)
+
+  useEffect(() => {
+    if (mode !== 'consolidate') return
+    let active = true
+    setInternalAddrLoading(true)
+    getWalletAddress()
+      .then((res: any) => {
+        if (!active) return
+        const next = res?.address || res?.addr || ''
+        if (!next) throw new Error('failed to derive internal address')
+        setAddress(next)
+        setInternalAddrError('')
+      })
+      .catch((err: any) => {
+        if (!active) return
+        setInternalAddrError(err?.message || 'failed to derive internal address')
+      })
+      .finally(() => {
+        if (active) setInternalAddrLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [mode])
+
+  const outpoints = useMemo(() => selection.map((u) => u.outpoint), [selection])
+  const totalSat = useMemo(() => selection.reduce((a, u) => a + (u.amount_sat || 0), 0), [selection])
+  const warnings = useMemo(
+    () =>
+      computePrivacyWarnings(selection, {
+        mode,
+        satPerVbyte: Number(satPerVbyte) || 0
+      }),
+    [selection, mode, satPerVbyte]
+  )
+
+  const formattedSelection = useMemo(() => {
+    const list = selection.slice(0, 4).map((u) => u.outpoint.slice(0, 12) + '…')
+    if (selection.length > 4) list.push(`+${selection.length - 4} more`)
+    return list.join(', ')
+  }, [selection])
+
+  const runPreview = async () => {
+    setPreviewError('')
+    setPreview(null)
+    const rate = Number(satPerVbyte)
+    if (!Number.isFinite(rate) || rate <= 0) {
+      setPreviewError('Invalid fee rate.')
+      return
+    }
+    const amount = sweepAll ? 0 : Number(amountSat)
+    if (!sweepAll && (!Number.isFinite(amount) || amount <= 0)) {
+      setPreviewError('Invalid amount.')
+      return
+    }
+    if (!address.trim()) {
+      setPreviewError('Destination address required.')
+      return
+    }
+    setPreviewing(true)
+    try {
+      const res: any = await previewOnchainSend({
+        address: address.trim(),
+        amount_sat: amount,
+        sweep_all: sweepAll,
+        sat_per_vbyte: rate,
+        outpoints
+      })
+      setPreview(res)
+    } catch (err: any) {
+      setPreviewError(err?.message || 'Preview failed.')
+    } finally {
+      setPreviewing(false)
+    }
+  }
+
+  const submit = async () => {
+    setSubmitError('')
+    const rate = Number(satPerVbyte)
+    if (!Number.isFinite(rate) || rate <= 0) {
+      setSubmitError('Invalid fee rate.')
+      return
+    }
+    const amount = sweepAll ? 0 : Number(amountSat)
+    if (!sweepAll && (!Number.isFinite(amount) || amount <= 0)) {
+      setSubmitError('Invalid amount.')
+      return
+    }
+    if (!address.trim()) {
+      setSubmitError('Destination address required.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const res: any = await sendOnchain({
+        address: address.trim(),
+        amount_sat: amount,
+        sweep_all: sweepAll,
+        sat_per_vbyte: rate,
+        outpoints,
+        label: label.trim() || undefined,
+        confirm_password: confirmPassword || undefined
+      })
+      onSuccess(res?.txid || 'ok')
+    } catch (err: any) {
+      const message: string = err?.message || 'Send failed.'
+      const code: string | undefined = err?.code
+      if (code === 'wallet_send_external_reauth_required' || message.toLowerCase().includes('password')) {
+        setNeedsPassword(true)
+        setSubmitError('Password confirmation required to send to an external address.')
+      } else {
+        setSubmitError(message)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const title = mode === 'consolidate' ? 'Consolidate UTXOs' : 'Spend UTXOs'
+  const cta = mode === 'consolidate' ? 'Broadcast consolidate' : 'Broadcast send'
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/75 backdrop-blur-sm"
+        onClick={() => (!submitting ? onClose() : undefined)}
+        aria-label="Close"
+      />
+      <div className="relative z-10 w-full max-w-xl rounded-3xl border border-white/10 bg-slate/95 p-6 shadow-panel">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-fog/50">UTXO Manager</p>
+            <h2 className="mt-3 text-2xl font-semibold">{title}</h2>
+            <p className="mt-2 text-sm text-fog/65">
+              {selection.length} input(s) · {totalSat.toLocaleString()} sats total
+            </p>
+            <p className="mt-1 text-xs text-fog/50 break-all">{formattedSelection}</p>
+          </div>
+          <button
+            type="button"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-ink/50 text-fog/70 hover:text-white"
+            onClick={() => (!submitting ? onClose() : undefined)}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <div>
+            <label className="text-xs uppercase tracking-wide text-fog/50">Destination</label>
+            <input
+              className="input-field mt-1"
+              placeholder={mode === 'consolidate' ? 'Internal wallet address (auto)' : 'bc1…'}
+              value={address}
+              readOnly={mode === 'consolidate'}
+              onChange={(e) => setAddress(e.target.value)}
+            />
+            {internalAddrLoading && <p className="text-xs text-fog/50 mt-1">Deriving address…</p>}
+            {internalAddrError && <p className="text-xs text-ember mt-1">{internalAddrError}</p>}
+          </div>
+
+          {mode === 'spend' && (
+            <>
+              <label className="flex items-center gap-2 text-xs text-fog/70">
+                <input
+                  type="checkbox"
+                  checked={sweepAll}
+                  onChange={(e) => setSweepAll(e.target.checked)}
+                />
+                Sweep all selected (send everything minus fees)
+              </label>
+              {!sweepAll && (
+                <div>
+                  <label className="text-xs uppercase tracking-wide text-fog/50">Amount (sats)</label>
+                  <input
+                    className="input-field mt-1"
+                    inputMode="numeric"
+                    value={amountSat}
+                    onChange={(e) => setAmountSat(e.target.value.replace(/[^\d]/g, ''))}
+                  />
+                </div>
+              )}
+            </>
+          )}
+
+          <div>
+            <label className="text-xs uppercase tracking-wide text-fog/50">Fee rate (sat/vB)</label>
+            <input
+              className="input-field mt-1"
+              inputMode="decimal"
+              value={satPerVbyte}
+              onChange={(e) => setSatPerVbyte(e.target.value.replace(/[^\d.]/g, ''))}
+            />
+          </div>
+
+          {mode === 'spend' && (
+            <div>
+              <label className="text-xs uppercase tracking-wide text-fog/50">Label (optional)</label>
+              <input
+                className="input-field mt-1"
+                placeholder="On-chain tx label"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+              />
+            </div>
+          )}
+
+          {needsPassword && (
+            <div>
+              <label className="text-xs uppercase tracking-wide text-fog/50">Confirm password</label>
+              <input
+                className="input-field mt-1"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+              />
+            </div>
+          )}
+
+          {warnings.length > 0 && (
+            <div className="rounded-2xl border border-brass/40 bg-brass/10 p-3 text-xs space-y-1">
+              <p className="text-brass font-semibold">Privacy notes</p>
+              {warnings.map((w, i) => (
+                <p key={i} className={w.severity === 'warn' ? 'text-brass' : 'text-fog/70'}>
+                  {w.message}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {preview && (
+            <div className="rounded-2xl border border-white/10 bg-ink/40 p-3 text-xs space-y-1">
+              <p>
+                Fee: <span className="text-fog">{Number(preview.fee_sat || 0).toLocaleString()} sats</span>{' '}
+                · Vbytes: {Number(preview.estimated_vbytes || 0).toLocaleString()}
+              </p>
+              <p>
+                Recipient: <span className="text-fog">{Number(preview.recipient_amount_sat || 0).toLocaleString()} sats</span>
+                {preview.change_sat ? ` · Change: ${Number(preview.change_sat).toLocaleString()} sats` : ''}
+              </p>
+              <p className={preview.enough_funds ? 'text-glow' : 'text-ember'}>
+                {preview.message || (preview.enough_funds ? 'Ready to broadcast.' : 'Inputs insufficient.')}
+              </p>
+            </div>
+          )}
+          {previewError && <p className="text-xs text-ember">{previewError}</p>}
+          {submitError && !needsPassword && <p className="text-xs text-ember">{submitError}</p>}
+          {submitError && needsPassword && <p className="text-xs text-brass">{submitError}</p>}
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center justify-end gap-2">
+          <button
+            type="button"
+            className="btn-secondary text-xs px-3 py-2"
+            onClick={runPreview}
+            disabled={previewing || submitting || internalAddrLoading}
+          >
+            {previewing ? 'Previewing…' : 'Preview'}
+          </button>
+          <button
+            type="button"
+            className="btn-primary text-xs px-3 py-2"
+            onClick={submit}
+            disabled={submitting || internalAddrLoading}
+          >
+            {submitting ? 'Broadcasting…' : cta}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lightningos-light/ui/src/pages/OnchainHub.tsx
+++ b/lightningos-light/ui/src/pages/OnchainHub.tsx
@@ -1,8 +1,24 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { getMempoolFees, getOnchainTransactions, getOnchainUtxos, getWalletSummary } from '../api'
+import {
+  assignUtxoGroup,
+  deleteUtxoGroup,
+  getMempoolFees,
+  getOnchainTransactions,
+  getOnchainUtxos,
+  getWalletSummary,
+  listUtxoGroups,
+  lockUtxos,
+  unlockUtxos,
+  upsertUtxoGroup,
+  upsertUtxoMetadata
+} from '../api'
 import { getLocale } from '../i18n'
 import clsx from '../utils/clsx'
+import UtxoCanvas, { type CanvasGroup, type CanvasUtxo } from '../components/UtxoCanvas'
+import UtxoSpendDialog, { type SpendMode } from '../components/UtxoSpendDialog'
+import UtxoBumpDialog from '../components/UtxoBumpDialog'
+import UtxoOpenChannelDialog from '../components/UtxoOpenChannelDialog'
 
 const emptySummary = {
   balances: {
@@ -25,6 +41,12 @@ type OnchainUtxo = {
   amount_sat: number
   confirmations: number
   pk_script?: string
+  label?: string
+  tag?: string
+  color?: string
+  group_id?: string
+  locked?: boolean
+  lease_expiration?: number
 }
 
 type OnchainTx = {
@@ -63,6 +85,15 @@ export default function OnchainHub() {
   const [feesStatus, setFeesStatus] = useState('')
   const [activePane, setActivePane] = useState<'utxos' | 'txs'>('txs')
   const mountedRef = useRef(true)
+
+  const [utxoView, setUtxoView] = useState<'canvas' | 'table'>('canvas')
+  const [canvasTopN, setCanvasTopN] = useState<number>(10)
+  const [utxoGroups, setUtxoGroups] = useState<CanvasGroup[]>([])
+  const [utxoSelected, setUtxoSelected] = useState<Set<string>>(new Set())
+  const [utxoActionMsg, setUtxoActionMsg] = useState('')
+  const [spendMode, setSpendMode] = useState<SpendMode | null>(null)
+  const [bumpTarget, setBumpTarget] = useState<string | null>(null)
+  const [openChannelOpen, setOpenChannelOpen] = useState(false)
 
   const [utxoQuery, setUtxoQuery] = useState('')
   const [utxoStatus, setUtxoStatus] = useState<'all' | 'confirmed' | 'unconfirmed'>('all')
@@ -144,6 +175,157 @@ export default function OnchainHub() {
     }
   }
 
+  const loadGroups = async () => {
+    try {
+      const res: any = await listUtxoGroups()
+      if (!mountedRef.current) return
+      setUtxoGroups(Array.isArray(res?.groups) ? res.groups : [])
+    } catch {
+      if (!mountedRef.current) return
+      setUtxoGroups([])
+    }
+  }
+
+  const refreshUtxoState = async () => {
+    await Promise.all([loadUtxos(), loadGroups()])
+  }
+
+  const clearSelection = () => setUtxoSelected(new Set())
+
+  const reportAction = (msg: string) => {
+    setUtxoActionMsg(msg)
+    window.setTimeout(() => {
+      if (mountedRef.current) setUtxoActionMsg('')
+    }, 4000)
+  }
+
+  const handleRenameSelected = async () => {
+    if (utxoSelected.size !== 1) return
+    const outpoint = Array.from(utxoSelected)[0]
+    const current = utxos.find((u) => u.outpoint === outpoint)
+    const next = window.prompt('Label for this UTXO (empty to clear):', current?.label || '')
+    if (next === null) return
+    try {
+      await upsertUtxoMetadata({ outpoint, label: next })
+      reportAction('Label updated.')
+      await refreshUtxoState()
+    } catch (err: any) {
+      reportAction(err?.message || 'Failed to update label.')
+    }
+  }
+
+  const handleLockSelected = async () => {
+    if (utxoSelected.size === 0) return
+    try {
+      await lockUtxos({ outpoints: Array.from(utxoSelected) })
+      reportAction(`Locked ${utxoSelected.size} UTXO(s).`)
+      await refreshUtxoState()
+    } catch (err: any) {
+      reportAction(err?.message || 'Failed to lock UTXOs.')
+    }
+  }
+
+  const handleUnlockSelected = async () => {
+    if (utxoSelected.size === 0) return
+    try {
+      await unlockUtxos({ outpoints: Array.from(utxoSelected) })
+      reportAction(`Unlocked ${utxoSelected.size} UTXO(s).`)
+      await refreshUtxoState()
+    } catch (err: any) {
+      reportAction(err?.message || 'Failed to unlock UTXOs.')
+    }
+  }
+
+  const handleGroupSelected = async (name?: string) => {
+    if (utxoSelected.size < 2 && !name) return
+    const groupName = name || window.prompt('Name this group:', `Group ${utxoGroups.length + 1}`)
+    if (!groupName) return
+    try {
+      await upsertUtxoGroup({
+        name: groupName,
+        outpoints: Array.from(utxoSelected)
+      })
+      reportAction(`Grouped ${utxoSelected.size} UTXO(s).`)
+      clearSelection()
+      await refreshUtxoState()
+    } catch (err: any) {
+      reportAction(err?.message || 'Failed to create group.')
+    }
+  }
+
+  const handleUngroupSelected = async () => {
+    if (utxoSelected.size === 0) return
+    const groupIds = new Set(
+      Array.from(utxoSelected)
+        .map((op) => utxos.find((u) => u.outpoint === op)?.group_id)
+        .filter((id): id is string => Boolean(id))
+    )
+    if (groupIds.size === 0) {
+      reportAction('Selection has no group to leave.')
+      return
+    }
+    try {
+      for (const gid of groupIds) {
+        const members = Array.from(utxoSelected).filter(
+          (op) => utxos.find((u) => u.outpoint === op)?.group_id === gid
+        )
+        if (members.length === 0) continue
+        await assignUtxoGroup(gid, { outpoints: members, detach: true })
+      }
+      reportAction('Removed from group.')
+      await refreshUtxoState()
+    } catch (err: any) {
+      reportAction(err?.message || 'Failed to ungroup.')
+    }
+  }
+
+  const handleConsolidateSelected = () => {
+    if (utxoSelected.size < 2) return
+    setSpendMode('consolidate')
+  }
+
+  const handleSendSelected = () => {
+    if (utxoSelected.size === 0) return
+    setSpendMode('spend')
+  }
+
+  const handleBumpSelected = () => {
+    if (utxoSelected.size !== 1) return
+    const outpoint = Array.from(utxoSelected)[0]
+    const utxo = utxos.find((u) => u.outpoint === outpoint)
+    if (!utxo || utxo.confirmations > 0) {
+      reportAction('Bump only works on a single unconfirmed UTXO.')
+      return
+    }
+    setBumpTarget(outpoint)
+  }
+
+  const handleOpenChannelSelected = () => {
+    if (utxoSelected.size === 0) return
+    setOpenChannelOpen(true)
+  }
+
+  const handleConsolidateAll = () => {
+    const spendable = utxos.filter((u) => !u.locked && u.confirmations > 0)
+    if (spendable.length < 2) {
+      reportAction('Need at least 2 confirmed unlocked UTXOs to consolidate.')
+      return
+    }
+    setUtxoSelected(new Set(spendable.map((u) => u.outpoint)))
+    setSpendMode('consolidate')
+  }
+
+  const handleDeleteGroup = async (groupId: string) => {
+    if (!window.confirm('Delete this group? UTXOs stay in your wallet.')) return
+    try {
+      await deleteUtxoGroup(groupId)
+      reportAction('Group deleted.')
+      await refreshUtxoState()
+    } catch (err: any) {
+      reportAction(err?.message || 'Failed to delete group.')
+    }
+  }
+
   const loadTxs = async () => {
     setTxError('')
     try {
@@ -163,10 +345,12 @@ export default function OnchainHub() {
     mountedRef.current = true
     loadSummary()
     loadUtxos()
+    loadGroups()
     loadTxs()
     const timer = window.setInterval(() => {
       loadSummary()
       loadUtxos()
+      loadGroups()
       loadTxs()
     }, 30000)
     return () => {
@@ -420,6 +604,181 @@ export default function OnchainHub() {
             </button>
           </div>
 
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                className={clsx('text-xs px-3 py-2', utxoView === 'canvas' ? 'btn-primary' : 'btn-secondary')}
+                onClick={() => setUtxoView('canvas')}
+              >
+                Canvas
+              </button>
+              <button
+                className={clsx('text-xs px-3 py-2', utxoView === 'table' ? 'btn-primary' : 'btn-secondary')}
+                onClick={() => setUtxoView('table')}
+              >
+                Table
+              </button>
+              {utxoView === 'canvas' && (
+                <label className="flex items-center gap-1 text-xs text-fog/70">
+                  Top
+                  <input
+                    className="input-field w-16 px-2 py-1"
+                    inputMode="numeric"
+                    value={canvasTopN === 0 ? '' : String(canvasTopN)}
+                    placeholder="all"
+                    onChange={(e) => {
+                      const raw = e.target.value.replace(/[^\d]/g, '')
+                      setCanvasTopN(raw ? Math.min(Number(raw), 500) : 0)
+                    }}
+                  />
+                  by amount
+                </label>
+              )}
+              <button
+                className="btn-secondary text-xs px-3 py-2"
+                onClick={handleConsolidateAll}
+                title="Consolidate all confirmed, unlocked UTXOs"
+              >
+                Consolidate all
+              </button>
+            </div>
+            {utxoSelected.size > 0 && (
+              <div className="flex items-center gap-2 text-xs text-fog/70">
+                <span>
+                  {utxoSelected.size} selected ·{' '}
+                  {formatSats(
+                    Array.from(utxoSelected)
+                      .map((op) => utxos.find((u) => u.outpoint === op)?.amount_sat || 0)
+                      .reduce((a, b) => a + b, 0)
+                  )}{' '}
+                  sats
+                </span>
+                <button className="btn-secondary text-xs px-2 py-1" onClick={clearSelection}>
+                  Clear
+                </button>
+              </div>
+            )}
+          </div>
+
+          {utxoSelected.size > 0 && (
+            <div className="flex flex-wrap gap-2">
+              <button className="btn-primary text-xs px-3 py-2" onClick={handleSendSelected}>
+                Spend…
+              </button>
+              {utxoSelected.size >= 2 && (
+                <button className="btn-primary text-xs px-3 py-2" onClick={handleConsolidateSelected}>
+                  Consolidate
+                </button>
+              )}
+              {utxoSelected.size === 1 && (
+                <button className="btn-secondary text-xs px-3 py-2" onClick={handleRenameSelected}>
+                  Rename
+                </button>
+              )}
+              {utxoSelected.size >= 2 && (
+                <button className="btn-secondary text-xs px-3 py-2" onClick={() => handleGroupSelected()}>
+                  Group
+                </button>
+              )}
+              <button className="btn-secondary text-xs px-3 py-2" onClick={handleUngroupSelected}>
+                Ungroup
+              </button>
+              <button className="btn-secondary text-xs px-3 py-2" onClick={handleLockSelected}>
+                Lock
+              </button>
+              <button className="btn-secondary text-xs px-3 py-2" onClick={handleUnlockSelected}>
+                Unlock
+              </button>
+              {utxoSelected.size === 1 && (() => {
+                const sel = Array.from(utxoSelected)[0]
+                const u = utxos.find((x) => x.outpoint === sel)
+                return u && u.confirmations === 0 ? (
+                  <button className="btn-secondary text-xs px-3 py-2" onClick={handleBumpSelected}>
+                    Bump fee
+                  </button>
+                ) : null
+              })()}
+              <button className="btn-secondary text-xs px-3 py-2" onClick={handleOpenChannelSelected}>
+                Open channel
+              </button>
+            </div>
+          )}
+
+          {utxoActionMsg && <p className="text-xs text-brass">{utxoActionMsg}</p>}
+
+          {utxoGroups.length > 0 && (
+            <div className="flex flex-wrap gap-2 text-xs">
+              {utxoGroups.map((g) => (
+                <span
+                  key={g.id}
+                  className="rounded-full border px-2 py-1 flex items-center gap-2"
+                  style={{ borderColor: g.color || '#64748b' }}
+                >
+                  <span
+                    className="inline-block h-2 w-2 rounded-full"
+                    style={{ background: g.color || '#64748b' }}
+                  />
+                  {g.name || g.id}
+                  <button
+                    className="text-fog/50 hover:text-ember"
+                    title="Delete group"
+                    onClick={() => handleDeleteGroup(g.id)}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {utxoView === 'canvas' ? (
+            <div className="onchain-canvas">
+              {utxoLoading && <p className="text-sm text-fog/60">{t('onchainHub.loadingUtxos')}</p>}
+              {utxoError && <p className="text-sm text-ember">{utxoError}</p>}
+              {!utxoLoading && !utxoError && (() => {
+                const sortedByAmount = [...utxoFiltered].sort((a, b) => b.amount_sat - a.amount_sat)
+                const limited = canvasTopN > 0 ? sortedByAmount.slice(0, canvasTopN) : sortedByAmount
+                const hidden = sortedByAmount.length - limited.length
+                return (
+                  <>
+                    {hidden > 0 && (
+                      <p className="text-xs text-fog/60 mb-2">
+                        Showing top {limited.length} of {sortedByAmount.length} by amount · {hidden} hidden
+                      </p>
+                    )}
+                    <UtxoCanvas
+                      utxos={limited as CanvasUtxo[]}
+                      groups={utxoGroups}
+                  selected={utxoSelected}
+                  onSelectionChange={setUtxoSelected}
+                  onAssignToGroup={async (groupId, outpoints) => {
+                    try {
+                      await assignUtxoGroup(groupId, { outpoints })
+                      reportAction('Added to group.')
+                      await refreshUtxoState()
+                    } catch (err: any) {
+                      reportAction(err?.message || 'Failed to assign group.')
+                    }
+                  }}
+                  onCreateGroupWith={async (outpoints, suggested) => {
+                    const name = window.prompt('Name the new group:', suggested || `Group ${utxoGroups.length + 1}`)
+                    if (!name) return
+                    try {
+                      await upsertUtxoGroup({ name, outpoints })
+                      reportAction('Group created.')
+                      clearSelection()
+                      await refreshUtxoState()
+                    } catch (err: any) {
+                      reportAction(err?.message || 'Failed to create group.')
+                    }
+                  }}
+                  formatSats={formatSats}
+                />
+                  </>
+                )
+              })()}
+            </div>
+          ) : (
           <div className="onchain-table">
             <div className="onchain-table-head">
               <span>{t('onchainHub.amount')}</span>
@@ -472,6 +831,7 @@ export default function OnchainHub() {
               ))}
             </div>
           </div>
+          )}
         </div>
 
         <div className={clsx('section-card space-y-4', !txPaneVisible && 'hidden lg:block')}>
@@ -611,6 +971,49 @@ export default function OnchainHub() {
           </div>
         </div>
       </div>
+      {spendMode && (
+        <UtxoSpendDialog
+          mode={spendMode}
+          selection={Array.from(utxoSelected)
+            .map((op) => utxos.find((u) => u.outpoint === op))
+            .filter((u): u is OnchainUtxo => Boolean(u))}
+          defaultSatPerVbyte={fees?.hour}
+          onClose={() => setSpendMode(null)}
+          onSuccess={(txid) => {
+            setSpendMode(null)
+            reportAction(`Broadcast: ${txid}`)
+            clearSelection()
+            refreshUtxoState()
+          }}
+        />
+      )}
+      {bumpTarget && (
+        <UtxoBumpDialog
+          outpoint={bumpTarget}
+          defaultSatPerVbyte={fees?.fastest}
+          onClose={() => setBumpTarget(null)}
+          onSuccess={() => {
+            setBumpTarget(null)
+            reportAction('Bump submitted.')
+            refreshUtxoState()
+          }}
+        />
+      )}
+      {openChannelOpen && (
+        <UtxoOpenChannelDialog
+          selection={Array.from(utxoSelected)
+            .map((op) => utxos.find((u) => u.outpoint === op))
+            .filter((u): u is OnchainUtxo => Boolean(u))}
+          defaultSatPerVbyte={fees?.hour}
+          onClose={() => setOpenChannelOpen(false)}
+          onSuccess={(channelPoint) => {
+            setOpenChannelOpen(false)
+            reportAction(`Channel opening: ${channelPoint}`)
+            clearSelection()
+            refreshUtxoState()
+          }}
+        />
+      )}
     </section>
   )
 }

--- a/lightningos-light/ui/src/pages/WalletFlow.tsx
+++ b/lightningos-light/ui/src/pages/WalletFlow.tsx
@@ -1,0 +1,661 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import ReactFlow, {
+  Background,
+  Controls,
+  type Edge,
+  type Node,
+  Position,
+  ReactFlowProvider
+} from 'reactflow'
+import dagre from 'dagre'
+import 'reactflow/dist/style.css'
+import { getProvenanceGraph, getProvenanceStatus, rebuildProvenance } from '../api'
+import TxNode, {
+  MAX_BARS_PER_SIDE,
+  TX_NODE_WIDTH,
+  barHeightFor,
+  computeTxNodeHeight,
+  type TxBar,
+  type TxNodeData
+} from '../components/TxNode'
+import SankeyEdge from '../components/SankeyEdge'
+
+const NODE_TYPES = { tx: TxNode }
+const EDGE_TYPES = { sankey: SankeyEdge }
+
+type ProvenanceTx = {
+  txid: string
+  block_height: number
+  confirmations: number
+  timestamp: number
+  amount_sat: number
+  fee_sat: number
+  label?: string
+  is_external: boolean
+}
+
+type ProvenanceOutput = {
+  txid: string
+  vout: number
+  address?: string
+  amount_sat: number
+  is_ours: boolean
+  spent_by_txid?: string
+  spent_in_vin?: number
+  is_current_utxo: boolean
+}
+
+type ProvenanceState = {
+  last_sync_height: number
+  last_sync_at: string
+  last_error: string
+  tx_count: number
+  output_count: number
+  ours_outputs: number
+  in_flight: boolean
+}
+
+type GraphPayload = {
+  state: ProvenanceState
+  txs: ProvenanceTx[]
+  outputs: ProvenanceOutput[]
+}
+
+function layout(nodes: Node[], edges: Edge[]): Node[] {
+  const g = new dagre.graphlib.Graph()
+  g.setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: 'LR', nodesep: 24, ranksep: 180 })
+  const sized = nodes.map((n) => {
+    const h = (n.data as TxNodeData)?.inputs ? computeTxNodeHeight(n.data as TxNodeData) : 80
+    const w = TX_NODE_WIDTH
+    g.setNode(n.id, { width: w, height: h })
+    return { ...n, _w: w, _h: h }
+  })
+  for (const e of edges) g.setEdge(e.source, e.target)
+  dagre.layout(g)
+  return sized.map((n) => {
+    const pos = g.node(n.id)
+    return {
+      ...n,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+      position: { x: pos.x - n._w / 2, y: pos.y - n._h / 2 }
+    }
+  })
+}
+
+function shortTxid(txid: string) {
+  if (!txid) return ''
+  return `${txid.slice(0, 8)}…${txid.slice(-6)}`
+}
+
+function fmtSats(value: number) {
+  return value.toLocaleString()
+}
+
+export default function WalletFlow() {
+  const [graph, setGraph] = useState<GraphPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [actionMsg, setActionMsg] = useState('')
+  const [liveStatus, setLiveStatus] = useState<ProvenanceState | null>(null)
+  const [refreshStartedAt, setRefreshStartedAt] = useState<string | null>(null)
+  const inFlight = Boolean(liveStatus?.in_flight)
+  const autoTriggeredRef = useRef(false)
+  const [mode, setMode] = useState<'live' | 'ours' | 'all' | 'lineage'>('live')
+  const [limit, setLimit] = useState<number>(20)
+  const [rootTxid, setRootTxid] = useState<string>('')
+  const [hops, setHops] = useState<number>(3)
+  const [rootInputDraft, setRootInputDraft] = useState<string>('')
+  const [includeExternal, setIncludeExternal] = useState<boolean>(false)
+
+  const load = async () => {
+    setError('')
+    try {
+      const params: Parameters<typeof getProvenanceGraph>[0] = { mode, limit }
+      if (mode === 'lineage') {
+        if (!rootTxid) {
+          setGraph({
+            state: liveStatus ?? graph?.state ?? ({} as ProvenanceState),
+            txs: [],
+            outputs: []
+          })
+          setLoading(false)
+          return
+        }
+        params.root = rootTxid
+        params.hops = hops
+        if (includeExternal) params.include_external = true
+      }
+      const res: any = await getProvenanceGraph(params)
+      setGraph(res)
+    } catch (err: any) {
+      setError(err?.message || 'Failed to load provenance graph.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false
+    const doLoad = async () => {
+      if (cancelled) return
+      await load()
+    }
+    doLoad()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, limit, rootTxid, hops, includeExternal])
+
+  useEffect(() => {
+    let cancelled = false
+    const tick = async () => {
+      try {
+        const status: any = await getProvenanceStatus()
+        if (cancelled) return
+        setLiveStatus(status)
+        if (
+          refreshStartedAt &&
+          !status?.in_flight &&
+          status?.last_sync_at &&
+          status.last_sync_at > refreshStartedAt
+        ) {
+          await load()
+          setRefreshStartedAt(null)
+          setActionMsg('Refresh complete.')
+        }
+      } catch {
+        // ignore transient errors
+      }
+    }
+    tick()
+    const t = window.setInterval(tick, 2000)
+    return () => {
+      cancelled = true
+      window.clearInterval(t)
+    }
+  }, [refreshStartedAt])
+
+  const triggerRebuild = async (full: boolean) => {
+    setActionMsg(full ? 'Full rebuild started…' : 'Building wallet graph…')
+    setRefreshStartedAt(new Date().toISOString())
+    try {
+      await rebuildProvenance(full)
+    } catch (err: any) {
+      setActionMsg(err?.message || 'Refresh failed to start.')
+      setRefreshStartedAt(null)
+    }
+  }
+
+  useEffect(() => {
+    if (autoTriggeredRef.current) return
+    if (loading) return
+    if (inFlight) return
+    if (liveStatus == null) return
+    if (liveStatus.tx_count > 0) return
+    if (graph && graph.txs.length > 0) return
+    autoTriggeredRef.current = true
+    void triggerRebuild(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, inFlight, liveStatus?.tx_count, graph?.txs?.length])
+
+  const { nodes, edges } = useMemo(() => {
+    if (!graph) return { nodes: [] as Node[], edges: [] as Edge[] }
+    const txs = graph.txs ?? []
+    const outputs = graph.outputs ?? []
+    if (txs.length === 0) return { nodes: [] as Node[], edges: [] as Edge[] }
+
+    const txMap = new Map<string, ProvenanceTx>()
+    for (const t of txs) txMap.set(t.txid, t)
+
+    // Outputs grouped by producer tx, and inputs (outputs spent by this tx)
+    // grouped by consumer tx.
+    const outsByProducer = new Map<string, ProvenanceOutput[]>()
+    const insByConsumer = new Map<string, ProvenanceOutput[]>()
+    let minAmt = Number.POSITIVE_INFINITY
+    let maxAmt = 0
+    for (const o of outputs) {
+      if (o.amount_sat > 0) {
+        if (o.amount_sat < minAmt) minAmt = o.amount_sat
+        if (o.amount_sat > maxAmt) maxAmt = o.amount_sat
+      }
+      if (o.txid) {
+        const list = outsByProducer.get(o.txid) ?? []
+        list.push(o)
+        outsByProducer.set(o.txid, list)
+      }
+      if (o.spent_by_txid) {
+        const list = insByConsumer.get(o.spent_by_txid) ?? []
+        list.push(o)
+        insByConsumer.set(o.spent_by_txid, list)
+      }
+    }
+    if (!Number.isFinite(minAmt)) minAmt = 0
+
+    // Visible bars per tx are kept in these sets so we can skip edges that
+    // would attach to a bar we collapsed into "+N more".
+    const visibleInputs = new Map<string, Set<number>>()
+    const visibleOutputs = new Map<string, Set<number>>()
+
+    const rawNodes: Node[] = txs.map((t) => {
+      const allOuts = (outsByProducer.get(t.txid) ?? []).slice()
+      const allIns = (insByConsumer.get(t.txid) ?? []).slice()
+
+      // Show the heaviest bars; hide the long tail behind a summary line.
+      const sortedIns = allIns.slice().sort((a, b) => b.amount_sat - a.amount_sat)
+      const sortedOuts = allOuts.slice().sort((a, b) => b.amount_sat - a.amount_sat)
+      const visibleIns = sortedIns.slice(0, MAX_BARS_PER_SIDE)
+      const visibleOuts = sortedOuts.slice(0, MAX_BARS_PER_SIDE)
+      const hiddenIns = sortedIns.slice(MAX_BARS_PER_SIDE)
+      const hiddenOuts = sortedOuts.slice(MAX_BARS_PER_SIDE)
+
+      const inVis = new Set<number>()
+      for (const o of visibleIns) inVis.add(o.spent_in_vin ?? 0)
+      visibleInputs.set(t.txid, inVis)
+
+      const outVis = new Set<number>()
+      for (const o of visibleOuts) outVis.add(o.vout)
+      visibleOutputs.set(t.txid, outVis)
+
+      const inputs: TxBar[] = visibleIns.map((o, i) => ({
+        index: o.spent_in_vin ?? i,
+        amount: o.amount_sat,
+        address: o.address,
+        isOurs: o.is_ours,
+        refTxid: o.txid
+      }))
+      const outs: TxBar[] = visibleOuts.map((o) => ({
+        index: o.vout,
+        amount: o.amount_sat,
+        address: o.address,
+        isOurs: o.is_ours,
+        isCurrentUtxo: o.is_current_utxo ?? (o.is_ours && !o.spent_by_txid)
+      }))
+
+      const data: TxNodeData = {
+        txid: t.txid,
+        blockHeight: t.block_height,
+        confirmations: t.confirmations,
+        timestamp: t.timestamp,
+        amountSat: t.amount_sat,
+        feeSat: t.fee_sat,
+        label: t.label,
+        isExternal: t.is_external,
+        inputs,
+        outputs: outs,
+        minBarAmount: minAmt,
+        maxBarAmount: maxAmt,
+        hiddenInputCount: hiddenIns.length,
+        hiddenInputSat: hiddenIns.reduce((s, o) => s + o.amount_sat, 0),
+        hiddenOutputCount: hiddenOuts.length,
+        hiddenOutputSat: hiddenOuts.reduce((s, o) => s + o.amount_sat, 0)
+      }
+
+      return {
+        id: t.txid,
+        type: 'tx',
+        data,
+        position: { x: 0, y: 0 }
+      }
+    })
+
+    const rawEdges: Edge[] = []
+    // Edges that go into a collapsed bar group are merged into a single
+    // aggregate ribbon per (sourceHandle, targetTxId/out-more) pair so the
+    // flow visually terminates at the "+N more" row instead of orphaning.
+    const aggregates = new Map<string, { amount: number; isOurs: boolean }>()
+    for (const o of outputs) {
+      if (!o.spent_by_txid) continue
+      if (!txMap.has(o.txid) || !txMap.has(o.spent_by_txid)) continue
+      const srcVis = visibleOutputs.get(o.txid)
+      const tgtVis = visibleInputs.get(o.spent_by_txid)
+      const sourceHandle = srcVis && !srcVis.has(o.vout) ? 'out-more' : `out-${o.vout}`
+      const targetHandle =
+        tgtVis && !tgtVis.has(o.spent_in_vin ?? 0) ? 'in-more' : `in-${o.spent_in_vin ?? 0}`
+
+      // If either endpoint resolves to an aggregate handle, fold the edge
+      // into a per-(source,target,handles) bucket so we draw one fat ribbon
+      // instead of N tiny ones piled on the same anchor.
+      if (sourceHandle === 'out-more' || targetHandle === 'in-more') {
+        const key = `${o.txid}|${sourceHandle}|${o.spent_by_txid}|${targetHandle}`
+        const cur = aggregates.get(key) ?? { amount: 0, isOurs: false }
+        cur.amount += o.amount_sat
+        cur.isOurs = cur.isOurs || o.is_ours
+        aggregates.set(key, cur)
+        continue
+      }
+
+      const baseColor = o.is_ours ? '#14b8a6' : '#64748b'
+      const ribbonHeight = barHeightFor(o.amount_sat, minAmt, maxAmt)
+      rawEdges.push({
+        id: `${o.txid}:${o.vout}->${o.spent_by_txid}:${o.spent_in_vin ?? '?'}`,
+        source: o.txid,
+        sourceHandle,
+        target: o.spent_by_txid,
+        targetHandle,
+        type: 'sankey',
+        data: {
+          height: ribbonHeight,
+          color: baseColor,
+          opacity: o.is_ours ? 0.85 : 0.45
+        }
+      })
+    }
+    for (const [key, agg] of aggregates) {
+      const [srcTx, srcHandle, tgtTx, tgtHandle] = key.split('|')
+      const baseColor = agg.isOurs ? '#14b8a6' : '#64748b'
+      rawEdges.push({
+        id: `agg-${key}`,
+        source: srcTx,
+        sourceHandle: srcHandle,
+        target: tgtTx,
+        targetHandle: tgtHandle,
+        type: 'sankey',
+        data: {
+          height: barHeightFor(agg.amount, minAmt, maxAmt),
+          color: baseColor,
+          opacity: agg.isOurs ? 0.6 : 0.35
+        }
+      })
+    }
+
+    // Declutter: drop external tx nodes whose only contribution to the view
+    // is feeding the "+N more" aggregate handle of some consumer. They show
+    // up as a row of identical little blocks on the left feeding one bundled
+    // ribbon into the bottom of the consumer — visual noise.
+    const keepTxs = new Set<string>()
+    for (const t of txs) {
+      if (!t.is_external) {
+        keepTxs.add(t.txid)
+        continue
+      }
+      const tOuts = outsByProducer.get(t.txid) ?? []
+      for (const o of tOuts) {
+        if (o.is_current_utxo) {
+          keepTxs.add(t.txid)
+          break
+        }
+        if (!o.spent_by_txid) continue
+        // The consumer must be in the rendered slice. If we don't render the
+        // consumer, the external tx has no on-screen ribbon target and would
+        // appear as a dangling block with a curve flying off into nowhere.
+        if (!txMap.has(o.spent_by_txid)) continue
+        const tgtVis = visibleInputs.get(o.spent_by_txid)
+        // Keep the external tx only when its output lands on a VISIBLE input
+        // bar of the consumer (not the "+N more" aggregate).
+        if (tgtVis && tgtVis.has(o.spent_in_vin ?? 0)) {
+          keepTxs.add(t.txid)
+          break
+        }
+      }
+    }
+
+    const filteredNodes = rawNodes.filter((n) => keepTxs.has(n.id))
+    const filteredEdges = rawEdges.filter((e) => keepTxs.has(e.source) && keepTxs.has(e.target))
+
+    // Drop noise nodes:
+    //   - In lineage mode: hide every node with no rendered edges (including
+    //     ours-side orphans) so the trace stays focused on actual flow.
+    //   - In live/ours/all modes: only hide *external* isolated nodes — keep
+    //     ours-side orphans visible so coinbase live UTXOs still render even
+    //     though they have no real parents.
+    // Root of the trace is always preserved.
+    const connected = new Set<string>()
+    for (const e of filteredEdges) {
+      connected.add(e.source)
+      connected.add(e.target)
+    }
+    if (mode === 'lineage' && rootTxid) connected.add(rootTxid)
+    const isLineage = mode === 'lineage'
+    const finalNodes = filteredNodes.filter((n) => {
+      if (connected.has(n.id)) return true
+      return isLineage ? false : !(n.data as TxNodeData).isExternal
+    })
+    const finalIds = new Set(finalNodes.map((n) => n.id))
+    const finalEdges = filteredEdges.filter((e) => finalIds.has(e.source) && finalIds.has(e.target))
+
+    return { nodes: layout(finalNodes, finalEdges), edges: finalEdges }
+  }, [graph, mode, rootTxid])
+
+  return (
+    <section className="space-y-4">
+      <div className="section-card">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-fog/50">UTXO Provenance</p>
+            <h2 className="mt-2 text-2xl font-semibold">Wallet flow</h2>
+            <p className="mt-1 text-sm text-fog/65">
+              Every tx your wallet has touched. Teal = live UTXO ahead. Amber = spent. Grey = external.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              className="input-field text-xs py-1 px-2"
+              value={mode}
+              onChange={(e) => setMode(e.target.value as typeof mode)}
+              title="What to show in the graph"
+            >
+              <option value="live">Live UTXOs only</option>
+              <option value="ours">My transactions</option>
+              <option value="all">Everything (slow)</option>
+              <option value="lineage">Trace lineage from…</option>
+            </select>
+            <label className="flex items-center gap-1 text-xs text-fog/70">
+              Limit
+              <input
+                className="input-field w-16 text-xs py-1 px-2"
+                inputMode="numeric"
+                value={limit}
+                onChange={(e) => {
+                  const v = Number(e.target.value.replace(/[^\d]/g, '')) || 0
+                  setLimit(Math.min(Math.max(v, 1), 2000))
+                }}
+              />
+            </label>
+            <button
+              className="btn-secondary text-xs px-3 py-2"
+              onClick={() => triggerRebuild(false)}
+              disabled={inFlight}
+            >
+              {inFlight ? 'Walking history…' : 'Refresh'}
+            </button>
+            <button
+              className="btn-secondary text-xs px-3 py-2"
+              onClick={() => triggerRebuild(true)}
+              disabled={inFlight}
+              title="Truncate and re-walk all history"
+            >
+              Full rebuild
+            </button>
+            <button
+              className="btn-primary text-xs px-3 py-2"
+              title="Switch to lineage mode and start from your biggest live UTXO"
+              onClick={() => {
+                if (!graph) return
+                let biggestTxid = ''
+                let biggestSat = 0
+                for (const o of graph.outputs ?? []) {
+                  if (o.is_current_utxo && o.amount_sat > biggestSat) {
+                    biggestSat = o.amount_sat
+                    biggestTxid = o.txid
+                  }
+                }
+                if (biggestTxid) {
+                  setMode('lineage')
+                  setRootTxid(biggestTxid)
+                  setHops(3)
+                }
+              }}
+            >
+              Trace biggest
+            </button>
+          </div>
+        </div>
+        {mode === 'lineage' && (
+          <div className="mt-3 flex flex-wrap items-center gap-2 rounded-2xl border border-white/10 bg-ink/40 p-3">
+            <span className="text-xs text-fog/70">Trace from</span>
+            <input
+              className="input-field text-xs py-1 px-2 w-72"
+              placeholder="txid or txid:vout (click a node to set)"
+              value={rootInputDraft || rootTxid}
+              onChange={(e) => setRootInputDraft(e.target.value.trim())}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  const raw = rootInputDraft.trim()
+                  if (raw) {
+                    setRootTxid(raw.split(':')[0].toLowerCase())
+                    setRootInputDraft('')
+                  }
+                }
+              }}
+            />
+            <button
+              className="btn-secondary text-xs px-3 py-1"
+              onClick={() => {
+                const raw = rootInputDraft.trim()
+                if (!raw) return
+                setRootTxid(raw.split(':')[0].toLowerCase())
+                setRootInputDraft('')
+              }}
+            >
+              Trace
+            </button>
+            <label className="flex items-center gap-1 text-xs text-fog/70">
+              Hops
+              <input
+                className="input-field w-14 text-xs py-1 px-2"
+                inputMode="numeric"
+                value={hops}
+                onChange={(e) => {
+                  const v = Number(e.target.value.replace(/[^\d]/g, '')) || 1
+                  setHops(Math.min(Math.max(v, 1), 20))
+                }}
+              />
+            </label>
+            <label className="flex items-center gap-1 text-xs text-fog/70" title="Walk past the wallet boundary via electrs">
+              <input
+                type="checkbox"
+                checked={includeExternal}
+                onChange={(e) => setIncludeExternal(e.target.checked)}
+              />
+              Include external history
+            </label>
+            {rootTxid && (
+              <span className="text-xs text-fog/55 font-mono">
+                root: {rootTxid.slice(0, 10)}… · {hops} gen back
+              </span>
+            )}
+            {!rootTxid && (
+              <span className="text-xs text-fog/55">
+                Paste an outpoint above, or click any node in the graph to set it as root.
+              </span>
+            )}
+          </div>
+        )}
+        {(liveStatus || graph?.state) && (
+          <p className="mt-3 text-xs text-fog/55">
+            Synced at height {(liveStatus ?? graph?.state)?.last_sync_height} ·{' '}
+            {(liveStatus ?? graph?.state)?.tx_count} txs ·{' '}
+            {(liveStatus ?? graph?.state)?.ours_outputs} live UTXOs ·{' '}
+            {(liveStatus ?? graph?.state)?.last_sync_at &&
+            (liveStatus ?? graph?.state)?.last_sync_at !== '0001-01-01T00:00:00Z'
+              ? new Date(((liveStatus ?? graph?.state) as ProvenanceState).last_sync_at).toLocaleString()
+              : 'never'}
+          </p>
+        )}
+        {inFlight && (
+          <div className="mt-3 flex items-center gap-3 rounded-2xl border border-brass/40 bg-brass/10 px-3 py-2">
+            <span className="inline-block h-3 w-3 animate-pulse rounded-full bg-brass" />
+            <p className="text-xs text-brass">
+              Walking your wallet history… current count: {liveStatus?.tx_count ?? 0} txs.
+              This can take a minute on first run.
+            </p>
+          </div>
+        )}
+        {liveStatus?.last_error && !inFlight && (
+          <p className="mt-2 text-xs text-ember">{liveStatus.last_error}</p>
+        )}
+        {actionMsg && !inFlight && <p className="mt-2 text-xs text-brass">{actionMsg}</p>}
+        {error && <p className="mt-2 text-xs text-ember">{error}</p>}
+      </div>
+
+      <div className="relative section-card p-0 overflow-hidden" style={{ height: '70vh', minHeight: 480 }}>
+        {loading ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="flex items-center gap-3 text-sm text-fog/70">
+              <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-brass border-t-transparent" />
+              Loading…
+            </div>
+          </div>
+        ) : nodes.length > 500 ? (
+          <div className="flex h-full items-center justify-center p-6">
+            <div className="max-w-md text-center text-sm text-fog/80 space-y-2">
+              <p className="text-brass font-semibold">{nodes.length} nodes is too many to render safely.</p>
+              <p>Lower the limit (top right) or switch mode to <b>Live UTXOs only</b>.</p>
+            </div>
+          </div>
+        ) : nodes.length === 0 ? (
+          <div className="flex h-full items-center justify-center p-6">
+            <div className="flex flex-col items-center gap-3 text-center">
+              {inFlight ? (
+                <>
+                  <span className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-brass border-t-transparent" />
+                  <p className="text-sm text-fog/80">
+                    Building graph from your transaction history…
+                  </p>
+                  <p className="text-xs text-fog/55">
+                    {liveStatus?.tx_count ?? 0} txs scanned · this can take a minute on first run
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-sm text-fog/80">
+                    No graph yet. Click <b>Refresh</b> above to walk your wallet’s transaction history.
+                  </p>
+                  <button
+                    type="button"
+                    className="btn-primary text-xs px-4 py-2"
+                    onClick={() => triggerRebuild(false)}
+                  >
+                    Start now
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        ) : (
+          <ReactFlowProvider>
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              nodeTypes={NODE_TYPES}
+              edgeTypes={EDGE_TYPES}
+              fitView
+              proOptions={{ hideAttribution: true }}
+              onNodeClick={(_, node) => {
+                setMode('lineage')
+                setRootTxid(node.id)
+              }}
+              nodesDraggable={false}
+            >
+              <Background gap={20} color="#1e293b" />
+              <Controls />
+            </ReactFlow>
+          </ReactFlowProvider>
+        )}
+        {inFlight && nodes.length > 0 && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-ink/40 backdrop-blur-[1px]">
+            <div className="flex items-center gap-3 rounded-2xl border border-white/15 bg-slate/85 px-4 py-3 shadow-panel">
+              <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-brass border-t-transparent" />
+              <span className="text-xs text-fog/85">
+                Refreshing… {liveStatus?.tx_count ?? 0} txs scanned so far
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/lightningos-light/ui/src/utils/utxoPrivacy.ts
+++ b/lightningos-light/ui/src/utils/utxoPrivacy.ts
@@ -1,0 +1,54 @@
+export type UtxoLike = {
+  outpoint: string
+  address?: string
+  address_type?: string
+  amount_sat?: number
+}
+
+export type PrivacyWarning = {
+  severity: 'info' | 'warn'
+  message: string
+}
+
+const DUST_VBYTES_PER_INPUT = 68
+const DUST_RATIO_THRESHOLD = 0.05
+
+export function computePrivacyWarnings(
+  selection: UtxoLike[],
+  options?: { mode?: 'spend' | 'consolidate'; satPerVbyte?: number }
+): PrivacyWarning[] {
+  if (selection.length < 2) return []
+
+  const warnings: PrivacyWarning[] = []
+  const addresses = new Set(selection.map((u) => (u.address || '').trim()).filter(Boolean))
+  const addressTypes = new Set(selection.map((u) => (u.address_type || '').trim()).filter(Boolean))
+
+  if (addresses.size > 1) {
+    warnings.push({
+      severity: 'warn',
+      message: `Mixing UTXOs from ${addresses.size} addresses will link them on-chain (common-input ownership heuristic).`
+    })
+  }
+  if (addressTypes.size > 1) {
+    warnings.push({
+      severity: 'warn',
+      message: `Mixing ${addressTypes.size} address types (${Array.from(addressTypes).join(', ')}) reveals coin control.`
+    })
+  }
+
+  if (options?.mode === 'consolidate' && options.satPerVbyte && options.satPerVbyte > 0) {
+    const totalSat = selection.reduce((acc, u) => acc + (u.amount_sat || 0), 0)
+    if (totalSat > 0) {
+      const approxFee = DUST_VBYTES_PER_INPUT * selection.length * options.satPerVbyte
+      const ratio = approxFee / totalSat
+      if (ratio >= DUST_RATIO_THRESHOLD) {
+        warnings.push({
+          severity: 'warn',
+          message: `Fee (~${approxFee.toLocaleString()} sats) would consume ${(ratio * 100).toFixed(1)}% of the consolidated value at ${options.satPerVbyte} sat/vB. Consider waiting for lower fees.`
+        })
+      }
+    }
+  }
+
+  return warnings
+}

--- a/lightningos-light/ui/src/utils/utxoStyles.ts
+++ b/lightningos-light/ui/src/utils/utxoStyles.ts
@@ -1,0 +1,85 @@
+// Shared palette + style helpers used by both the wallet-flow TxNode bars and
+// the coin-selector UtxoCanvas blocks. Keep style decisions for "ours" /
+// "external" / group coloring in here so the two views never drift visually.
+
+export const PALETTE = {
+  oursLive: '#14b8a6', // teal — ours still unspent
+  oursSpent: '#f59e0b', // amber — ours, moved on
+  external: '#64748b', // slate — not ours
+  locked: '#94a3b8', // muted slate — locked from coinselect
+  /** color cycle for user-created UTXO groups */
+  groupCycle: [
+    '#14b8a6',
+    '#f59e0b',
+    '#a855f7',
+    '#ec4899',
+    '#38bdf8',
+    '#f97316',
+    '#84cc16',
+    '#facc15'
+  ]
+} as const
+
+export type BarKind = 'ours-live' | 'ours-spent' | 'external' | 'locked'
+
+/** Pick the base color for a bar/block. Group color wins if present. */
+export function pickBarColor(kind: BarKind, groupColor?: string): string {
+  if (groupColor) return groupColor
+  switch (kind) {
+    case 'ours-live':
+      return PALETTE.oursLive
+    case 'ours-spent':
+      return PALETTE.oursSpent
+    case 'locked':
+      return PALETTE.locked
+    default:
+      return PALETTE.external
+  }
+}
+
+/** Deterministic palette pick from a group id, used when group.color isn't set. */
+export function colorFromGroupId(id: string): string {
+  let h = 0
+  for (let i = 0; i < id.length; i += 1) {
+    h = (h << 5) - h + id.charCodeAt(i)
+    h |= 0
+  }
+  return PALETTE.groupCycle[Math.abs(h) % PALETTE.groupCycle.length]
+}
+
+/**
+ * Fill gradient for *small* color-filled bars (the per-vin / per-vout bars
+ * inside TxNode). Top of the bar is solid color, bottom slightly transparent.
+ */
+export function fillBarGradient(color: string): string {
+  return `linear-gradient(180deg, ${color} 0%, ${color}aa 100%)`
+}
+
+/**
+ * Body gradient for *larger* blocks that frame their content (UtxoCanvas
+ * cards). Dark navy → slate; the color is conveyed via border + accent
+ * stripes, not by filling the whole block.
+ */
+export const CARD_BODY_GRADIENT = 'linear-gradient(180deg, #0b1220 0%, #0f172a 100%)'
+
+/** Glow for a TxNode bar — only applied to "ours" bars. */
+export function barGlow(color: string, isOurs: boolean): string | undefined {
+  return isOurs ? `0 0 0 1px ${color}, 0 0 8px ${color}55` : undefined
+}
+
+/** Box shadow for a UtxoCanvas card — always glowing softly, brighter when selected. */
+export function cardShadow(color: string, isSelected: boolean): string {
+  return isSelected
+    ? `0 0 0 2px ${color} inset, 0 0 14px ${color}aa`
+    : `0 0 10px ${color}55, 0 4px 14px rgba(0,0,0,0.45)`
+}
+
+/** Decorative accent stripe for the top edge of a UtxoCanvas card. */
+export function accentStripeTop(color: string): string {
+  return `linear-gradient(90deg, ${color} 0%, ${color}aa 50%, ${color}55 100%)`
+}
+
+/** Decorative accent stripe for the left edge of a UtxoCanvas card. */
+export function accentStripeLeft(color: string): string {
+  return `linear-gradient(180deg, ${color}cc 0%, ${color}55 100%)`
+}

--- a/lightningos-light/ui/vite.config.ts
+++ b/lightningos-light/ui/vite.config.ts
@@ -3,6 +3,13 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  // Dedupe d3-* so reactflow's d3-zoom and recharts' d3-transition operate on
+  // the same d3-selection instance. Without this, reactflow throws
+  // "selection.interrupt is not a function" because d3-transition monkey-patches
+  // a different selection prototype than the one d3-zoom uses.
+  resolve: {
+    dedupe: ['d3-selection', 'd3-transition', 'd3-zoom', 'd3-drag', 'd3-dispatch']
+  },
   server: {
     port: 5173,
     strictPort: true,


### PR DESCRIPTION
## Summary

- **UTXO Manager** on the on-chain page: canvas of UTXOs sized by sat amount, drag-to-group, action sheet (spend / consolidate / rename / tag / lock / CPFP bump / open channel) with fee preview, privacy warnings, and reauth.
- **Wallet Flow** new page: mempool.space-style sankey graph of every tx the wallet has touched, with lineage tracing (root + N hops back), optional electrs-backed walk past the wallet boundary, and "+N more" aggregate handles for long tails of vins/vouts.
- **Dev:** `BRLN_SKIP_WIZARD=1` env var bypasses the first-run wizard when LND is set up out-of-band (lnd-recover on testnet). Vite `d3-*` dedupe fix.

## Screenshots

**UTXO canvas — multi-select + action bar (Spend / Consolidate / Group / Lock / Open channel)**

![UTXO manager — selection and actions](https://raw.githubusercontent.com/pagcoinbr/brln-os-light/media/pr-20/utxo-manager.jpg)

**Force-layout view — one large locked UTXO surrounded by smaller outputs**

![UTXO manager — locked output + force layout](https://raw.githubusercontent.com/pagcoinbr/brln-os-light/media/pr-20/wallet-flow.jpg)

## Demo

<video src="https://raw.githubusercontent.com/pagcoinbr/brln-os-light/media/pr-20/demo.mp4" controls width="720"></video>

If the video does not embed: [download / open demo.mp4](https://raw.githubusercontent.com/pagcoinbr/brln-os-light/media/pr-20/demo.mp4)

## New endpoints (all under `/api/onchain/`)

| Method | Path | Notes |
|---|---|---|
| POST | `/utxos/metadata` | upsert label/tag/color/group_id (stored in postgres) |
| POST | `/utxos/lock`, `/utxos/unlock` | LeaseOutput / ReleaseOutput with deterministic id |
| POST | `/utxos/bump` | wraps walletkit.BumpFee for CPFP on unconfirmed outpoints |
| GET / POST / DELETE | `/utxos/groups[/{id}]` | group CRUD |
| GET | `/provenance` | `?mode=live\|ours\|all\|lineage&limit=N&root=TXID&hops=N&include_external=true` |
| GET | `/provenance/status` | last_sync, in_flight, counts |
| GET | `/provenance/health` | electrs reachability — UI hides the Wallet Flow route when false |
| POST | `/provenance/rebuild` | `?full=true` to truncate first; otherwise incremental from last_sync_height |

Existing endpoints extended (backwards compatible):
- `POST /api/wallet/send` and `/send/preview` accept `outpoints[]` + `label`
- `POST /api/lnops/channel/open` accepts `outpoints[]` (uses `OpenChannelWithOutpoints`)

## Backend

- New `internal/electrs/client.go`: minimal Electrum JSON-RPC client, address via `ELECTRUM_RPC_ADDR` env var (default `127.0.0.1:50001`).
- New `internal/lndclient/utxo_manager.go`: `SendCoinsAdvanced`, `OpenChannelWithOutpoints`, `LeaseOutput` / `ReleaseOutput` / `ListLeases` with sha256-derived lease IDs.
- New `internal/lndclient/utxo_provenance.go`: `ListAllTransactions(start, end)` thin wrapper.
- New `internal/server/utxo_manager_*.go`: postgres tables `utxo_groups`, `utxo_metadata`; auto-prune on every GET of the enriched UTXO list.
- New `internal/server/provenance_*.go`: tables `provenance_tx`, `provenance_output`, `provenance_state`; incremental refresh via `last_sync_height`; external lineage walker BFS-fetches ancestors through electrs (capped 500/req).

## Frontend

- `components/UtxoCanvas.tsx` + four dialogs (Spend / Bump / OpenChannel + privacy warnings util).
- `components/TxNode.tsx`: mempool-style tx block — input/output bars sized sqrt(sat), gradient fill, address + amount per bar, relative timestamp in header.
- `components/SankeyEdge.tsx`: custom reactflow edge — filled cubic-bezier ribbon, height = bar size, colored gradient.
- `pages/WalletFlow.tsx`: orchestrates modes (live / ours / all / lineage), refresh polling, click-node-to-trace, hide-orphans (strict in lineage mode), top-N-bars cap with aggregate "+N more" handles.

## Testing notes

- Tested on testnet3 with an LND populated via `lnd-recover` (skip-wizard path).
- Electrs endpoint pointed at a local `electrs` instance over Tailscale; UI gracefully hides Wallet Flow when `/provenance/health` reports unreachable.
- CPFP bump verified against unconfirmed deposits; lock/unlock round-trip preserves coin selection across restarts via `utxo_metadata`.
