### PR TITLE
0.5.12-Beta: stabilize upgrades and legacy Bitcoin migration

### DIFF
--- a/docs/03_API_SPEC.md
+++ b/docs/03_API_SPEC.md
@@ -573,6 +573,7 @@ POST /api/lnops/succession/simulate
 
 GET /api/apps
 - Returns app list with status.
+- A historical App Store Bitcoin container is returned as installed with `legacy_migration_required=true`; ordinary lifecycle controls must be replaced by the explicit safe-migration flow.
 - While a lifecycle action is active, the affected app includes `operation` with `action`, UTC `started_at`, and an optional truthful `stage` for instrumented workflows.
 - Apps that currently receive privileged direct LND access include `security_notices=["elevated_lnd_access"]`. `lndg` additionally reports `lnd_data_directory_read`. These values are informational disclosures and do not alter lifecycle behavior.
 - Public Pool firewall admission is broker-owned and fixed to its UI and Stratum ports; no executable UFW command is returned to the manager or API client.
@@ -597,14 +598,17 @@ POST /api/apps/{id}/install
 - `data_dir` is install-time only; existing blockchain data is not migrated.
 - `bitcoincore` defaults to `/data/bitcoin`; `elements` defaults to `/data/elements`.
 - Custom `bitcoincore` data directories must be on an already mounted volume and have at least 10 GiB free.
+- A detected legacy Bitcoin runtime requires `{"confirm_legacy_migration":true}`. Before cutover, the broker validates the attested official image, enrolled storage, configuration, network, ports, and a local rollback image. It accepts success only after mainnet RPC and loopback RPC/ZMQ probes pass; otherwise it automatically restores the previous runtime. The flow never restarts LND or removes the blockchain volume.
 - Installing `electrs` against Bitcoin Core managed by the App Store requires
   `{"confirm_bitcoin_restart":true}`. On a legacy `rpcauth` installation the
   manager adds a root-stored dedicated Electrs credential and may restart
   Bitcoin Core exactly once to activate it. The restart is skipped when the
   credential is already active. Native/systemd Bitcoin configurations and
   services are never modified by this migration.
+- Mempool uses a closed lightweight default of `MEMPOOL_INDEXING_BLOCKS_AMOUNT=8` to avoid saturating shared rotational storage during its initial history load. Arbitrary environment overrides remain rejected.
 
 POST /api/apps/{id}/start
+- Starting a detected legacy `bitcoincore` runtime requires `{"confirm_legacy_migration":true}` and follows the same transactional migration and rollback contract as installation.
 - Starting `electrs` against App Store Bitcoin accepts the same
   `confirm_bitcoin_restart` body and restart policy as installation.
 POST /api/apps/{id}/stop

--- a/lightningos-light/install.sh
+++ b/lightningos-light/install.sh
@@ -1462,13 +1462,26 @@ install_ui() {
   local current_stamp
   current_stamp=$(ui_build_stamp)
   build_ui
-  rm -rf /opt/lightningos/ui/*
-  cp -a "$REPO_ROOT/ui/dist/." /opt/lightningos/ui/
+  publish_ui_tree
   if [[ -n "$current_stamp" ]]; then
     echo "$current_stamp" > "$stamp_file"
     chmod 0644 "$stamp_file"
   fi
   print_ok "UI installed"
+}
+
+publish_ui_tree() {
+  local source="$REPO_ROOT/ui/dist"
+  local target="/opt/lightningos/ui"
+  [[ -d "$source" && ! -L "$source" ]] || die "UI build output is missing or unsafe"
+  [[ -d "$target" && ! -L "$target" ]] || die "UI destination is missing or unsafe"
+  [[ -z "$(find "$source" -type l -print -quit)" ]] || die "UI build output contains a symbolic link"
+  [[ -z "$(find "$source" ! -type d ! -type f -print -quit)" ]] || die "UI build output contains an unsupported file type"
+  find "$target" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+  cp -R --no-preserve=mode,ownership,timestamps -- "$source/." "$target/"
+  find "$target" -type d -exec chmod 0755 {} +
+  find "$target" -type f -exec chmod 0644 {} +
+  chown -R root:root "$target"
 }
 
 generate_tls() {

--- a/lightningos-light/install_existing.sh
+++ b/lightningos-light/install_existing.sh
@@ -730,9 +730,22 @@ build_manager() {
 build_ui() {
   print_step "Building UI"
   (cd "$REPO_ROOT/ui" && npm install && npm run build)
-  rm -rf /opt/lightningos/ui/*
-  cp -a "$REPO_ROOT/ui/dist/." /opt/lightningos/ui/
+  publish_ui_tree
   print_ok "UI built and installed"
+}
+
+publish_ui_tree() {
+  local source="$REPO_ROOT/ui/dist"
+  local target="/opt/lightningos/ui"
+  [[ -d "$source" && ! -L "$source" ]] || die "UI build output is missing or unsafe"
+  [[ -d "$target" && ! -L "$target" ]] || die "UI destination is missing or unsafe"
+  [[ -z "$(find "$source" -type l -print -quit)" ]] || die "UI build output contains a symbolic link"
+  [[ -z "$(find "$source" ! -type d ! -type f -print -quit)" ]] || die "UI build output contains an unsupported file type"
+  find "$target" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+  cp -R --no-preserve=mode,ownership,timestamps -- "$source/." "$target/"
+  find "$target" -type d -exec chmod 0755 {} +
+  find "$target" -type f -exec chmod 0644 {} +
+  chown -R root:root "$target"
 }
 
 ensure_tls() {

--- a/lightningos-light/install_existing_pi.sh
+++ b/lightningos-light/install_existing_pi.sh
@@ -713,9 +713,22 @@ build_manager() {
 build_ui() {
   print_step "Building UI"
   (cd "$REPO_ROOT/ui" && npm install && npm run build)
-  rm -rf /opt/lightningos/ui/*
-  cp -a "$REPO_ROOT/ui/dist/." /opt/lightningos/ui/
+  publish_ui_tree
   print_ok "UI built and installed"
+}
+
+publish_ui_tree() {
+  local source="$REPO_ROOT/ui/dist"
+  local target="/opt/lightningos/ui"
+  [[ -d "$source" && ! -L "$source" ]] || die "UI build output is missing or unsafe"
+  [[ -d "$target" && ! -L "$target" ]] || die "UI destination is missing or unsafe"
+  [[ -z "$(find "$source" -type l -print -quit)" ]] || die "UI build output contains a symbolic link"
+  [[ -z "$(find "$source" ! -type d ! -type f -print -quit)" ]] || die "UI build output contains an unsupported file type"
+  find "$target" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+  cp -R --no-preserve=mode,ownership,timestamps -- "$source/." "$target/"
+  find "$target" -type d -exec chmod 0755 {} +
+  find "$target" -type f -exec chmod 0644 {} +
+  chown -R root:root "$target"
 }
 
 ensure_tls() {

--- a/lightningos-light/internal/appmanifest/mempool.go
+++ b/lightningos-light/internal/appmanifest/mempool.go
@@ -21,8 +21,11 @@ const (
 	MempoolContainerGID   = 1000
 	MempoolDatabaseUID    = 999
 	MempoolDatabaseGID    = 999
-	MempoolDBVolume       = "mempool_dbdata"
-	MempoolCacheVolume    = "mempool_cache"
+	// Keep the default installation usable when Bitcoin, Electrs and Mempool
+	// share rotational storage. This remains a fixed catalog value.
+	MempoolIndexingBlocksAmount = 8
+	MempoolDBVolume             = "mempool_dbdata"
+	MempoolCacheVolume          = "mempool_cache"
 
 	MempoolRelease = "3.3.1"
 	// These are the official multi-architecture manifests for the upstream
@@ -257,6 +260,7 @@ func MempoolCompose(runtime MempoolRuntime) (string, error) {
       DATABASE_USERNAME: "mempool"
       DATABASE_PASSWORD: "${MEMPOOL_DB_PASSWORD}"
       STATISTICS_ENABLED: "true"
+      MEMPOOL_INDEXING_BLOCKS_AMOUNT: "%d"
     working_dir: /run/backend
     tmpfs:
       - /run/backend:rw,exec,nosuid,nodev,size=512m,uid=%d,gid=%d,mode=0700
@@ -318,7 +322,7 @@ networks:
 		MempoolContainerUID, MempoolContainerGID, MempoolContainerUID, MempoolContainerGID,
 		MempoolPort, MempoolFrontendPort,
 		MempoolBackendImage, MempoolContainerUID, MempoolContainerGID, MempoolStopTimeout,
-		mempoolNetwork, bitcoinHost, network.RPCPort,
+		mempoolNetwork, bitcoinHost, network.RPCPort, MempoolIndexingBlocksAmount,
 		MempoolContainerUID, MempoolContainerGID, MempoolContainerUID, MempoolContainerGID,
 		cacheMount, MempoolDatabaseImage, MempoolDatabaseUID, MempoolDatabaseGID,
 		MempoolStopTimeout, MempoolDatabaseUID, MempoolDatabaseGID, MempoolDatabaseUID, MempoolDatabaseGID,

--- a/lightningos-light/internal/appmanifest/mempool_test.go
+++ b/lightningos-light/internal/appmanifest/mempool_test.go
@@ -47,6 +47,7 @@ func TestMempoolComposeIsClosedAndHardened(t *testing.T) {
 		"/run/frontend:rw,exec,nosuid,nodev,size=512m,uid=1000,gid=1000,mode=0700",
 		"name: bitcoincore_default", "name: electrs_default", "name: mempool_dbdata", "name: mempool_cache",
 		`MARIADB_AUTO_UPGRADE: "1"`,
+		`MEMPOOL_INDEXING_BLOCKS_AMOUNT: "8"`,
 	} {
 		if !strings.Contains(compose, required) {
 			t.Fatalf("compose missing %q", required)

--- a/lightningos-light/internal/privileged/apps.go
+++ b/lightningos-light/internal/privileged/apps.go
@@ -37,14 +37,15 @@ const (
 )
 
 type ComposeAppManager struct {
-	Runner             CommandRunner
-	AppsRoot           string
-	AppsDataRoot       string
-	PrivilegedAppsRoot string
-	LNDDataRoot        string
-	LNDConfigPath      string
-	TempRoot           string
-	ElectrsRPCProbe    electrsRPCProbeFunc
+	Runner                CommandRunner
+	AppsRoot              string
+	AppsDataRoot          string
+	PrivilegedAppsRoot    string
+	LNDDataRoot           string
+	LNDConfigPath         string
+	TempRoot              string
+	ElectrsRPCProbe       electrsRPCProbeFunc
+	BitcoinMigrationProbe func(context.Context, string) error
 }
 
 type composeAppSnapshot struct {
@@ -576,6 +577,7 @@ func (manager *ComposeAppManager) Lifecycle(ctx context.Context, appID string, a
 	var snapshot composeAppSnapshot
 	var cleanup func()
 	var images []string
+	var legacyBitcoin *preparedLegacyBitcoinMigration
 	switch manifest.ID {
 	case appmanifest.CPUMinerID:
 		composeRaw, envRaw, err := manager.validatedCPUMinerFiles()
@@ -625,6 +627,13 @@ func (manager *ComposeAppManager) Lifecycle(ctx context.Context, appID string, a
 			state, err := manager.ImageStatus(ctx, appmanifest.BitcoinCoreID, appmanifest.BitcoinCoreImageNode)
 			if err != nil || state.Status != "ready" {
 				return errors.New("verified bitcoin core image is not ready")
+			}
+			legacyBitcoin, err = manager.prepareLegacyBitcoinMigration(ctx)
+			if err != nil {
+				return err
+			}
+			if legacyBitcoin != nil {
+				defer legacyBitcoin.cleanup()
 			}
 		}
 		if dryRun {
@@ -865,7 +874,28 @@ func (manager *ComposeAppManager) Lifecycle(ctx context.Context, appID string, a
 		}
 	}
 	if _, err := manager.Runner.Run(ctx, commandPath, args...); err != nil {
+		if legacyBitcoin != nil {
+			return manager.rollbackLegacyBitcoinMigration(ctx, commandPath, prefix, manifest, legacyBitcoin, errors.New("new Bitcoin Core container did not start"))
+		}
 		return errors.New("app lifecycle command failed")
+	}
+	if legacyBitcoin != nil {
+		containerID, lookupErr := manager.catalogRunningContainerID(ctx, manifest)
+		if lookupErr != nil || containerID == "" {
+			return manager.rollbackLegacyBitcoinMigration(ctx, commandPath, prefix, manifest, legacyBitcoin, errors.New("new Bitcoin Core container is unavailable"))
+		}
+		currentRuntime, found, inspectErr := manager.inspectBitcoinCoreCatalogRuntime(ctx)
+		if inspectErr != nil || !found || currentRuntime.ContainerID != containerID || currentRuntime.ImageRef != appmanifest.BitcoinCoreImage {
+			return manager.rollbackLegacyBitcoinMigration(ctx, commandPath, prefix, manifest, legacyBitcoin, errors.New("new Bitcoin Core container did not adopt the verified image"))
+		}
+		probe := manager.BitcoinMigrationProbe
+		if probe == nil {
+			probe = manager.probeMigratedBitcoinCore
+		}
+		if probeErr := probe(ctx, containerID); probeErr != nil {
+			return manager.rollbackLegacyBitcoinMigration(ctx, commandPath, prefix, manifest, legacyBitcoin, probeErr)
+		}
+		_, _ = manager.Runner.Run(ctx, dockerPath, "image", "rm", bitcoinCoreLegacyRollbackImage)
 	}
 	return nil
 }
@@ -1126,8 +1156,23 @@ func (manager *ComposeAppManager) Inspect(ctx context.Context, appID string) (Ap
 		}
 		return manager.inspectCatalogRuntime(ctx, manifest, false)
 	case appmanifest.BitcoinCoreID:
+		runtime, found, runtimeErr := manager.inspectBitcoinCoreCatalogRuntime(ctx)
+		if runtimeErr == nil && found && isLegacyBitcoinCoreImage(runtime.ImageRef) {
+			status := "stopped"
+			if runtime.Running {
+				status = "running"
+			}
+			return AppInspection{Status: status, LegacyMigrationRequired: true}, nil
+		}
 		snapshot, cleanup, err := manager.createBitcoinCoreInspectionSnapshot(ctx)
 		if err != nil {
+			if runtimeErr == nil && found && runtime.ImageRef == appmanifest.BitcoinCoreImage {
+				status := "stopped"
+				if runtime.Running {
+					status = "running"
+				}
+				return AppInspection{Status: status}, nil
+			}
 			return inspection, err
 		}
 		defer cleanup()

--- a/lightningos-light/internal/privileged/bitcoincore_legacy.go
+++ b/lightningos-light/internal/privileged/bitcoincore_legacy.go
@@ -33,6 +33,7 @@ type bitcoinCoreRuntime struct {
 
 type preparedLegacyBitcoinMigration struct {
 	runtime      bitcoinCoreRuntime
+	rollbackBase string
 	rollbackRoot string
 	composePath  string
 }
@@ -41,10 +42,15 @@ func (migration *preparedLegacyBitcoinMigration) cleanup() {
 	if migration == nil || migration.rollbackRoot == "" {
 		return
 	}
+	base := filepath.Clean(migration.rollbackBase)
 	root := filepath.Clean(migration.rollbackRoot)
-	if strings.Contains(filepath.Base(root), "bitcoincore-rollback-") {
-		_ = os.RemoveAll(root)
+	info, err := os.Lstat(root)
+	if base == "." || root == "." || filepath.Dir(root) != base ||
+		!strings.HasPrefix(filepath.Base(root), "bitcoincore-rollback-") ||
+		err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return
 	}
+	_ = os.RemoveAll(root)
 }
 
 func (manager *ComposeAppManager) prepareLegacyBitcoinMigration(ctx context.Context) (*preparedLegacyBitcoinMigration, error) {
@@ -80,11 +86,18 @@ func (manager *ComposeAppManager) prepareLegacyBitcoinMigration(ctx context.Cont
 	if rollbackRootBase == "" {
 		rollbackRootBase = os.TempDir()
 	}
+	rollbackRootBase, err = filepath.Abs(filepath.Clean(rollbackRootBase))
+	if err != nil {
+		return nil, errors.New("Bitcoin Core rollback workspace location is invalid")
+	}
 	rollbackRoot, err := os.MkdirTemp(rollbackRootBase, "bitcoincore-rollback-")
 	if err != nil {
 		return nil, errors.New("Bitcoin Core rollback workspace could not be created")
 	}
-	migration := &preparedLegacyBitcoinMigration{runtime: runtimeState, rollbackRoot: rollbackRoot, composePath: filepath.Join(rollbackRoot, "docker-compose.yaml")}
+	migration := &preparedLegacyBitcoinMigration{
+		runtime: runtimeState, rollbackBase: rollbackRootBase, rollbackRoot: rollbackRoot,
+		composePath: filepath.Join(rollbackRoot, "docker-compose.yaml"),
+	}
 	if err := os.Chmod(rollbackRoot, 0700); err != nil {
 		migration.cleanup()
 		return nil, errors.New("Bitcoin Core rollback workspace could not be secured")

--- a/lightningos-light/internal/privileged/bitcoincore_legacy.go
+++ b/lightningos-light/internal/privileged/bitcoincore_legacy.go
@@ -25,10 +25,12 @@ type bitcoinCoreRuntime struct {
 	Running     bool
 	DataDir     string
 	Network     string
-	Ports       map[string][]struct {
-		HostIP   string `json:"HostIp"`
-		HostPort string `json:"HostPort"`
-	}
+	Ports       map[string][]legacyBitcoinPortBinding
+}
+
+type legacyBitcoinPortBinding struct {
+	HostIP   string `json:"HostIp"`
+	HostPort string `json:"HostPort"`
 }
 
 type preparedLegacyBitcoinMigration struct {
@@ -115,10 +117,7 @@ func (manager *ComposeAppManager) prepareLegacyBitcoinMigration(ctx context.Cont
 	return migration, nil
 }
 
-func validatedLegacyBitcoinPortLines(bindings map[string][]struct {
-	HostIP   string `json:"HostIp"`
-	HostPort string `json:"HostPort"`
-}) ([]string, error) {
+func validatedLegacyBitcoinPortLines(bindings map[string][]legacyBitcoinPortBinding) ([]string, error) {
 	allowed := map[string]string{"8332/tcp": "8332", "8333/tcp": "8333", "28332/tcp": "28332", "28333/tcp": "28333"}
 	lines := make([]string, 0, len(bindings))
 	for containerPort, entries := range bindings {
@@ -257,11 +256,8 @@ func (manager *ComposeAppManager) inspectBitcoinCoreCatalogRuntime(ctx context.C
 			Running bool `json:"Running"`
 		} `json:"State"`
 		HostConfig struct {
-			NetworkMode  string `json:"NetworkMode"`
-			PortBindings map[string][]struct {
-				HostIP   string `json:"HostIp"`
-				HostPort string `json:"HostPort"`
-			} `json:"PortBindings"`
+			NetworkMode  string                                `json:"NetworkMode"`
+			PortBindings map[string][]legacyBitcoinPortBinding `json:"PortBindings"`
 		} `json:"HostConfig"`
 		Mounts []struct {
 			Type        string `json:"Type"`

--- a/lightningos-light/internal/privileged/bitcoincore_legacy.go
+++ b/lightningos-light/internal/privileged/bitcoincore_legacy.go
@@ -1,0 +1,296 @@
+package privileged
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"lightningos-light/internal/appmanifest"
+)
+
+const bitcoinCoreLegacyRollbackImage = "lightningos/bitcoin-core-legacy-rollback:0.5.12"
+
+type bitcoinCoreRuntime struct {
+	ContainerID string
+	ImageID     string
+	ImageRef    string
+	Running     bool
+	DataDir     string
+	Network     string
+	Ports       map[string][]struct {
+		HostIP   string `json:"HostIp"`
+		HostPort string `json:"HostPort"`
+	}
+}
+
+type preparedLegacyBitcoinMigration struct {
+	runtime      bitcoinCoreRuntime
+	rollbackRoot string
+	composePath  string
+}
+
+func (migration *preparedLegacyBitcoinMigration) cleanup() {
+	if migration == nil || migration.rollbackRoot == "" {
+		return
+	}
+	root := filepath.Clean(migration.rollbackRoot)
+	if strings.Contains(filepath.Base(root), "bitcoincore-rollback-") {
+		_ = os.RemoveAll(root)
+	}
+}
+
+func (manager *ComposeAppManager) prepareLegacyBitcoinMigration(ctx context.Context) (*preparedLegacyBitcoinMigration, error) {
+	runtimeState, found, err := manager.inspectBitcoinCoreCatalogRuntime(ctx)
+	if err != nil || !found {
+		return nil, err
+	}
+	if runtimeState.ImageRef == appmanifest.BitcoinCoreImage {
+		return nil, nil
+	}
+	if !isLegacyBitcoinCoreImage(runtimeState.ImageRef) {
+		return nil, errors.New("Bitcoin Core runtime image is not eligible for automatic migration")
+	}
+	root := manager.PrivilegedAppsRoot
+	if root == "" {
+		root = defaultPrivilegedAppsRoot
+	}
+	expectedDataDir, err := readStorageMetadata(filepath.Join(root, appmanifest.BitcoinCoreID, bitcoinCoreStorageDataDirFile))
+	if err != nil || filepath.Clean(runtimeState.DataDir) != filepath.Clean(expectedDataDir) {
+		return nil, errors.New("Bitcoin Core legacy storage does not match the enrolled volume")
+	}
+	if runtimeState.Network != appmanifest.BitcoinCoreNetwork {
+		return nil, errors.New("Bitcoin Core legacy network is not eligible for automatic migration")
+	}
+	portLines, err := validatedLegacyBitcoinPortLines(runtimeState.Ports)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := manager.Runner.Run(ctx, dockerPath, "image", "inspect", runtimeState.ImageID); err != nil {
+		return nil, errors.New("Bitcoin Core legacy image is unavailable")
+	}
+	rollbackRootBase := manager.TempRoot
+	if rollbackRootBase == "" {
+		rollbackRootBase = os.TempDir()
+	}
+	rollbackRoot, err := os.MkdirTemp(rollbackRootBase, "bitcoincore-rollback-")
+	if err != nil {
+		return nil, errors.New("Bitcoin Core rollback workspace could not be created")
+	}
+	migration := &preparedLegacyBitcoinMigration{runtime: runtimeState, rollbackRoot: rollbackRoot, composePath: filepath.Join(rollbackRoot, "docker-compose.yaml")}
+	if err := os.Chmod(rollbackRoot, 0700); err != nil {
+		migration.cleanup()
+		return nil, errors.New("Bitcoin Core rollback workspace could not be secured")
+	}
+	rollbackCompose := legacyBitcoinRollbackCompose(expectedDataDir, portLines)
+	if err := os.WriteFile(migration.composePath, []byte(rollbackCompose), 0600); err != nil {
+		migration.cleanup()
+		return nil, errors.New("Bitcoin Core rollback manifest could not be prepared")
+	}
+	output, err := manager.Runner.Run(ctx, dockerPath, "commit", "--pause=false", runtimeState.ContainerID, bitcoinCoreLegacyRollbackImage)
+	if err != nil || !dockerImageIDPattern.MatchString(strings.TrimSpace(output)) {
+		migration.cleanup()
+		return nil, errors.New("Bitcoin Core legacy rollback image could not be captured")
+	}
+	return migration, nil
+}
+
+func validatedLegacyBitcoinPortLines(bindings map[string][]struct {
+	HostIP   string `json:"HostIp"`
+	HostPort string `json:"HostPort"`
+}) ([]string, error) {
+	allowed := map[string]string{"8332/tcp": "8332", "8333/tcp": "8333", "28332/tcp": "28332", "28333/tcp": "28333"}
+	lines := make([]string, 0, len(bindings))
+	for containerPort, entries := range bindings {
+		port, ok := allowed[containerPort]
+		if !ok {
+			return nil, errors.New("Bitcoin Core legacy port topology is not eligible for automatic migration")
+		}
+		for _, entry := range entries {
+			if entry.HostPort != port {
+				return nil, errors.New("Bitcoin Core legacy port topology is not eligible for automatic migration")
+			}
+			hostIP := strings.TrimSpace(entry.HostIP)
+			switch hostIP {
+			case "", "0.0.0.0", "::", "127.0.0.1":
+			default:
+				return nil, errors.New("Bitcoin Core legacy port topology is not eligible for automatic migration")
+			}
+			binding := port + ":" + port
+			if hostIP != "" && hostIP != "0.0.0.0" {
+				binding = hostIP + ":" + binding
+			}
+			lines = append(lines, "      - \""+binding+"\"")
+		}
+	}
+	sort.Strings(lines)
+	return lines, nil
+}
+
+func legacyBitcoinRollbackCompose(dataDir string, portLines []string) string {
+	ports := ""
+	if len(portLines) > 0 {
+		ports = "\n    ports:\n" + strings.Join(portLines, "\n")
+	}
+	return fmt.Sprintf(`services:
+  bitcoind:
+    image: %s
+    restart: unless-stopped%s
+    volumes:
+      - %s:%s
+networks:
+  default:
+    external: true
+    name: %s
+`, bitcoinCoreLegacyRollbackImage, ports, dataDir, appmanifest.BitcoinCoreContainerDataDir, appmanifest.BitcoinCoreNetwork)
+}
+
+func (manager *ComposeAppManager) rollbackLegacyBitcoinMigration(ctx context.Context, commandPath string, prefix []string, manifest appmanifest.ComposeManifest, migration *preparedLegacyBitcoinMigration, cause error) error {
+	rollbackArgs := append([]string(nil), prefix...)
+	rollbackArgs = append(rollbackArgs,
+		"--project-name", manifest.Project,
+		"--project-directory", migration.rollbackRoot,
+		"-f", migration.composePath,
+		"up", "-d", "--force-recreate", "--no-deps", manifest.PrimaryService,
+	)
+	rollbackCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if _, err := manager.Runner.Run(rollbackCtx, commandPath, rollbackArgs...); err != nil {
+		return errors.New("Bitcoin Core migration failed and automatic rollback could not restore the legacy runtime; check local broker logs before taking action")
+	}
+	containerID, err := manager.catalogRunningContainerID(rollbackCtx, manifest)
+	if err != nil || containerID == "" || manager.probeBitcoinCoreMainnet(rollbackCtx, containerID) != nil {
+		return errors.New("Bitcoin Core migration failed and automatic rollback could not verify the restored legacy runtime; check local broker logs before taking action")
+	}
+	_ = cause
+	return errors.New("Bitcoin Core migration failed; the legacy runtime was restored automatically and LND was not restarted")
+}
+
+func (manager *ComposeAppManager) probeBitcoinCoreMainnet(ctx context.Context, containerID string) error {
+	output, err := manager.Runner.Run(ctx, dockerPath, "exec", "-i", containerID,
+		"bitcoin-cli", "-datadir="+appmanifest.BitcoinCoreContainerDataDir,
+		"-conf="+appmanifest.BitcoinCoreContainerConfig, "-rpcwait", "-rpcwaittimeout=60", "getblockchaininfo")
+	if err != nil || len(output) == 0 || len(output) > 64*1024 {
+		return errors.New("Bitcoin Core RPC did not become ready")
+	}
+	var state struct {
+		Chain string `json:"chain"`
+	}
+	if json.Unmarshal([]byte(output), &state) != nil || state.Chain != "main" {
+		return errors.New("Bitcoin Core RPC did not confirm mainnet")
+	}
+	return nil
+}
+
+func (manager *ComposeAppManager) probeMigratedBitcoinCore(ctx context.Context, containerID string) error {
+	if err := manager.probeBitcoinCoreMainnet(ctx, containerID); err != nil {
+		return err
+	}
+	for _, port := range []int{8332, 28332, 28333} {
+		connection, err := (&net.Dialer{Timeout: 2 * time.Second}).DialContext(ctx, "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if err != nil {
+			return errors.New("Bitcoin Core loopback RPC/ZMQ endpoints did not become ready")
+		}
+		_ = connection.Close()
+	}
+	return nil
+}
+
+func (manager *ComposeAppManager) inspectBitcoinCoreCatalogRuntime(ctx context.Context) (bitcoinCoreRuntime, bool, error) {
+	manifest, _ := appmanifest.ComposeManifestForApp(appmanifest.BitcoinCoreID)
+	output, err := manager.Runner.Run(ctx, dockerPath,
+		"ps", "-a",
+		"--filter", "label=com.docker.compose.project="+manifest.Project,
+		"--filter", "label=com.docker.compose.service="+manifest.PrimaryService,
+		"--format", "{{.ID}}",
+	)
+	if err != nil {
+		return bitcoinCoreRuntime{}, false, errors.New("Bitcoin Core runtime lookup failed")
+	}
+	containerID := ""
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parsed := parseDockerContainerID(line)
+		if parsed == "" || containerID != "" {
+			return bitcoinCoreRuntime{}, false, errors.New("Bitcoin Core runtime lookup returned invalid container IDs")
+		}
+		containerID = parsed
+	}
+	if containerID == "" {
+		return bitcoinCoreRuntime{}, false, nil
+	}
+
+	raw, err := manager.Runner.Run(ctx, dockerPath, "inspect", containerID)
+	if err != nil || len(raw) == 0 || len(raw) > 256*1024 {
+		return bitcoinCoreRuntime{}, false, errors.New("Bitcoin Core runtime inspection failed")
+	}
+	var payload []struct {
+		ID     string `json:"Id"`
+		Image  string `json:"Image"`
+		Config struct {
+			Image string `json:"Image"`
+		} `json:"Config"`
+		State struct {
+			Running bool `json:"Running"`
+		} `json:"State"`
+		HostConfig struct {
+			NetworkMode  string `json:"NetworkMode"`
+			PortBindings map[string][]struct {
+				HostIP   string `json:"HostIp"`
+				HostPort string `json:"HostPort"`
+			} `json:"PortBindings"`
+		} `json:"HostConfig"`
+		Mounts []struct {
+			Type        string `json:"Type"`
+			Source      string `json:"Source"`
+			Destination string `json:"Destination"`
+			RW          bool   `json:"RW"`
+		} `json:"Mounts"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil || len(payload) != 1 {
+		return bitcoinCoreRuntime{}, false, errors.New("Bitcoin Core runtime inspection returned invalid data")
+	}
+	item := payload[0]
+	if parseDockerContainerID(item.ID) == "" || !dockerImageIDPattern.MatchString(item.Image) {
+		return bitcoinCoreRuntime{}, false, errors.New("Bitcoin Core runtime identity is invalid")
+	}
+	runtime := bitcoinCoreRuntime{
+		ContainerID: item.ID,
+		ImageID:     item.Image,
+		ImageRef:    strings.TrimSpace(item.Config.Image),
+		Running:     item.State.Running,
+		Network:     strings.TrimSpace(item.HostConfig.NetworkMode),
+		Ports:       item.HostConfig.PortBindings,
+	}
+	for _, mount := range item.Mounts {
+		if mount.Destination == appmanifest.BitcoinCoreContainerDataDir {
+			if runtime.DataDir != "" || mount.Type != "bind" || !mount.RW {
+				return bitcoinCoreRuntime{}, false, errors.New("Bitcoin Core runtime storage is invalid")
+			}
+			runtime.DataDir = mount.Source
+		}
+	}
+	if runtime.DataDir == "" {
+		return bitcoinCoreRuntime{}, false, errors.New("Bitcoin Core runtime storage is unavailable")
+	}
+	return runtime, true, nil
+}
+
+func isLegacyBitcoinCoreImage(image string) bool {
+	switch image {
+	case "bitcoin/bitcoin:latest", bitcoinCoreLegacyRollbackImage:
+		return true
+	default:
+		return false
+	}
+}

--- a/lightningos-light/internal/privileged/bitcoincore_lifecycle_linux_test.go
+++ b/lightningos-light/internal/privileged/bitcoincore_lifecycle_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -269,7 +270,7 @@ func TestBitcoinCoreLegacyMigrationSucceedsWithoutTouchingLND(t *testing.T) {
 	}
 	for _, command := range runner.commands {
 		joined := command.path + " " + strings.Join(command.args, " ")
-		if strings.Contains(strings.ToLower(joined), "lnd") || strings.Contains(joined, "/data/lnd") {
+		if strings.Contains(joined, "/data/lnd") || (command.path == systemctlPath && slices.Contains(command.args, "lnd")) {
 			t.Fatalf("Bitcoin migration touched LND: %s", joined)
 		}
 	}
@@ -317,7 +318,7 @@ func TestBitcoinCoreLegacyMigrationFailureRollsBack(t *testing.T) {
 		if strings.Contains(joined, "bitcoincore-rollback-") && hasArgsSuffix(command.args, "up", "-d", "--force-recreate", "--no-deps", "bitcoind") {
 			rollbackSeen = true
 		}
-		if strings.Contains(strings.ToLower(joined), "lnd") {
+		if strings.Contains(joined, "/data/lnd") || (command.path == systemctlPath && slices.Contains(command.args, "lnd")) {
 			t.Fatalf("rollback touched LND: %s", joined)
 		}
 	}

--- a/lightningos-light/internal/privileged/bitcoincore_lifecycle_linux_test.go
+++ b/lightningos-light/internal/privileged/bitcoincore_lifecycle_linux_test.go
@@ -222,6 +222,118 @@ func TestBitcoinCoreLifecycleRejectsWrongStorageIdentityBeforeDocker(t *testing.
 	}
 }
 
+func TestBitcoinCoreLegacyMigrationSucceedsWithoutTouchingLND(t *testing.T) {
+	manager, runner, _, dataDir := newTestBitcoinCoreLifecycleManager(t)
+	legacyID := strings.Repeat("b", 64)
+	newID := strings.Repeat("c", 64)
+	legacyImageID := "sha256:" + strings.Repeat("d", 64)
+	runner.containerID = newID
+	baseHook := runner.hook
+	newStarted := false
+	runner.hook = func(path string, args []string) (string, error, bool) {
+		if output, err, handled := baseHook(path, args); handled {
+			return output, err, true
+		}
+		if path == dockerPath && len(args) > 1 && args[0] == "ps" && args[1] == "-a" {
+			if newStarted {
+				return newID + "\n", nil, true
+			}
+			return legacyID + "\n", nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"inspect", legacyID}) {
+			return legacyBitcoinInspectJSON(legacyID, legacyImageID, dataDir), nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"inspect", newID}) {
+			return managedBitcoinInspectJSON(newID, lifecycleTestBitcoinCoreImageID, dataDir), nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"image", "inspect", legacyImageID}) {
+			return legacyImageID, nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"commit", "--pause=false", legacyID, bitcoinCoreLegacyRollbackImage}) {
+			return "sha256:" + strings.Repeat("e", 64), nil, true
+		}
+		if hasArgsSuffix(args, "up", "-d") {
+			newStarted = true
+			return "", nil, false
+		}
+		return "", nil, false
+	}
+	manager.BitcoinMigrationProbe = func(_ context.Context, containerID string) error {
+		if containerID != newID {
+			t.Fatalf("migration probed container %q, want %q", containerID, newID)
+		}
+		return nil
+	}
+	if err := manager.Lifecycle(context.Background(), appmanifest.BitcoinCoreID, AppLifecycleStart, false); err != nil {
+		t.Fatal(err)
+	}
+	for _, command := range runner.commands {
+		joined := command.path + " " + strings.Join(command.args, " ")
+		if strings.Contains(strings.ToLower(joined), "lnd") || strings.Contains(joined, "/data/lnd") {
+			t.Fatalf("Bitcoin migration touched LND: %s", joined)
+		}
+	}
+}
+
+func TestBitcoinCoreLegacyMigrationFailureRollsBack(t *testing.T) {
+	manager, runner, _, dataDir := newTestBitcoinCoreLifecycleManager(t)
+	legacyID := strings.Repeat("b", 64)
+	legacyImageID := "sha256:" + strings.Repeat("d", 64)
+	runner.containerID = legacyID
+	baseHook := runner.hook
+	newStartFailed := false
+	runner.hook = func(path string, args []string) (string, error, bool) {
+		if output, err, handled := baseHook(path, args); handled {
+			return output, err, true
+		}
+		if path == dockerPath && len(args) > 1 && args[0] == "ps" && args[1] == "-a" {
+			return legacyID + "\n", nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"inspect", legacyID}) {
+			return legacyBitcoinInspectJSON(legacyID, legacyImageID, dataDir), nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"image", "inspect", legacyImageID}) {
+			return legacyImageID, nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"commit", "--pause=false", legacyID, bitcoinCoreLegacyRollbackImage}) {
+			return "sha256:" + strings.Repeat("e", 64), nil, true
+		}
+		if hasArgsSuffix(args, "up", "-d") && !strings.Contains(strings.Join(args, " "), "bitcoincore-rollback-") {
+			newStartFailed = true
+			return "", errors.New("simulated cutover failure"), true
+		}
+		if path == dockerPath && len(args) > 2 && args[0] == "exec" && args[2] == legacyID {
+			return `{"chain":"main"}`, nil, true
+		}
+		return "", nil, false
+	}
+	err := manager.Lifecycle(context.Background(), appmanifest.BitcoinCoreID, AppLifecycleStart, false)
+	if err == nil || !strings.Contains(err.Error(), "restored automatically") || !newStartFailed {
+		t.Fatalf("migration error/failure=%v/%v", err, newStartFailed)
+	}
+	rollbackSeen := false
+	for _, command := range runner.commands {
+		joined := strings.Join(command.args, " ")
+		if strings.Contains(joined, "bitcoincore-rollback-") && hasArgsSuffix(command.args, "up", "-d", "--force-recreate", "--no-deps", "bitcoind") {
+			rollbackSeen = true
+		}
+		if strings.Contains(strings.ToLower(joined), "lnd") {
+			t.Fatalf("rollback touched LND: %s", joined)
+		}
+	}
+	if !rollbackSeen {
+		t.Fatal("automatic rollback command was not executed")
+	}
+}
+
+func legacyBitcoinInspectJSON(containerID, imageID, dataDir string) string {
+	return fmt.Sprintf(`[{"Id":%q,"Image":%q,"Config":{"Image":"bitcoin/bitcoin:latest"},"State":{"Running":true},"HostConfig":{"NetworkMode":"bitcoincore_default","PortBindings":{}},"Mounts":[{"Type":"bind","Source":%q,"Destination":"/home/bitcoin/.bitcoin","RW":true}]}]`, containerID, imageID, dataDir)
+}
+
+func managedBitcoinInspectJSON(containerID, imageID, dataDir string) string {
+	return fmt.Sprintf(`[{"Id":%q,"Image":%q,"Config":{"Image":%q},"State":{"Running":true},"HostConfig":{"NetworkMode":"bitcoincore_default","PortBindings":{}},"Mounts":[{"Type":"bind","Source":%q,"Destination":"/home/bitcoin/.bitcoin","RW":true}]}]`, containerID, imageID, appmanifest.BitcoinCoreImage, dataDir)
+}
+
 func newTestBitcoinCoreLifecycleManager(t *testing.T) (*ComposeAppManager, *composeRecordingRunner, string, string) {
 	t.Helper()
 	if os.Geteuid() != 0 {

--- a/lightningos-light/internal/privileged/bitcoincore_lifecycle_linux_test.go
+++ b/lightningos-light/internal/privileged/bitcoincore_lifecycle_linux_test.go
@@ -316,11 +316,7 @@ func TestBitcoinCoreLegacyMigrationPreflightFailureDoesNotCutOver(t *testing.T) 
 }
 
 func TestValidatedLegacyBitcoinPortLines(t *testing.T) {
-	type binding struct {
-		HostIP   string `json:"HostIp"`
-		HostPort string `json:"HostPort"`
-	}
-	valid := map[string][]binding{
+	valid := map[string][]legacyBitcoinPortBinding{
 		"8332/tcp":  {{HostIP: "127.0.0.1", HostPort: "8332"}},
 		"8333/tcp":  {{HostIP: "0.0.0.0", HostPort: "8333"}},
 		"28332/tcp": {{HostIP: "127.0.0.1", HostPort: "28332"}},
@@ -329,7 +325,7 @@ func TestValidatedLegacyBitcoinPortLines(t *testing.T) {
 	if _, err := validatedLegacyBitcoinPortLines(valid); err != nil {
 		t.Fatalf("valid legacy port topology rejected: %v", err)
 	}
-	for name, invalid := range map[string]map[string][]binding{
+	for name, invalid := range map[string]map[string][]legacyBitcoinPortBinding{
 		"unknown container port": {"18443/tcp": {{HostPort: "18443"}}},
 		"remapped host port":     {"8332/tcp": {{HostIP: "127.0.0.1", HostPort: "18332"}}},
 		"unexpected host":        {"8332/tcp": {{HostIP: "192.0.2.10", HostPort: "8332"}}},

--- a/lightningos-light/internal/privileged/bitcoincore_lifecycle_linux_test.go
+++ b/lightningos-light/internal/privileged/bitcoincore_lifecycle_linux_test.go
@@ -276,6 +276,72 @@ func TestBitcoinCoreLegacyMigrationSucceedsWithoutTouchingLND(t *testing.T) {
 	}
 }
 
+func TestBitcoinCoreLegacyMigrationPreflightFailureDoesNotCutOver(t *testing.T) {
+	manager, runner, _, dataDir := newTestBitcoinCoreLifecycleManager(t)
+	legacyID := strings.Repeat("b", 64)
+	legacyImageID := "sha256:" + strings.Repeat("d", 64)
+	baseHook := runner.hook
+	runner.hook = func(path string, args []string) (string, error, bool) {
+		if output, err, handled := baseHook(path, args); handled {
+			return output, err, true
+		}
+		if path == dockerPath && len(args) > 1 && args[0] == "ps" && args[1] == "-a" {
+			return legacyID + "\n", nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"inspect", legacyID}) {
+			return legacyBitcoinInspectJSON(legacyID, legacyImageID, dataDir), nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"image", "inspect", legacyImageID}) {
+			return legacyImageID, nil, true
+		}
+		if path == dockerPath && reflect.DeepEqual(args, []string{"commit", "--pause=false", legacyID, bitcoinCoreLegacyRollbackImage}) {
+			return "", errors.New("simulated rollback capture failure"), true
+		}
+		return "", nil, false
+	}
+
+	err := manager.Lifecycle(context.Background(), appmanifest.BitcoinCoreID, AppLifecycleStart, false)
+	if err == nil || !strings.Contains(err.Error(), "rollback image could not be captured") {
+		t.Fatalf("unexpected migration result: %v", err)
+	}
+	for _, command := range runner.commands {
+		joined := strings.Join(command.args, " ")
+		if slices.Contains(command.args, "up") || slices.Contains(command.args, "down") || slices.Contains(command.args, "stop") || slices.Contains(command.args, "rm") {
+			t.Fatalf("preflight failure reached lifecycle cutover: %s", joined)
+		}
+		if strings.Contains(joined, "/data/lnd") || (command.path == systemctlPath && slices.Contains(command.args, "lnd")) {
+			t.Fatalf("preflight failure touched LND: %s", joined)
+		}
+	}
+}
+
+func TestValidatedLegacyBitcoinPortLines(t *testing.T) {
+	type binding struct {
+		HostIP   string `json:"HostIp"`
+		HostPort string `json:"HostPort"`
+	}
+	valid := map[string][]binding{
+		"8332/tcp":  {{HostIP: "127.0.0.1", HostPort: "8332"}},
+		"8333/tcp":  {{HostIP: "0.0.0.0", HostPort: "8333"}},
+		"28332/tcp": {{HostIP: "127.0.0.1", HostPort: "28332"}},
+		"28333/tcp": {{HostIP: "::", HostPort: "28333"}},
+	}
+	if _, err := validatedLegacyBitcoinPortLines(valid); err != nil {
+		t.Fatalf("valid legacy port topology rejected: %v", err)
+	}
+	for name, invalid := range map[string]map[string][]binding{
+		"unknown container port": {"18443/tcp": {{HostPort: "18443"}}},
+		"remapped host port":     {"8332/tcp": {{HostIP: "127.0.0.1", HostPort: "18332"}}},
+		"unexpected host":        {"8332/tcp": {{HostIP: "192.0.2.10", HostPort: "8332"}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := validatedLegacyBitcoinPortLines(invalid); err == nil {
+				t.Fatal("unsafe legacy port topology was accepted")
+			}
+		})
+	}
+}
+
 func TestBitcoinCoreLegacyMigrationFailureRollsBack(t *testing.T) {
 	manager, runner, _, dataDir := newTestBitcoinCoreLifecycleManager(t)
 	legacyID := strings.Repeat("b", 64)

--- a/lightningos-light/internal/privileged/client.go
+++ b/lightningos-light/internal/privileged/client.go
@@ -1305,28 +1305,28 @@ func (client *Client) ResetAppAdmin(ctx context.Context, appID string, dryRun bo
 	return err
 }
 
-func (client *Client) InspectApp(ctx context.Context, appID string) (string, float64, error) {
+func (client *Client) InspectApp(ctx context.Context, appID string) (string, float64, bool, error) {
 	response, err := client.call(ctx, OperationAppInspect, AppInspectParams{AppID: appID}, false)
 	if err != nil {
 		if client != nil && client.mode == ModeShadow && client.logger != nil {
 			client.logger.Printf("privileged broker shadow inspection rejected app.compose.inspect: %v", err)
 		}
-		return "", 0, err
+		return "", 0, false, err
 	}
 	var result AppInspection
 	if err := decodeStrict(response.Result, &result); err != nil {
-		return "", 0, errors.New("invalid broker app inspection response")
+		return "", 0, false, errors.New("invalid broker app inspection response")
 	}
 	if result.Status != "running" && result.Status != "stopped" {
-		return "", 0, errors.New("invalid broker app inspection status")
+		return "", 0, false, errors.New("invalid broker app inspection status")
 	}
 	if result.CPUPercentRaw < 0 {
-		return "", 0, errors.New("invalid broker app CPU percentage")
+		return "", 0, false, errors.New("invalid broker app CPU percentage")
 	}
 	if client.mode == ModeShadow && client.logger != nil {
 		client.logger.Printf("privileged broker shadow inspection accepted app.compose.inspect for %s", appID)
 	}
-	return result.Status, result.CPUPercentRaw, nil
+	return result.Status, result.CPUPercentRaw, result.LegacyMigrationRequired, nil
 }
 
 func (client *Client) AppLogs(ctx context.Context, appID string, lines int, since string) ([]string, string, error) {

--- a/lightningos-light/internal/privileged/client_test.go
+++ b/lightningos-light/internal/privileged/client_test.go
@@ -462,7 +462,7 @@ func TestClientAppFirewallRejectsInvalidState(t *testing.T) {
 func TestClientInspectAppBuildsTypedRequest(t *testing.T) {
 	transport := &fakeTransport{result: AppInspection{Status: "running", CPUPercentRaw: 123.4}}
 	client := NewClientWithTransport(ModeEnforce, time.Second, transport, nil)
-	status, cpu, err := client.InspectApp(context.Background(), "cpuminer")
+	status, cpu, _, err := client.InspectApp(context.Background(), "cpuminer")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -486,7 +486,7 @@ func TestClientInspectAppRejectsInvalidResult(t *testing.T) {
 	for _, result := range tests {
 		transport := &fakeTransport{result: result}
 		client := NewClientWithTransport(ModeEnforce, time.Second, transport, nil)
-		if _, _, err := client.InspectApp(context.Background(), "cpuminer"); err == nil {
+		if _, _, _, err := client.InspectApp(context.Background(), "cpuminer"); err == nil {
 			t.Fatalf("expected invalid result to fail: %#v", result)
 		}
 	}

--- a/lightningos-light/internal/privileged/electrs.go
+++ b/lightningos-light/internal/privileged/electrs.go
@@ -257,7 +257,10 @@ func probeElectrsBitcoinRPC(ctx context.Context, endpoint, user, password, expec
 	if chain.Pruned {
 		return errors.New("Electrs requires an unpruned Bitcoin Full Node")
 	}
-	if chain.Blocks < 0 || chain.Headers < 0 || chain.VerificationProgress < 0.999 || chain.VerificationProgress > 1 || chain.InitialBlockDownload || chain.Blocks < chain.Headers {
+	// A fully synchronized node can briefly have one more announced header than
+	// processed blocks while it validates a newly arrived block. Keep the gate
+	// closed for larger lags, IBD, or incomplete verification.
+	if chain.Blocks < 0 || chain.Headers < 0 || chain.VerificationProgress < 0.999 || chain.VerificationProgress > 1 || chain.InitialBlockDownload || chain.Headers-chain.Blocks > 1 {
 		return errors.New("Electrs requires a fully synchronized Bitcoin Full Node")
 	}
 	var indexes map[string]electrsIndexInfo

--- a/lightningos-light/internal/privileged/electrs_test.go
+++ b/lightningos-light/internal/privileged/electrs_test.go
@@ -364,6 +364,8 @@ func TestProbeElectrsBitcoinRPCFullNodeContract(t *testing.T) {
 		wantErr string
 	}{
 		{name: "ready", state: state{chain: "regtest", blocks: 101, headers: 101, tx: &electrsIndexInfo{Synced: true, BestBlockHeight: 101}}},
+		{name: "transient one block lag", state: state{chain: "regtest", blocks: 100, headers: 101, tx: &electrsIndexInfo{Synced: true, BestBlockHeight: 100}}},
+		{name: "relevant block lag", state: state{chain: "regtest", blocks: 99, headers: 101, tx: &electrsIndexInfo{Synced: true, BestBlockHeight: 99}}, wantErr: "fully synchronized Bitcoin Full Node"},
 		{name: "wrong chain", state: state{chain: "main", blocks: 101, headers: 101, tx: &electrsIndexInfo{Synced: true, BestBlockHeight: 101}}, wantErr: "chain does not match"},
 		{name: "pruned", state: state{chain: "regtest", pruned: true, blocks: 101, headers: 101, tx: &electrsIndexInfo{Synced: true, BestBlockHeight: 101}}, wantErr: "unpruned"},
 		{name: "ibd", state: state{chain: "regtest", ibd: true, blocks: 100, headers: 101, tx: &electrsIndexInfo{Synced: true, BestBlockHeight: 100}}, wantErr: "fully synchronized Bitcoin Full Node"},

--- a/lightningos-light/internal/privileged/lightningos_upgrade.go
+++ b/lightningos-light/internal/privileged/lightningos_upgrade.go
@@ -10,7 +10,7 @@ const (
 	lightningOSUpgradeHelperPath   = "/usr/local/sbin/lightningos-upgrade-app"
 	lightningOSUpgradeUnit         = "lightningos-app-upgrade"
 	lightningOSVerifyUnit          = "lightningos-app-verify"
-	lightningOSUpgradeHelperSHA256 = "facac7d626359ae249d4cefdc822a8e35245ac79c529ded405f80eb3254342f6"
+	lightningOSUpgradeHelperSHA256 = "629df9694c304c1fa25ccfea854eab0c31133576e4c4b81b2ed19499183f3edd"
 )
 
 type NativeLightningOSUpgradeManager struct {

--- a/lightningos-light/internal/privileged/protocol.go
+++ b/lightningos-light/internal/privileged/protocol.go
@@ -453,8 +453,9 @@ type PackageFeatureState struct {
 }
 
 type AppInspection struct {
-	Status        string  `json:"status"`
-	CPUPercentRaw float64 `json:"cpu_percent_raw"`
+	Status                  string  `json:"status"`
+	CPUPercentRaw           float64 `json:"cpu_percent_raw"`
+	LegacyMigrationRequired bool    `json:"legacy_migration_required,omitempty"`
 }
 
 type LoopEnsureParams struct {

--- a/lightningos-light/internal/server/apps_bitcoincore.go
+++ b/lightningos-light/internal/server/apps_bitcoincore.go
@@ -37,9 +37,12 @@ const (
 )
 
 type bitcoinCoreInstallOptions struct {
-	DataDir      string `json:"data_dir"`
-	StorageMount string `json:"storage_mount"`
+	DataDir                string `json:"data_dir"`
+	StorageMount           string `json:"storage_mount"`
+	ConfirmLegacyMigration bool   `json:"confirm_legacy_migration"`
 }
+
+var errBitcoinCoreLegacyMigrationConfirmationRequired = errors.New("Bitcoin Core legacy runtime requires an explicit safe migration confirmation")
 
 func newBitcoinCoreApp(s *Server) appHandler {
 	return bitcoinCoreApp{server: s}
@@ -62,16 +65,24 @@ func (a bitcoinCoreApp) Info(ctx context.Context) (appInfo, error) {
 	def := a.Definition()
 	info := newAppInfo(def)
 	paths := bitcoinCoreAppPaths()
-	if !fileExists(paths.ComposePath) {
-		return info, nil
+	handled, status, _, legacyMigrationRequired, err := system.InspectAppWithBroker(ctx, appmanifest.BitcoinCoreID)
+	if !handled {
+		return info, errors.New("Bitcoin Core status requires privileged broker enforce mode")
 	}
-	info.Installed = true
-	status, err := inspectBitcoinCoreStatus(ctx)
 	if err != nil {
+		if !fileExists(paths.ComposePath) {
+			return info, nil
+		}
+		info.Installed = true
 		info.Status = "unknown"
 		return info, err
 	}
+	if !fileExists(paths.ComposePath) && !legacyMigrationRequired {
+		return info, nil
+	}
+	info.Installed = true
 	info.Status = status
+	info.LegacyMigrationRequired = legacyMigrationRequired
 	return info, nil
 }
 
@@ -165,6 +176,9 @@ func (s *Server) installBitcoinCore(ctx context.Context) error {
 }
 
 func (s *Server) installBitcoinCoreWithOptions(ctx context.Context, opts bitcoinCoreInstallOptions) error {
+	if err := requireBitcoinCoreLegacyMigrationConfirmation(ctx, opts.ConfirmLegacyMigration); err != nil {
+		return err
+	}
 	requestedDataDir, dataDirRequested, err := resolveBitcoinCoreInstallDataDir(ctx, opts)
 	if err != nil {
 		return err
@@ -284,6 +298,13 @@ func (s *Server) uninstallBitcoinCore(ctx context.Context) error {
 }
 
 func (s *Server) startBitcoinCore(ctx context.Context) error {
+	return s.startBitcoinCoreWithOptions(ctx, bitcoinCoreInstallOptions{})
+}
+
+func (s *Server) startBitcoinCoreWithOptions(ctx context.Context, opts bitcoinCoreInstallOptions) error {
+	if err := requireBitcoinCoreLegacyMigrationConfirmation(ctx, opts.ConfirmLegacyMigration); err != nil {
+		return err
+	}
 	paths := bitcoinCoreAppPaths()
 	if paths.DataDir != bitcoinCoreDefaultDataDir {
 		if err := validateBitcoinCoreInstallDataDir(ctx, paths.DataDir); err != nil {
@@ -318,6 +339,23 @@ func (s *Server) startBitcoinCore(ctx context.Context) error {
 		}
 	}
 	return ensureBitcoinCoreP2PFirewall(ctx)
+}
+
+func requireBitcoinCoreLegacyMigrationConfirmation(ctx context.Context, confirmed bool) error {
+	handled, _, _, migrationRequired, err := system.InspectAppWithBroker(ctx, appmanifest.BitcoinCoreID)
+	if !handled {
+		return errors.New("Bitcoin Core migration inspection requires privileged broker enforce mode")
+	}
+	if err != nil {
+		if !fileExists(bitcoinCoreAppPaths().ComposePath) {
+			return nil
+		}
+		return fmt.Errorf("Bitcoin Core migration preflight failed: %w", err)
+	}
+	if migrationRequired && !confirmed {
+		return errBitcoinCoreLegacyMigrationConfirmationRequired
+	}
+	return nil
 }
 
 func (s *Server) stopBitcoinCore(ctx context.Context) error {
@@ -369,7 +407,7 @@ func ensureBitcoinCoreP2PFirewall(ctx context.Context) error {
 }
 
 func inspectBitcoinCoreStatus(ctx context.Context) (string, error) {
-	if handled, status, _, err := system.InspectAppWithBroker(ctx, appmanifest.BitcoinCoreID); !handled {
+	if handled, status, _, _, err := system.InspectAppWithBroker(ctx, appmanifest.BitcoinCoreID); !handled {
 		return "unknown", errors.New("Bitcoin Core status requires privileged broker enforce mode")
 	} else if err != nil {
 		return "unknown", fmt.Errorf("Bitcoin Core status failed: %w", err)

--- a/lightningos-light/internal/server/apps_bitcoincore_test.go
+++ b/lightningos-light/internal/server/apps_bitcoincore_test.go
@@ -19,6 +19,18 @@ func TestBitcoinCoreImageIsPinned(t *testing.T) {
 	}
 }
 
+func TestBitcoinCoreLegacyMigrationRequiresExplicitConfirmation(t *testing.T) {
+	client := &cpuMinerPrivilegedClient{mode: "enforce", inspectStatus: "running", inspectLegacy: true}
+	system.ConfigurePrivilegedClient(client)
+	t.Cleanup(func() { system.ConfigurePrivilegedClient(nil) })
+	if err := requireBitcoinCoreLegacyMigrationConfirmation(context.Background(), false); !errors.Is(err, errBitcoinCoreLegacyMigrationConfirmationRequired) {
+		t.Fatalf("unconfirmed migration error = %v", err)
+	}
+	if err := requireBitcoinCoreLegacyMigrationConfirmation(context.Background(), true); err != nil {
+		t.Fatalf("confirmed migration rejected: %v", err)
+	}
+}
+
 func TestDefaultBitcoinCoreConfigAllowsDedicatedConsumerNetwork(t *testing.T) {
 	raw, err := defaultBitcoinCoreConfig()
 	if err != nil {

--- a/lightningos-light/internal/server/apps_btcpay.go
+++ b/lightningos-light/internal/server/apps_btcpay.go
@@ -94,7 +94,7 @@ func (a btcpayApp) Info(ctx context.Context) (appInfo, error) {
 		return info, nil
 	}
 	info.Installed = true
-	handled, status, _, err := system.InspectAppWithBroker(ctx, btcpayAppID)
+	handled, status, _, _, err := system.InspectAppWithBroker(ctx, btcpayAppID)
 	if !handled {
 		info.Status = "unknown"
 		return info, errors.New("BTCPay status requires privileged broker enforce mode")

--- a/lightningos-light/internal/server/apps_cpuminer.go
+++ b/lightningos-light/internal/server/apps_cpuminer.go
@@ -118,7 +118,7 @@ func (a cpuMinerApp) Info(ctx context.Context) (appInfo, error) {
 		return info, nil
 	}
 	info.Installed = true
-	handled, brokerStatus, _, err := system.InspectAppWithBroker(ctx, cpuMinerAppID)
+	handled, brokerStatus, _, _, err := system.InspectAppWithBroker(ctx, cpuMinerAppID)
 	if !handled {
 		info.Status = "unknown"
 		return info, errors.New("CPU Lottery Miner status requires privileged broker enforce mode")

--- a/lightningos-light/internal/server/apps_cpuminer_status.go
+++ b/lightningos-light/internal/server/apps_cpuminer_status.go
@@ -91,7 +91,7 @@ func (s *Server) fetchCpuMinerStatus(ctx context.Context) cpuMinerStatus {
 		status.Threads = threads
 	}
 
-	handled, composeStatus, cpuPercentRaw, err := system.InspectAppWithBroker(ctx, cpuMinerAppID)
+	handled, composeStatus, cpuPercentRaw, _, err := system.InspectAppWithBroker(ctx, cpuMinerAppID)
 	if !handled {
 		return status
 	}

--- a/lightningos-light/internal/server/apps_cpuminer_test.go
+++ b/lightningos-light/internal/server/apps_cpuminer_test.go
@@ -51,6 +51,7 @@ type cpuMinerPrivilegedClient struct {
 	inspectCalls      int
 	inspectAppID      string
 	inspectStatus     string
+	inspectLegacy     bool
 	inspectErr        error
 	storageCalls      int
 	storageDataDir    string
@@ -101,14 +102,14 @@ func (client *cpuMinerPrivilegedClient) RestartService(context.Context, string, 
 	return nil
 }
 func (client *cpuMinerPrivilegedClient) EnableLogin(context.Context, bool) error { return nil }
-func (client *cpuMinerPrivilegedClient) InspectApp(_ context.Context, appID string) (string, float64, error) {
+func (client *cpuMinerPrivilegedClient) InspectApp(_ context.Context, appID string) (string, float64, bool, error) {
 	client.inspectCalls++
 	client.inspectAppID = appID
 	status := client.inspectStatus
 	if status == "" {
 		status = "stopped"
 	}
-	return status, 0, client.inspectErr
+	return status, 0, client.inspectLegacy, client.inspectErr
 }
 func (client *cpuMinerPrivilegedClient) AppLifecycle(_ context.Context, appID, action string, dryRun bool) error {
 	client.appCalls++

--- a/lightningos-light/internal/server/apps_electrs.go
+++ b/lightningos-light/internal/server/apps_electrs.go
@@ -78,7 +78,7 @@ func (a electrsApp) Info(ctx context.Context) (appInfo, error) {
 		return info, nil
 	}
 	info.Installed = true
-	handled, status, _, err := system.InspectAppWithBroker(ctx, electrsAppID)
+	handled, status, _, _, err := system.InspectAppWithBroker(ctx, electrsAppID)
 	if !handled {
 		info.Status = "unknown"
 		return info, errors.New("Electrs status requires privileged broker enforce mode")
@@ -441,7 +441,7 @@ func (s *Server) fetchElectrsStatus(ctx context.Context) electrsStatus {
 	}
 	out.Installed = true
 
-	handled, composeStatus, _, err := system.InspectAppWithBroker(ctx, electrsAppID)
+	handled, composeStatus, _, _, err := system.InspectAppWithBroker(ctx, electrsAppID)
 	if handled && err == nil && composeStatus == "running" {
 		out.Running = true
 	}

--- a/lightningos-light/internal/server/apps_fedimint.go
+++ b/lightningos-light/internal/server/apps_fedimint.go
@@ -87,7 +87,7 @@ func fedimintBrokerInfo(ctx context.Context, definition appDefinition, composePa
 	}
 	info.Installed = true
 	info.AdminPasswordPath = adminPath
-	handled, status, _, err := system.InspectAppWithBroker(ctx, definition.ID)
+	handled, status, _, _, err := system.InspectAppWithBroker(ctx, definition.ID)
 	if !handled {
 		info.Status = "unknown"
 		return info, errors.New("Fedimint status requires privileged broker enforce mode")
@@ -408,7 +408,7 @@ func waitForFedimintAppStableWithPolicy(ctx context.Context, appID string, inter
 	lastStatus := "unknown"
 	var lastErr error
 	for check := 0; check < maxChecks; check++ {
-		handled, status, _, err := system.InspectAppWithBroker(ctx, appID)
+		handled, status, _, _, err := system.InspectAppWithBroker(ctx, appID)
 		if !handled {
 			return errors.New("Fedimint startup status requires privileged broker enforce mode")
 		}

--- a/lightningos-light/internal/server/apps_full_index.go
+++ b/lightningos-light/internal/server/apps_full_index.go
@@ -102,7 +102,7 @@ func managedBitcoinFullIndexStatusAvailability(status bitcoinLocalStatus, rawCon
 		Blocks: status.Blocks, Headers: status.Headers, VerificationProgress: status.VerificationProgress,
 		InitialBlockDownload: status.InitialBlockDownload,
 	}
-	if bitcoinInfoStillSyncing(info) {
+	if fullIndexBitcoinStillSyncing(info) {
 		return fullIndexUnavailable(fullIndexUnavailableBitcoinSync, "Electrs and Mempool require Bitcoin Core to be fully synced.")
 	}
 	if !parseBitcoinCoreBool(rawConfig, "txindex") {
@@ -131,7 +131,7 @@ func fullIndexBitcoinConfigAvailabilityWithFallbackHint(ctx context.Context, cfg
 	if info.Pruned {
 		return fullIndexUnavailable(fullIndexUnavailableUnpruned, "Electrs and Mempool require a non-pruned Bitcoin Core node. Disable pruning before installing."), false
 	}
-	if bitcoinInfoStillSyncing(info) {
+	if fullIndexBitcoinStillSyncing(info) {
 		return fullIndexUnavailable(fullIndexUnavailableBitcoinSync, "Electrs and Mempool require Bitcoin Core to be fully synced."), false
 	}
 	txIndexReady, txIndexKnown, err := bitcoinRPCConfigTxIndexReady(ctx, cfg)
@@ -140,6 +140,13 @@ func fullIndexBitcoinConfigAvailabilityWithFallbackHint(ctx context.Context, cfg
 	}
 
 	return fullIndexAppAvailability{Available: true}, false
+}
+
+func fullIndexBitcoinStillSyncing(info bitcoinInfo) bool {
+	if info.InitialBlockDownload || info.VerificationProgress < 0.9999 {
+		return true
+	}
+	return info.Headers > 0 && info.Headers-info.Blocks > 1
 }
 
 func fullIndexUnavailable(reason, message string) fullIndexAppAvailability {

--- a/lightningos-light/internal/server/apps_full_index_test.go
+++ b/lightningos-light/internal/server/apps_full_index_test.go
@@ -104,6 +104,11 @@ func TestManagedBitcoinFullIndexStatusAvailability(t *testing.T) {
 	if availability := managedBitcoinFullIndexStatusAvailability(ready, "server=1\ntxindex=1\n"); !availability.Available {
 		t.Fatalf("ready managed Bitcoin rejected: %#v", availability)
 	}
+	oneBlockLag := ready
+	oneBlockLag.Blocks = 899
+	if availability := managedBitcoinFullIndexStatusAvailability(oneBlockLag, "server=1\ntxindex=1\n"); !availability.Available {
+		t.Fatalf("transient one-block lag rejected: %#v", availability)
+	}
 
 	for _, test := range []struct {
 		name   string
@@ -113,7 +118,7 @@ func TestManagedBitcoinFullIndexStatusAvailability(t *testing.T) {
 	}{
 		{name: "RPC unavailable", status: bitcoinLocalStatus{Installed: true, Source: "app"}, config: "txindex=1\n", reason: fullIndexUnavailableBitcoinRPC},
 		{name: "pruned", status: func() bitcoinLocalStatus { value := ready; value.Pruned = true; return value }(), config: "txindex=1\n", reason: fullIndexUnavailableUnpruned},
-		{name: "syncing", status: func() bitcoinLocalStatus { value := ready; value.Blocks = 899; return value }(), config: "txindex=1\n", reason: fullIndexUnavailableBitcoinSync},
+		{name: "syncing", status: func() bitcoinLocalStatus { value := ready; value.Blocks = 898; return value }(), config: "txindex=1\n", reason: fullIndexUnavailableBitcoinSync},
 		{name: "txindex missing", status: ready, config: "server=1\n", reason: fullIndexUnavailableTxIndex},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/lightningos-light/internal/server/apps_handlers.go
+++ b/lightningos-light/internal/server/apps_handlers.go
@@ -310,6 +310,10 @@ func (s *Server) handleAppInstall(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if err := s.installBitcoinCoreWithOptions(r.Context(), req); err != nil {
+			if errors.Is(err, errBitcoinCoreLegacyMigrationConfirmationRequired) {
+				writeErrorCode(w, http.StatusConflict, "bitcoin_legacy_migration_confirmation_required", err.Error())
+				return
+			}
 			writeAppOperationError(w, http.StatusInternalServerError, err)
 			return
 		}
@@ -493,6 +497,26 @@ func (s *Server) handleAppStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer finishOperation()
+	if appID == bitcoinCoreAppID {
+		var req bitcoinCoreInstallOptions
+		if r.ContentLength != 0 {
+			if err := readJSON(r, &req); err != nil && !errors.Is(err, io.EOF) {
+				writeError(w, http.StatusBadRequest, "invalid json")
+				return
+			}
+		}
+		if err := s.startBitcoinCoreWithOptions(r.Context(), req); err != nil {
+			if errors.Is(err, errBitcoinCoreLegacyMigrationConfirmationRequired) {
+				writeErrorCode(w, http.StatusConflict, "bitcoin_legacy_migration_confirmation_required", err.Error())
+				return
+			}
+			writeAppOperationError(w, http.StatusInternalServerError, err)
+			return
+		}
+		s.invalidateBitcoinStatusCaches()
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		return
+	}
 	if appID == electrsAppID {
 		var req electrsInstallOptions
 		if r.ContentLength != 0 {

--- a/lightningos-light/internal/server/apps_lnbits.go
+++ b/lightningos-light/internal/server/apps_lnbits.go
@@ -59,7 +59,7 @@ func (a lnbitsApp) Info(ctx context.Context) (appInfo, error) {
 		return info, nil
 	}
 	info.Installed = true
-	handled, status, _, err := system.InspectAppWithBroker(ctx, appmanifest.LNbitsID)
+	handled, status, _, _, err := system.InspectAppWithBroker(ctx, appmanifest.LNbitsID)
 	if !handled {
 		info.Status = "unknown"
 		return info, errors.New("LNbits status requires privileged broker enforce mode")

--- a/lightningos-light/internal/server/apps_lndg.go
+++ b/lightningos-light/internal/server/apps_lndg.go
@@ -70,7 +70,7 @@ func (a lndgApp) Info(ctx context.Context) (appInfo, error) {
 	}
 	info.Installed = true
 	info.AdminPasswordPath = paths.AdminPasswordPath
-	handled, status, _, err := system.InspectAppWithBroker(ctx, appmanifest.LNDgID)
+	handled, status, _, _, err := system.InspectAppWithBroker(ctx, appmanifest.LNDgID)
 	if !handled {
 		info.Status = "unknown"
 		return info, errors.New("LNDg status requires privileged broker enforce mode")

--- a/lightningos-light/internal/server/apps_mempool.go
+++ b/lightningos-light/internal/server/apps_mempool.go
@@ -47,7 +47,7 @@ func (a mempoolApp) Info(ctx context.Context) (appInfo, error) {
 		return info, nil
 	}
 	info.Installed = true
-	handled, status, _, err := system.InspectAppWithBroker(ctx, mempoolAppID)
+	handled, status, _, _, err := system.InspectAppWithBroker(ctx, mempoolAppID)
 	if !handled {
 		info.Status = "unknown"
 		return info, errors.New("Mempool status requires privileged broker enforce mode")

--- a/lightningos-light/internal/server/apps_robosats.go
+++ b/lightningos-light/internal/server/apps_robosats.go
@@ -63,7 +63,7 @@ func (a robosatsApp) Info(ctx context.Context) (appInfo, error) {
 		return info, nil
 	}
 	info.Installed = true
-	handled, brokerStatus, _, err := system.InspectAppWithBroker(ctx, appmanifest.RoboSatsID)
+	handled, brokerStatus, _, _, err := system.InspectAppWithBroker(ctx, appmanifest.RoboSatsID)
 	if !handled {
 		info.Status = "unknown"
 		return info, errors.New("RoboSats status requires privileged broker enforce mode")

--- a/lightningos-light/internal/server/apps_types.go
+++ b/lightningos-light/internal/server/apps_types.go
@@ -27,22 +27,23 @@ type appDefinition struct {
 }
 
 type appInfo struct {
-	ID                 string            `json:"id"`
-	Name               string            `json:"name"`
-	Description        string            `json:"description"`
-	Installed          bool              `json:"installed"`
-	Status             string            `json:"status"`
-	Port               int               `json:"port"`
-	Scheme             string            `json:"scheme,omitempty"`
-	ExternalURL        string            `json:"external_url,omitempty"`
-	AdminPasswordPath  string            `json:"admin_password_path,omitempty"`
-	Available          bool              `json:"available"`
-	UnavailableReason  string            `json:"unavailable_reason,omitempty"`
-	UnavailableMessage string            `json:"unavailable_message,omitempty"`
-	UFWActive          bool              `json:"ufw_active,omitempty"`
-	UFWCommand         string            `json:"ufw_command,omitempty"`
-	SecurityNotices    []string          `json:"security_notices,omitempty"`
-	Operation          *appOperationInfo `json:"operation,omitempty"`
+	ID                      string            `json:"id"`
+	Name                    string            `json:"name"`
+	Description             string            `json:"description"`
+	Installed               bool              `json:"installed"`
+	Status                  string            `json:"status"`
+	Port                    int               `json:"port"`
+	Scheme                  string            `json:"scheme,omitempty"`
+	ExternalURL             string            `json:"external_url,omitempty"`
+	AdminPasswordPath       string            `json:"admin_password_path,omitempty"`
+	Available               bool              `json:"available"`
+	UnavailableReason       string            `json:"unavailable_reason,omitempty"`
+	UnavailableMessage      string            `json:"unavailable_message,omitempty"`
+	UFWActive               bool              `json:"ufw_active,omitempty"`
+	UFWCommand              string            `json:"ufw_command,omitempty"`
+	SecurityNotices         []string          `json:"security_notices,omitempty"`
+	Operation               *appOperationInfo `json:"operation,omitempty"`
+	LegacyMigrationRequired bool              `json:"legacy_migration_required,omitempty"`
 }
 
 type appOperationInfo struct {

--- a/lightningos-light/internal/server/assets/upgrade-app.sh
+++ b/lightningos-light/internal/server/assets/upgrade-app.sh
@@ -259,6 +259,9 @@ NPM_BIN="$(resolve_bin npm /usr/bin/npm /usr/local/bin/npm /bin/npm)" || die "Re
 SYSTEMCTL_BIN="$(resolve_bin systemctl /usr/bin/systemctl /bin/systemctl)" || die "Required command missing: systemctl"
 INSTALL_BIN="$(resolve_bin install /usr/bin/install /bin/install)" || die "Required command missing: install"
 CP_BIN="$(resolve_bin cp /usr/bin/cp /bin/cp)" || die "Required command missing: cp"
+FIND_BIN="$(resolve_bin find /usr/bin/find /bin/find)" || die "Required command missing: find"
+CHMOD_BIN="$(resolve_bin chmod /usr/bin/chmod /bin/chmod)" || die "Required command missing: chmod"
+CHOWN_BIN="$(resolve_bin chown /usr/bin/chown /bin/chown)" || die "Required command missing: chown"
 MV_BIN="$(resolve_bin mv /usr/bin/mv /bin/mv)" || die "Required command missing: mv"
 FLOCK_BIN="$(resolve_bin flock /usr/bin/flock /bin/flock)" || die "Required command missing: flock"
 DATE_BIN="$(resolve_bin date /usr/bin/date /bin/date)" || die "Required command missing: date"
@@ -1057,13 +1060,26 @@ print_step "Building UI"
 (cd "$project_dir/ui" && "$NPM_BIN" ci && "$NPM_BIN" run build)
 print_ok "UI built"
 
+publish_ui_tree() {
+  local source="$project_dir/ui/dist"
+  local target="/opt/lightningos/ui"
+  [[ -d "$source" && ! -L "$source" ]] || die "UI build output is missing or unsafe."
+  [[ -d "$target" && ! -L "$target" ]] || die "UI destination is missing or unsafe."
+  [[ -z "$($FIND_BIN "$source" -type l -print -quit)" ]] || die "UI build output contains a symbolic link."
+  [[ -z "$($FIND_BIN "$source" ! -type d ! -type f -print -quit)" ]] || die "UI build output contains an unsupported file type."
+  "$FIND_BIN" "$target" -mindepth 1 -maxdepth 1 -exec "$RM_BIN" -rf -- {} +
+  "$CP_BIN" -R --no-preserve=mode,ownership,timestamps -- "$source/." "$target/"
+  "$FIND_BIN" "$target" -type d -exec "$CHMOD_BIN" 0755 {} +
+  "$FIND_BIN" "$target" -type f -exec "$CHMOD_BIN" 0644 {} +
+  "$CHOWN_BIN" -R root:root "$target"
+}
+
 print_step "Preparing reversible privilege cutover"
 prepare_privilege_cutover
 cutover_prepared=1
 
 print_step "Installing UI"
-"$RM_BIN" -rf /opt/lightningos/ui/*
-"$CP_BIN" -a "$project_dir/ui/dist/." /opt/lightningos/ui/
+publish_ui_tree
 print_ok "UI installed"
 
 print_step "Ensuring fixed native application identities"

--- a/lightningos-light/internal/server/installer_scripts_test.go
+++ b/lightningos-light/internal/server/installer_scripts_test.go
@@ -798,7 +798,7 @@ func TestAppUpgradeStagesReversiblePrivilegeCutoverBeforeRestart(t *testing.T) {
 
 	stage := strings.LastIndex(content, "if ! stage_privilege_cutover; then")
 	prepare := strings.LastIndex(content, "prepare_privilege_cutover\n")
-	uiInstall := strings.LastIndex(content, `"$CP_BIN" -a "$project_dir/ui/dist/." /opt/lightningos/ui/`)
+	uiInstall := strings.LastIndex(content, "\npublish_ui_tree\n")
 	restart := strings.LastIndex(content, `if "$SYSTEMCTL_BIN" restart lightningos-manager; then`)
 	if prepare < 0 || uiInstall < 0 || prepare > uiInstall {
 		t.Fatal("rollback state must be prepared before the manager UI is replaced")
@@ -825,6 +825,62 @@ func TestAppUpgradeRecognizesDocumentedLegacyDockerSudoers(t *testing.T) {
 	}
 	if !strings.Contains(content, `((saw_broker == 0)) || return 1`) || strings.Contains(content, `saw_broker == 1 && saw_lnd_upgrade`) {
 		t.Fatal("legacy sudoers must accept zero or one known broker command, never duplicates")
+	}
+}
+
+func TestInstallersPublishUIWithExplicitSafeModes(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "..", "install.sh"),
+		filepath.Join("..", "..", "install_existing.sh"),
+		filepath.Join("..", "..", "install_existing_pi.sh"),
+		filepath.Join("assets", "upgrade-app.sh"),
+	}
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		content := strings.ReplaceAll(string(raw), "\r\n", "\n")
+		for _, required := range []string{
+			"publish_ui_tree", "! -L", "! -type d ! -type f", "--no-preserve=mode,ownership,timestamps",
+			"-type d", "0755", "-type f", "0644", "root:root",
+		} {
+			if !strings.Contains(content, required) {
+				t.Fatalf("%s UI publication is missing %q", path, required)
+			}
+		}
+		if strings.Contains(content, `cp -a "$REPO_ROOT/ui/dist/." /opt/lightningos/ui/`) ||
+			strings.Contains(content, `"$CP_BIN" -a "$project_dir/ui/dist/." /opt/lightningos/ui/`) {
+			t.Fatalf("%s still preserves arbitrary UI artifact modes", path)
+		}
+	}
+}
+
+func TestDashboardPersistsOnlyNonSensitiveUpgradeResumeMarker(t *testing.T) {
+	path := filepath.Join("..", "..", "ui", "src", "components", "dashboard", "DashboardScreen.tsx")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(raw)
+	for _, required := range []string{
+		"lightningos.app-upgrade.pending.v1", "target_version", "started_at",
+		"window.localStorage.setItem", "window.localStorage.removeItem", "setAppUpgradeModalOpen(true)",
+	} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("upgrade resume marker is missing %q", required)
+		}
+	}
+	markerStart := strings.Index(content, "type AppUpgradeMarker")
+	markerEnd := strings.Index(content[markerStart:], "export default function")
+	if markerStart < 0 || markerEnd < 0 {
+		t.Fatal("upgrade marker boundary is unavailable")
+	}
+	markerCode := strings.ToLower(content[markerStart : markerStart+markerEnd])
+	for _, forbidden := range []string{"password", "cookie", "csrf", "token"} {
+		if strings.Contains(markerCode, forbidden) {
+			t.Fatalf("upgrade resume marker contains sensitive field %q", forbidden)
+		}
 	}
 }
 

--- a/lightningos-light/internal/system/privileged_service_test.go
+++ b/lightningos-light/internal/system/privileged_service_test.go
@@ -317,10 +317,10 @@ func (client *fakePrivilegedServiceClient) SnapshotApp(_ context.Context, appID 
 	return client.snapshotErr
 }
 
-func (client *fakePrivilegedServiceClient) InspectApp(_ context.Context, appID string) (string, float64, error) {
+func (client *fakePrivilegedServiceClient) InspectApp(_ context.Context, appID string) (string, float64, bool, error) {
 	client.inspectCalls++
 	client.inspectAppID = appID
-	return client.inspectStatus, client.inspectCPU, client.inspectErr
+	return client.inspectStatus, client.inspectCPU, false, client.inspectErr
 }
 
 func (client *fakePrivilegedServiceClient) RemoveApp(_ context.Context, appID string, dryRun bool) error {
@@ -899,7 +899,7 @@ func TestInspectAppWithBrokerModes(t *testing.T) {
 			client := &fakePrivilegedServiceClient{mode: test.mode, inspectStatus: "running", inspectCPU: 99.5, inspectErr: test.inspectErr}
 			ConfigurePrivilegedClient(client)
 			t.Cleanup(func() { ConfigurePrivilegedClient(nil) })
-			handled, status, cpu, err := InspectAppWithBroker(context.Background(), "cpuminer")
+			handled, status, cpu, _, err := InspectAppWithBroker(context.Background(), "cpuminer")
 			if handled != test.wantHandled || (err != nil) != test.wantError {
 				t.Fatalf("handled/error = %v/%v", handled, err)
 			}

--- a/lightningos-light/internal/system/system.go
+++ b/lightningos-light/internal/system/system.go
@@ -24,7 +24,7 @@ type PrivilegedClient interface {
 	RestartService(ctx context.Context, unit string, noBlock bool, dryRun bool) error
 	EnableLogin(ctx context.Context, dryRun bool) error
 	AppLifecycle(ctx context.Context, appID string, action string, dryRun bool) error
-	InspectApp(ctx context.Context, appID string) (status string, cpuPercentRaw float64, err error)
+	InspectApp(ctx context.Context, appID string) (status string, cpuPercentRaw float64, legacyMigrationRequired bool, err error)
 	RemoveApp(ctx context.Context, appID string, dryRun bool) error
 	EnsureDockerRuntime(ctx context.Context, dryRun bool) (status string, err error)
 	DockerRuntimeStatus(ctx context.Context) (status string, err error)
@@ -1685,24 +1685,24 @@ func EnsureAppStorageWithBroker(ctx context.Context) (bool, error) {
 	}
 }
 
-func InspectAppWithBroker(ctx context.Context, appID string) (handled bool, status string, cpuPercentRaw float64, err error) {
+func InspectAppWithBroker(ctx context.Context, appID string) (handled bool, status string, cpuPercentRaw float64, legacyMigrationRequired bool, err error) {
 	privilegedState.RLock()
 	client := privilegedState.client
 	privilegedState.RUnlock()
 	if client == nil {
-		return false, "", 0, nil
+		return false, "", 0, false, nil
 	}
 	switch client.Mode() {
 	case "enforce":
-		status, cpuPercentRaw, err := client.InspectApp(ctx, appID)
-		return true, status, cpuPercentRaw, err
+		status, cpuPercentRaw, legacyMigrationRequired, err := client.InspectApp(ctx, appID)
+		return true, status, cpuPercentRaw, legacyMigrationRequired, err
 	case "shadow":
 		shadowCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
-		_, _, _ = client.InspectApp(shadowCtx, appID)
-		return false, "", 0, nil
+		_, _, _, _ = client.InspectApp(shadowCtx, appID)
+		return false, "", 0, false, nil
 	default:
-		return false, "", 0, nil
+		return false, "", 0, false, nil
 	}
 }
 

--- a/lightningos-light/ui/src/api.ts
+++ b/lightningos-light/ui/src/api.ts
@@ -1163,6 +1163,7 @@ export type AppStoreInfo = {
   ufw_command?: string
   security_notices?: string[]
   operation?: AppOperationInfo
+  legacy_migration_required?: boolean
 }
 
 export const getApps = (): Promise<AppStoreInfo[]> => request('/api/apps')
@@ -1754,11 +1755,11 @@ export const updateMagmaSettings = (payload: {
   request('/api/apps/magma-sales/settings', { method: 'POST', body: JSON.stringify(payload) })
 
 export const getAppAdminPassword = (id: string) => request(`/api/apps/${id}/admin-password`)
-export const installApp = (id: string, payload?: { data_dir?: string; storage_mount?: string; elements_mode?: 'local' | 'remote'; elements_rpc_url?: string; elements_rpc_user?: string; elements_rpc_password?: string; confirm_bitcoin_restart?: boolean }) =>
+export const installApp = (id: string, payload?: { data_dir?: string; storage_mount?: string; elements_mode?: 'local' | 'remote'; elements_rpc_url?: string; elements_rpc_user?: string; elements_rpc_password?: string; confirm_bitcoin_restart?: boolean; confirm_legacy_migration?: boolean }) =>
   request(`/api/apps/${id}/install`, { method: 'POST', body: JSON.stringify(payload ?? {}) })
 export const uninstallApp = (id: string) =>
   request(`/api/apps/${id}/uninstall`, { method: 'POST', body: JSON.stringify({ confirm: true, app_id: id }) })
-export const startApp = (id: string, payload?: { confirm_bitcoin_restart?: boolean }) =>
+export const startApp = (id: string, payload?: { confirm_bitcoin_restart?: boolean; confirm_legacy_migration?: boolean }) =>
   request(`/api/apps/${id}/start`, { method: 'POST', body: JSON.stringify(payload ?? {}) })
 export const stopApp = (id: string) => request(`/api/apps/${id}/stop`, { method: 'POST' })
 export const resetAppAdmin = (id: string) => request(`/api/apps/${id}/reset-admin`, { method: 'POST' })

--- a/lightningos-light/ui/src/components/dashboard/DashboardScreen.tsx
+++ b/lightningos-light/ui/src/components/dashboard/DashboardScreen.tsx
@@ -97,6 +97,40 @@ const LND_RESTART_POLL_INTERVAL_MS = 5000
 const LND_RESTART_TIMEOUT_MS = 2 * 60 * 60 * 1000
 const MARKET_REFRESH_INTERVAL_MS = 5 * 60 * 1000
 const BIP110_REFRESH_INTERVAL_MS = 2 * 60 * 1000
+const APP_UPGRADE_MARKER_KEY = 'lightningos.app-upgrade.pending.v1'
+const APP_UPGRADE_MARKER_MAX_AGE_MS = 48 * 60 * 60 * 1000
+
+type AppUpgradeMarker = {
+  target_version: string
+  started_at: string
+}
+
+const readAppUpgradeMarker = (): AppUpgradeMarker | null => {
+  try {
+    const raw = window.localStorage.getItem(APP_UPGRADE_MARKER_KEY)
+    if (!raw) return null
+    const marker = JSON.parse(raw) as Partial<AppUpgradeMarker>
+    const startedAt = typeof marker.started_at === 'string' ? Date.parse(marker.started_at) : Number.NaN
+    const targetVersion = typeof marker.target_version === 'string' ? marker.target_version.trim() : ''
+    const age = Date.now() - startedAt
+    if (!targetVersion || targetVersion.length > 64 || !Number.isFinite(startedAt) || age < -60000 || age > APP_UPGRADE_MARKER_MAX_AGE_MS) {
+      window.localStorage.removeItem(APP_UPGRADE_MARKER_KEY)
+      return null
+    }
+    return { target_version: targetVersion, started_at: new Date(startedAt).toISOString() }
+  } catch {
+    try { window.localStorage.removeItem(APP_UPGRADE_MARKER_KEY) } catch { /* storage unavailable */ }
+    return null
+  }
+}
+
+const writeAppUpgradeMarker = (marker: AppUpgradeMarker) => {
+  try { window.localStorage.setItem(APP_UPGRADE_MARKER_KEY, JSON.stringify(marker)) } catch { /* storage unavailable */ }
+}
+
+const clearAppUpgradeMarker = () => {
+  try { window.localStorage.removeItem(APP_UPGRADE_MARKER_KEY) } catch { /* storage unavailable */ }
+}
 
 type MarketTapeProps = {
   market: BitcoinMarketStatus | null
@@ -732,12 +766,14 @@ export default function DashboardScreen({ authState }: DashboardScreenProps) {
 
   const closeAppUpgradeModal = () => {
     if (appUpgradeBusy || (appUpgradeLocked && !appUpgradeError && !appUpgradeComplete)) return
+    if (appUpgradeError || appUpgradeComplete) clearAppUpgradeMarker()
     setAppUpgradeModalOpen(false)
   }
 
   const startAppUpgradeFlow = async () => {
     if (!appUpgrade?.latest_version || appUpgradeBusy) return
     const sinceNow = new Date(Date.now() - 15000).toISOString()
+    writeAppUpgradeMarker({ target_version: appUpgrade.latest_version, started_at: new Date().toISOString() })
     setAppUpgradeStartedVersion(appUpgrade.latest_version)
     setAppUpgradeLogSince(sinceNow)
     setAppUpgradeBusy(true)
@@ -759,6 +795,17 @@ export default function DashboardScreen({ authState }: DashboardScreenProps) {
       loadAppUpgradeStatus(true, true)
     }
   }
+
+  useEffect(() => {
+    const marker = readAppUpgradeMarker()
+    if (!marker) return
+    setAppUpgradeStartedVersion(marker.target_version)
+    setAppUpgradeLogSince(new Date(Date.parse(marker.started_at) - 15000).toISOString())
+    setAppUpgradeModalOpen(true)
+    setAppUpgradeLocked(true)
+    setAppUpgradeComplete(false)
+    setAppUpgradeError(null)
+  }, [])
 
   useEffect(() => {
     if (!lndRestartModalOpen || !lndRestartStartedAt) return
@@ -1330,7 +1377,7 @@ export default function DashboardScreen({ authState }: DashboardScreenProps) {
           >
             <h4 id="app-upgrade-title" className="text-lg font-semibold">{t('appUpgrade.confirmTitle')}</h4>
             <p className="mt-2 text-sm text-fog/70">
-              {t('appUpgrade.confirmBody', { version: formatVersion(appUpgrade?.latest_version) })}
+              {t('appUpgrade.confirmBody', { version: formatVersion(appUpgradeStartedVersion || appUpgrade?.latest_version) })}
             </p>
             <p className="mt-3 text-xs text-rose-200">{t('appUpgrade.confirmWarning')}</p>
             {appUpgradeMessage && <p className="mt-3 text-sm text-brass">{appUpgradeMessage}</p>}

--- a/lightningos-light/ui/src/i18n/en.json
+++ b/lightningos-light/ui/src/i18n/en.json
@@ -1204,6 +1204,12 @@
     }
   },
   "appStore": {
+    "bitcoinLegacyMigrationTitle": "Legacy Bitcoin Core migration required",
+    "bitcoinLegacyMigrationCard": "This node still uses the historical Store image. Ordinary start and stop controls are disabled until the verified image is adopted safely.",
+    "bitcoinLegacyMigrationAction": "Migrate safely",
+    "bitcoinLegacyMigrationBody": "LightningOS will validate the official image, storage, configuration, network and rollback path before replacing the legacy container.",
+    "bitcoinLegacyMigrationImpact": "Bitcoin Core will have a brief controlled restart. LND will not be restarted and the blockchain volume will not be removed. If the new RPC does not become ready on mainnet, the previous runtime is restored automatically.",
+    "bitcoinLegacyMigrationConfirm": "Confirm safe migration",
     "actionFailed": "Action failed.",
     "adminPasswordCopied": "Admin password copied.",
     "adminPasswordSavedAt": "Admin password saved at {{path}}",

--- a/lightningos-light/ui/src/i18n/pt-BR.json
+++ b/lightningos-light/ui/src/i18n/pt-BR.json
@@ -1204,6 +1204,12 @@
     }
   },
   "appStore": {
+    "bitcoinLegacyMigrationTitle": "Migração do Bitcoin Core legado necessária",
+    "bitcoinLegacyMigrationCard": "Este node ainda usa a imagem histórica da Loja. Os controles comuns de início e parada ficam desabilitados até a adoção segura da imagem verificada.",
+    "bitcoinLegacyMigrationAction": "Migrar com segurança",
+    "bitcoinLegacyMigrationBody": "O LightningOS validará a imagem oficial, armazenamento, configuração, rede e caminho de rollback antes de substituir o contêiner legado.",
+    "bitcoinLegacyMigrationImpact": "O Bitcoin Core terá um reinício breve e controlado. O LND não será reiniciado e o volume da blockchain não será removido. Se o novo RPC não ficar pronto em mainnet, o runtime anterior será restaurado automaticamente.",
+    "bitcoinLegacyMigrationConfirm": "Confirmar migração segura",
     "actionFailed": "Falha na ação.",
     "adminPasswordCopied": "Senha admin copiada.",
     "adminPasswordSavedAt": "Senha admin salva em {{path}}",

--- a/lightningos-light/ui/src/pages/AppStore.tsx
+++ b/lightningos-light/ui/src/pages/AppStore.tsx
@@ -54,6 +54,7 @@ type InstallPayload = {
   elements_rpc_user?: string
   elements_rpc_password?: string
   confirm_bitcoin_restart?: boolean
+  confirm_legacy_migration?: boolean
 }
 
 type PendingElevatedInstall = {
@@ -186,6 +187,7 @@ export default function AppStore() {
   const [pendingElevatedInstall, setPendingElevatedInstall] = useState<PendingElevatedInstall | null>(null)
   const [elevatedInstallAcknowledged, setElevatedInstallAcknowledged] = useState(false)
   const [pendingUninstall, setPendingUninstall] = useState<AppInfo | null>(null)
+  const [bitcoinLegacyMigrationOpen, setBitcoinLegacyMigrationOpen] = useState(false)
   const [installFilter, setInstallFilter] = useState<InstallFilter>(() => {
     if (typeof window === 'undefined') return 'all'
     const stored = window.localStorage.getItem(APP_STORE_INSTALL_FILTER_KEY)
@@ -572,6 +574,11 @@ export default function AppStore() {
     await handleAction('bitcoincore', 'install', payload)
   }
 
+  const handleBitcoinLegacyMigrationConfirm = async () => {
+    setBitcoinLegacyMigrationOpen(false)
+    await handleAction('bitcoincore', 'start', { confirm_legacy_migration: true })
+  }
+
   const handleUninstallConfirm = async () => {
     const app = pendingUninstall
     setPendingUninstall(null)
@@ -921,6 +928,13 @@ export default function AppStore() {
                 </div>
               )}
 
+              {app.legacy_migration_required && (
+                <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100/85">
+                  <p className="font-semibold">{t('appStore.bitcoinLegacyMigrationTitle')}</p>
+                  <p className="mt-1 text-xs leading-relaxed">{t('appStore.bitcoinLegacyMigrationCard')}</p>
+                </div>
+              )}
+
               {hasDirectLndAccess && (
                 <div className={`rounded-lg px-4 py-3 text-sm ${hasElevatedLndAccess ? 'border border-amber-400/25 bg-amber-500/10' : 'border border-cyan-400/25 bg-cyan-500/10'}`}>
                   <div className="flex items-start gap-3">
@@ -1050,7 +1064,12 @@ export default function AppStore() {
                     {isBusy ? t('appStore.installing') : t('appStore.install')}
                   </button>
                 )}
-                {app.installed && app.status === 'running' && (
+                {app.legacy_migration_required && (
+                  <button className="btn-primary" disabled={isBusy} onClick={() => setBitcoinLegacyMigrationOpen(true)}>
+                    {t('appStore.bitcoinLegacyMigrationAction')}
+                  </button>
+                )}
+                {app.installed && app.status === 'running' && !app.legacy_migration_required && (
                   <>
                     {internalRoute && (
                       <a className="btn-primary" href={`#${internalRoute}`}>
@@ -1090,7 +1109,7 @@ export default function AppStore() {
                     </button>
                   </>
                 )}
-                {app.installed && app.status !== 'running' && (
+                {app.installed && app.status !== 'running' && !app.legacy_migration_required && (
                   <>
                     <button className="btn-primary" disabled={isBusy || unavailable} title={unavailable ? unavailableMessage : undefined} onClick={() => handleAction(app.id, 'start')}>
                       {isBusy ? t('appStore.starting') : t('common.start')}
@@ -1145,6 +1164,22 @@ export default function AppStore() {
               <button className="btn-secondary text-rose-200" type="button" onClick={() => void handleUninstallConfirm()}>
                 {t('appStore.uninstallConfirmAction', { app: pendingUninstall.name })}
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {bitcoinLegacyMigrationOpen && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 px-4" role="dialog" aria-modal="true" aria-labelledby="bitcoin-legacy-migration-title">
+          <div className="w-full max-w-lg rounded-lg border border-amber-400/30 bg-ink p-5 shadow-2xl">
+            <h3 id="bitcoin-legacy-migration-title" className="text-lg font-semibold">{t('appStore.bitcoinLegacyMigrationTitle')}</h3>
+            <p className="mt-3 text-sm leading-relaxed text-fog/75">{t('appStore.bitcoinLegacyMigrationBody')}</p>
+            <div className="mt-4 rounded-lg border border-amber-400/20 bg-amber-500/5 p-4 text-sm leading-relaxed text-amber-100/85">
+              {t('appStore.bitcoinLegacyMigrationImpact')}
+            </div>
+            <div className="mt-6 flex flex-wrap justify-end gap-3">
+              <button className="btn-secondary" type="button" onClick={() => setBitcoinLegacyMigrationOpen(false)}>{t('common.cancel')}</button>
+              <button className="btn-primary" type="button" onClick={() => void handleBitcoinLegacyMigrationConfirm()}>{t('appStore.bitcoinLegacyMigrationConfirm')}</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What changed

- makes migration of the historical App Store Bitcoin Core runtime transactional, with explicit confirmation, full preflight, verified official image cutover, mainnet/RPC/loopback checks, and automatic rollback without restarting LND or changing blockchain storage;
- keeps legacy Bitcoin Core visible in the App Store before migration instead of reporting an unknown/not-installed state;
- repairs deterministic UI publication permissions during install and in-app upgrades;
- resumes the upgrade modal and logs after the Manager restarts;
- tolerates the safe one-block Bitcoin header lag for Electrs/Mempool readiness while continuing to reject IBD, pruning, incomplete verification, larger lag, or unavailable txindex;
- reduces the default initial Mempool indexing window to 8 blocks as a safe first slice of #65.

## Why

These changes remove the highest-impact 0.5.12 upgrade and legacy Bitcoin failure paths, particularly the case where an older Store Bitcoin container could be stopped before the hardened replacement was proven healthy.

## Validation

- `go test ./...` on Windows;
- production UI build with `npm run build`;
- complete `go test ./...` on Ubuntu Linux in LOS TEST2;
- focused Linux success, pre-cutover failure, post-cutover rollback, port-topology, and no-LND-action migration tests;
- preliminary 0.5.12 upgrade on LOS TEST2 while preserving the Bitcoin container identity and LND activation;
- live LOS TEST2 health check with Bitcoin mainnet fully synced/unpruned, LND and Manager active, broker socket active, and Electrs/Mempool intentionally stopped.

Closes #55
Closes #56
Closes #61
Closes #62

Partial progress on #65; the full selectable profile/progress experience remains open.