### PR TITLE
0.5.12-Beta: add English issue forms and stabilize Electrs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Relatar um problema / Bug report
+name: Relatar um problema (Português)
 description: Informe uma falha com dados suficientes para reproduzir e diagnosticar o problema.
 title: "[Bug]: "
 labels:

--- a/.github/ISSUE_TEMPLATE/bug_report_en.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_en.yml
@@ -1,0 +1,188 @@
+name: Report a problem (English)
+description: Report a failure with enough information to reproduce and diagnose it.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve LightningOS.
+
+        Never publish wallet seeds, private keys, passwords, macaroons, cookies, tokens, or RPC credentials. For vulnerabilities or situations that may put funds at risk, use the private reporting channel shown on the previous page.
+
+  - type: dropdown
+    id: installation_origin
+    attributes:
+      label: How was the node originally installed?
+      description: This is different from the method used to update LightningOS.
+      options:
+        - install.sh (new installation managed by LightningOS)
+        - install_existing.sh (pre-existing Bitcoin/LND)
+        - I do not know
+    validations:
+      required: true
+
+  - type: dropdown
+    id: current_version_method
+    attributes:
+      label: How did the node reach its current version?
+      options:
+        - Upgrade through the web interface (UI)
+        - Upgrade through a script or terminal
+        - Fresh installation without an upgrade
+        - Other
+        - I do not know
+    validations:
+      required: true
+
+  - type: input
+    id: initial_version
+    attributes:
+      label: Originally installed version
+      description: Enter "I do not know" if this information is unavailable.
+      placeholder: "Example: 0.5.2-Beta"
+    validations:
+      required: true
+
+  - type: input
+    id: previous_version
+    attributes:
+      label: Version before the problem
+      description: Complete this field when the problem started after an upgrade.
+      placeholder: "Example: 0.5.10-Beta"
+
+  - type: input
+    id: current_version
+    attributes:
+      label: Current LightningOS version
+      placeholder: "Example: 0.5.12-Beta"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ubuntu_version
+    attributes:
+      label: Operating system
+      options:
+        - Ubuntu 24.04 LTS
+        - Ubuntu 26.04
+        - Another Ubuntu version
+        - Another operating system
+        - I do not know
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Host architecture
+      options:
+        - x86_64 / amd64
+        - ARM64 / aarch64
+        - I do not know
+    validations:
+      required: true
+
+  - type: dropdown
+    id: bitcoin_source
+    attributes:
+      label: Bitcoin Core source
+      options:
+        - App Store Bitcoin Core (Docker)
+        - Pre-existing local Bitcoin Core (systemd)
+        - Remote Bitcoin Core
+        - Bitcoin Core is not used
+        - I do not know
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lnd_origin
+    attributes:
+      label: LND origin
+      options:
+        - Installed by LightningOS
+        - Pre-existing LND (install_existing.sh)
+        - LND is not used
+        - I do not know
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_areas
+    attributes:
+      label: Affected area
+      multiple: true
+      options:
+        - Installation or upgrade
+        - Dashboard or web interface
+        - Bitcoin Core
+        - LND
+        - App Store
+        - App Store application
+        - Reports or historical data
+        - Terminal
+        - Security or privileges
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: affected_app
+    attributes:
+      label: Affected application
+      description: Complete this field when the problem involves an App Store application.
+      placeholder: "Example: Electrs, Mempool, LNDG"
+
+  - type: textarea
+    id: observed_behavior
+    attributes:
+      label: What happened?
+      description: Include the complete error message and when the problem started.
+      placeholder: Describe the observed behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: What should have happened?
+      placeholder: Describe the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Steps to reproduce
+      description: List the actions from the initial state until the error appears.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant_logs
+    attributes:
+      label: Relevant logs without secrets
+      description: Remove credentials, macaroons, cookies, tokens, wallet seeds, private keys, and personal information before pasting logs.
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or additional information
+      description: Drag images here and redact public IP addresses or other sensitive information when necessary.
+
+  - type: checkboxes
+    id: safety_confirmation
+    attributes:
+      label: Security confirmations
+      options:
+        - label: I reviewed the content and removed wallet seeds, private keys, passwords, macaroons, cookies, tokens, and RPC credentials.
+          required: true
+        - label: This report does not describe an active vulnerability or an immediate risk of loss of funds.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: Sugerir uma melhoria / Feature request
+name: Sugerir uma melhoria (Português)
 description: Proponha uma melhoria permanente para o LightningOS ou para seu processo de operação.
 title: "[Melhoria]: "
 labels:

--- a/.github/ISSUE_TEMPLATE/feature_request_en.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_en.yml
@@ -1,0 +1,92 @@
+name: Suggest an improvement (English)
+description: Propose a permanent improvement to LightningOS or its operational workflow.
+title: "[Enhancement]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for the suggestion. Describe the problem first; this helps evaluate alternatives and select the appropriate target version.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this improvement solve?
+      placeholder: Describe the current need, limitation, or difficulty.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: Explain how you expect the improvement to work.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_areas
+    attributes:
+      label: Related areas
+      multiple: true
+      options:
+        - Installation or upgrade
+        - Dashboard or web interface
+        - Bitcoin Core
+        - LND
+        - App Store
+        - App Store application
+        - Reports or historical data
+        - Terminal
+        - Security or privileges
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: installation_scope
+    attributes:
+      label: Which installations are affected?
+      options:
+        - All installations
+        - install.sh only
+        - install_existing.sh only
+        - I do not know
+    validations:
+      required: true
+
+  - type: textarea
+    id: user_impact
+    attributes:
+      label: User impact
+      description: Explain who benefits and what improves in day-to-day operation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe workarounds or different approaches that you have already evaluated.
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and risks
+      description: When applicable, consider upgrades, existing nodes, external Bitcoin/LND services, persistent data, and security.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional information
+      description: Include examples, mockups, or relevant links without sensitive information.
+
+  - type: checkboxes
+    id: safety_confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I reviewed the content and did not include wallet seeds, private keys, passwords, macaroons, cookies, tokens, or RPC credentials.
+          required: true

--- a/lightningos-light/internal/appmanifest/electrs.go
+++ b/lightningos-light/internal/appmanifest/electrs.go
@@ -19,6 +19,7 @@ const (
 	ElectrsRPCPort        = 50001
 	ElectrsMonitorPort    = 4224
 	ElectrsStopTimeout    = 60
+	ElectrsNoFileLimit    = 65536
 	ElectrsContainerUID   = 1000
 	ElectrsContainerGID   = 1000
 
@@ -156,6 +157,10 @@ func ElectrsCompose(runtime ElectrsRuntime) (string, error) {
     user: "%d:%d"
     restart: unless-stopped
     stop_grace_period: %ds
+    ulimits:
+      nofile:
+        soft: %d
+        hard: %d
     read_only: true
     init: true
     cap_drop:
@@ -193,6 +198,7 @@ networks:
     external: true
     name: %s
 %s`, ElectrsImage, ElectrsContainerUID, ElectrsContainerGID, ElectrsStopTimeout,
+		ElectrsNoFileLimit, ElectrsNoFileLimit,
 		ElectrsContainerUID, ElectrsContainerGID,
 		ElectrsRPCPort, ElectrsRPCPort, ElectrsMonitorPort, ElectrsMonitorPort,
 		dataMount, ElectrsCookieFile, network.ElectrsName,

--- a/lightningos-light/internal/appmanifest/electrs_test.go
+++ b/lightningos-light/internal/appmanifest/electrs_test.go
@@ -68,6 +68,7 @@ func TestElectrsComposeClosesPrivilegesAndBitcoinWiring(t *testing.T) {
 		for _, required := range []string{
 			"image: " + ElectrsImage,
 			"user: \"1000:1000\"",
+			"ulimits:\n      nofile:\n        soft: 65536\n        hard: 65536",
 			"read_only: true",
 			"no-new-privileges:true",
 			"127.0.0.1:50001:50001",

--- a/lightningos-light/internal/server/legacy_upgrade_transition.go
+++ b/lightningos-light/internal/server/legacy_upgrade_transition.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	legacyTransitionTargetVersion = "0.5.11-beta"
+	legacyTransitionTargetVersion = "0.5.12-beta"
 	legacyTransitionUnitName      = "lightningos-legacy-privilege-transition"
 	legacyTransitionRetryCount    = 60
 	legacyTransitionRetryDelay    = 10 * time.Second
@@ -53,7 +53,7 @@ func (s *Server) startLegacyPrivilegeTransitionReconciler() {
 				state, err = startLegacyPrivilegeTransition(ctx, s.cfg, info, embeddedAppUpgradeScript)
 				if state == legacyTransitionStarted {
 					if s.logger != nil {
-						s.logger.Printf("legacy 0.5.2 upgrade bridge to 0.5.11 started")
+						s.logger.Printf("legacy 0.5.2 upgrade bridge to %s started", legacyTransitionTargetVersion)
 					}
 				}
 				if state == legacyTransitionNotApplicable {
@@ -64,7 +64,7 @@ func (s *Server) startLegacyPrivilegeTransitionReconciler() {
 			cancel()
 
 			if err != nil && s.logger != nil && (attempt == 0 || attempt == legacyTransitionRetryCount-1) {
-				s.logger.Printf("legacy 0.5.2 upgrade bridge to 0.5.11 pending: %v", err)
+				s.logger.Printf("legacy 0.5.2 upgrade bridge to %s pending: %v", legacyTransitionTargetVersion, err)
 			}
 			if !s.waitLegacyPrivilegeTransitionRetry(attempt) {
 				return

--- a/lightningos-light/internal/server/legacy_upgrade_transition_test.go
+++ b/lightningos-light/internal/server/legacy_upgrade_transition_test.go
@@ -19,19 +19,19 @@ func TestLegacyTransitionTargetMatchesBuiltUIVersion(t *testing.T) {
 
 func TestLegacyTransitionReleaseIsLimitedToExactTargetRelease(t *testing.T) {
 	valid := appReleaseInfo{
-		Version: "0.5.11-beta",
-		Tag:     "0.5.11-Beta",
+		Version: "0.5.12-beta",
+		Tag:     "0.5.12-Beta",
 		Commit:  strings.Repeat("a", 40),
 	}
-	if err := validateLegacyTransitionRelease(valid, "0.5.11-Beta"); err != nil {
+	if err := validateLegacyTransitionRelease(valid, "0.5.12-Beta"); err != nil {
 		t.Fatal(err)
 	}
 	for _, test := range []appReleaseInfo{
 		{Version: "0.5.7-beta", Tag: "0.5.7-Beta", Commit: valid.Commit},
-		{Version: valid.Version, Tag: "release/0.5.11-beta", Commit: valid.Commit},
+		{Version: valid.Version, Tag: "release/0.5.12-beta", Commit: valid.Commit},
 		{Version: valid.Version, Tag: valid.Tag, Commit: "not-a-commit"},
 	} {
-		if err := validateLegacyTransitionRelease(test, "0.5.11-Beta"); err == nil {
+		if err := validateLegacyTransitionRelease(test, "0.5.12-Beta"); err == nil {
 			t.Fatalf("unsafe legacy transition release accepted: %#v", test)
 		}
 	}
@@ -44,8 +44,8 @@ func TestLegacyTransitionReleaseIsLimitedToExactTargetRelease(t *testing.T) {
 
 func TestLegacyTransitionRootCommandVerifiesStagedHelper(t *testing.T) {
 	info := appReleaseInfo{
-		Version: "0.5.11-beta",
-		Tag:     "0.5.11-Beta",
+		Version: "0.5.12-beta",
+		Tag:     "0.5.12-Beta",
 		Commit:  strings.Repeat("b", 40),
 	}
 	digest := strings.Repeat("c", 64)
@@ -64,7 +64,7 @@ func TestLegacyTransitionRootCommandVerifiesStagedHelper(t *testing.T) {
 		"1234:1234:700",
 		"/usr/bin/sha256sum -c -",
 		"/usr/bin/install -o root -g root -m 0755",
-		"--version 0.5.11-beta --tag 0.5.11-Beta --commit " + info.Commit,
+		"--version 0.5.12-beta --tag 0.5.12-Beta --commit " + info.Commit,
 		"trap cleanup EXIT",
 	} {
 		if !strings.Contains(command, expected) {
@@ -79,7 +79,7 @@ func TestLegacyTransitionRootCommandVerifiesStagedHelper(t *testing.T) {
 }
 
 func TestLegacyTransitionRejectsUnsafeStagingInputs(t *testing.T) {
-	info := appReleaseInfo{Version: "0.5.11-beta", Tag: "0.5.11-Beta", Commit: strings.Repeat("d", 40)}
+	info := appReleaseInfo{Version: "0.5.12-beta", Tag: "0.5.12-Beta", Commit: strings.Repeat("d", 40)}
 	for _, path := range []string{
 		"/tmp/helper.sh",
 		"/var/lib/lightningos/upgrade-staging/../helper.sh",


### PR DESCRIPTION
## Summary

- adds complete English Issue Forms for bug reports and enhancement requests while retaining the Portuguese forms;
- identifies each form clearly as `Português` or `English` in the issue chooser;
- raises the Electrs container `nofile` soft and hard limits from Docker's effective default of 1,024 to 65,536;
- updates the canonical compose test so the limit cannot regress;
- aligns the legacy 0.5.2 privilege-transition target and tests with `0.5.12-Beta`.

## Root cause

On LOS TESTE2, RocksDB exhausted the Electrs container's 1,024-file soft limit during normal indexed-database access. Electrs logged `Too many open files`, restarted three times, and caused Mempool to lose its Electrum connection. Mempool could still serve historical blocks, but `/api/v1/fees/recommended` returned HTTP 503 and the mempool fee histogram remained empty.

The host supports a substantially higher limit. Applying a container-scoped limit of 65,536 fixes the resource ceiling without adding capabilities, privileged mode, host networking, or host mounts.

## Validation

- all four Issue Form YAML files parsed successfully;
- Issue Form types, unique IDs, required dropdown options, names, and description lengths were validated;
- `go test ./internal/appmanifest ./internal/privileged` passed;
- `go test ./...` passed;
- `git diff --check` passed.

## Operational impact

Existing Electrs installations receive the new canonical compose definition when Electrs is started/reapplied. Docker recreates only the Electrs container; Bitcoin Core does not need to restart. Mempool reconnects to Electrs automatically.