### PR TITLE
0.5.18-Beta: Magma - recusar explicitamente quando o accept falha em série

### DIFF
--- a/lightningos-light/internal/server/magma_accept_failure_test.go
+++ b/lightningos-light/internal/server/magma_accept_failure_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// Order 1ad98d50 was created 2026-08-20 21:19:33 and answered every 95 seconds
+// for two hours: roughly 75 identical attempts, each refused by Amboss with
+// "Unable to find a route to this destination". The node had 504M sat of inbound
+// across 93 public channels at the time and the previous order of the same shape
+// had been accepted 36 hours earlier, so the blocker was not ours to clear.
+// Amboss recorded SELLER_FAILED_TO_REACT at 23:21.
+//
+// The approval deadline already existed, but only on the policy branch - it
+// judged whether an order was worth taking, never whether taking it kept
+// failing. So a decision to accept that could not be carried out retried
+// forever, which is the one outcome that loses the sale AND the seller record.
+func TestMagmaFailedAcceptRefusesOnceTheWindowIsSpent(t *testing.T) {
+	// The first attempts, minutes in: the failure may well be transient.
+	if v := classifyMagmaAcceptFailure(1*time.Minute, true); v != magmaAcceptRetry {
+		t.Fatalf("a fresh failure must be retried, got %v", v)
+	}
+	if v := classifyMagmaAcceptFailure(magmaApprovalGrace-time.Second, true); v != magmaAcceptRetry {
+		t.Fatalf("one second before the grace period must still retry, got %v", v)
+	}
+
+	// Past the grace period the retry is no longer a retry: it is waiting for the
+	// window to shut. The sale is gone either way, so refuse and keep the record.
+	if v := classifyMagmaAcceptFailure(magmaApprovalGrace, true); v != magmaAcceptRefuse {
+		t.Fatalf("at the grace period the order must be refused explicitly, got %v", v)
+	}
+	if v := classifyMagmaAcceptFailure(2*time.Hour, true); v != magmaAcceptRefuse {
+		t.Fatalf("well past the window the order must still be refused, got %v", v)
+	}
+}
+
+// An unknown creation time gives PendingFor == 0. Refusing then would be
+// refusing on a guessed age, so the order keeps its chances.
+func TestMagmaFailedAcceptWithUnknownAgeKeepsRetrying(t *testing.T) {
+	if v := classifyMagmaAcceptFailure(0, true); v != magmaAcceptRetry {
+		t.Fatalf("an order of unknown age must not be refused, got %v", v)
+	}
+}
+
+// Auto-rejection off is the operator's call, but it is not free. The order is
+// left to lapse and the coming seller failure is stated rather than filed as a
+// routine retry - being invisible until too late is what made 1ad98d50 hurt.
+func TestMagmaFailedAcceptWithAutoRejectOffOnlyWarns(t *testing.T) {
+	if v := classifyMagmaAcceptFailure(magmaApprovalGrace+time.Minute, false); v != magmaAcceptWarnOnly {
+		t.Fatalf("with auto-reject off the deadline must warn, not reject, got %v", v)
+	}
+	if v := classifyMagmaAcceptFailure(time.Minute, false); v != magmaAcceptRetry {
+		t.Fatalf("before the deadline there is nothing to warn about yet, got %v", v)
+	}
+}
+
+// The remaining-window figure goes into an operator-facing message, so a pass
+// that runs after the window closed must not announce negative minutes.
+func TestMagmaWindowRemainingFloorsAtZero(t *testing.T) {
+	if got := magmaWindowRemaining(magmaApprovalWindow + time.Hour); got != 0 {
+		t.Fatalf("expected 0 once the window has closed, got %s", got)
+	}
+	if got := magmaWindowRemaining(magmaApprovalWindow); got != 0 {
+		t.Fatalf("expected 0 exactly at the window, got %s", got)
+	}
+	if got := magmaWindowRemaining(magmaApprovalGrace); got != magmaApprovalWindow-magmaApprovalGrace {
+		t.Fatalf("expected the real remainder inside the window, got %s", got)
+	}
+}

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -814,8 +814,8 @@ func (s *MagmaService) reconcileExecution(ctx context.Context, token string) {
 	rows, err := s.db.Query(ctx, `
 select order_id, local_state, funding_txid, channel_point, buyer_pubkey, size_sat
 from magma_orders
-where local_state in ($1,$2,$3)
-`, magmaStateOpening, magmaStateOpenBroadcast, magmaStateConfirming)
+where local_state in ($1,$2,$3,$4)
+`, magmaStateOpening, magmaStateOpenBroadcast, magmaStateConfirming, magmaStateAccepting)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Printf("magma: reconcile query failed: %v", err)
@@ -843,6 +843,33 @@ where local_state in ($1,$2,$3)
 
 	for _, row := range pendingRows {
 		switch row.state {
+		// `accepting` is written before the invoice goes to Amboss, so an order
+		// stranded there was interrupted mid-accept - by a restart, or by a context
+		// that expired before failOrder could put the state back. Nothing else
+		// reads that state, and autoEvaluatePending only queries `observed`, so
+		// without this the order silently leaves the automation for good.
+		case magmaStateAccepting:
+			// Whether the accept landed is Amboss's to answer, never ours to guess:
+			// resetting a successful accept would re-invoice an order that is already
+			// waiting to be funded.
+			live, err := s.liveOrder(ctx, token, row.orderID)
+			if err != nil {
+				continue
+			}
+			switch live.Status {
+			case "WAITING_FOR_SELLER_APPROVAL":
+				// Amboss never got it. Back to observed so the loop can retry, and
+				// so the approval deadline can refuse it if time runs out.
+				_ = s.setLocalState(ctx, row.orderID, magmaStateObserved, "")
+				s.appendEvent(ctx, row.orderID, "recovered", "info",
+					"accept was interrupted and Amboss never received it; back in the queue", nil)
+			case "WAITING_FOR_CHANNEL_OPEN":
+				// It landed after all. Adopt the real state instead of re-accepting.
+				_ = s.setLocalState(ctx, row.orderID, magmaStateAccepted, "")
+				s.appendEvent(ctx, row.orderID, "recovered", "info",
+					"accept had in fact reached Amboss; waiting for the buyer to pay", nil)
+			}
+
 		case magmaStateConfirming:
 			if row.channelPoint == "" {
 				continue

--- a/lightningos-light/internal/server/magma_policy.go
+++ b/lightningos-light/internal/server/magma_policy.go
@@ -69,6 +69,16 @@ const (
 	magmaApprovalGrace  = 80 * time.Minute
 )
 
+// magmaWindowRemaining is how long Amboss is still expected to wait. It floors at
+// zero because a pass running after the window already closed would otherwise
+// announce a negative number of minutes left.
+func magmaWindowRemaining(pendingFor time.Duration) time.Duration {
+	if remaining := magmaApprovalWindow - pendingFor; remaining > 0 {
+		return remaining
+	}
+	return 0
+}
+
 // magmaDecision is the outcome of evaluating one order.
 type magmaDecision struct {
 	Accept bool
@@ -108,7 +118,7 @@ func evaluateMagmaOrder(policy MagmaPolicy, in magmaPolicyInputs) magmaDecision 
 	if !decision.Accept && !decision.Reject && in.PendingFor >= magmaApprovalGrace {
 		return magmaDecision{Reject: true, Reason: fmt.Sprintf(
 			"%s - refusing explicitly, the approval window closes in about %d minutes",
-			decision.Reason, int((magmaApprovalWindow-in.PendingFor)/time.Minute))}
+			decision.Reason, int(magmaWindowRemaining(in.PendingFor)/time.Minute))}
 	}
 	return decision
 }
@@ -410,6 +420,13 @@ order by coalesce(order_created_at, first_seen_at) asc
 			if _, err := s.acceptOrderLocked(ctx, orderID); err != nil {
 				s.appendEvent(ctx, orderID, "auto_error", "warning",
 					fmt.Sprintf("auto accept failed: %v", err), nil)
+				// Retrying is right while there is time: an invoice can be refused
+				// for reasons that pass, on Amboss's side as often as ours. Past the
+				// grace period it stops being a retry and becomes waiting for the
+				// window to shut. The sale is lost either way by then, so take the
+				// one outcome still available - silence costs the same sale AND a
+				// SELLER_FAILED_TO_REACT that stays on the account.
+				s.rejectAfterFailedAccept(ctx, order, inputs.PendingFor, policy, err)
 				return
 			}
 			s.appendEvent(ctx, orderID, "auto_accepted", "info",
@@ -483,6 +500,67 @@ where o.magma_status = 'WAITING_FOR_SELLER_APPROVAL'
 
 // recordDeferral logs a wait only when the reason changed. A 90s poll would
 // otherwise write the same "waiting for funds" line forever.
+// magmaAcceptFailureVerdict is what a failed accept means right now. The
+// judgement is separated from the acting so it can be tested without a node, a
+// database or Amboss - the same reason evaluateMagmaOrder is a pure function.
+type magmaAcceptFailureVerdict int
+
+const (
+	// Keep trying: there is still time for the blocker to clear.
+	magmaAcceptRetry magmaAcceptFailureVerdict = iota
+	// Out of time and auto-rejection is on: refuse explicitly.
+	magmaAcceptRefuse
+	// Out of time but the operator turned auto-rejection off. Nothing to do but
+	// say clearly that a seller failure is now coming.
+	magmaAcceptWarnOnly
+)
+
+// classifyMagmaAcceptFailure decides between retrying and refusing. A zero
+// pendingFor means the order's age is unknown, and that always retries: refusing
+// on a guessed age would burn a sale that had only just arrived.
+func classifyMagmaAcceptFailure(pendingFor time.Duration, autoReject bool) magmaAcceptFailureVerdict {
+	if pendingFor < magmaApprovalGrace {
+		return magmaAcceptRetry
+	}
+	if !autoReject {
+		return magmaAcceptWarnOnly
+	}
+	return magmaAcceptRefuse
+}
+
+// rejectAfterFailedAccept turns a run of failed accepts into an explicit refusal
+// once the approval window is nearly spent. It does nothing while there is still
+// time to succeed, and nothing when the order's age is unknown - refusing on a
+// guessed age would burn a sale that had only just arrived.
+func (s *MagmaService) rejectAfterFailedAccept(
+	ctx context.Context, order MagmaOrder, pendingFor time.Duration,
+	policy MagmaPolicy, cause error,
+) {
+	verdict := classifyMagmaAcceptFailure(pendingFor, policy.AutoRejectDeclined)
+	if verdict == magmaAcceptRetry {
+		return
+	}
+	reason := fmt.Sprintf(
+		"accepting keeps failing (%v) and the approval window closes in about %d minutes",
+		cause, int(magmaWindowRemaining(pendingFor)/time.Minute))
+	if verdict == magmaAcceptWarnOnly {
+		// Auto-rejection is off, so the order is left to lapse. Say plainly that a
+		// failure record is coming instead of filing it as a routine retry, which
+		// is what kept the last one invisible until it was too late.
+		s.recordDeferral(ctx, order.ID, reason+
+			", but auto-reject is off, so Amboss will record a seller failure")
+		return
+	}
+	if _, err := s.rejectOrderLocked(ctx, order.ID); err != nil {
+		s.appendEvent(ctx, order.ID, "auto_error", "warning",
+			fmt.Sprintf("auto reject after a failed accept also failed: %v", err), nil)
+		return
+	}
+	s.appendEvent(ctx, order.ID, "auto_rejected", "info", "auto mode rejected: "+reason, nil)
+	s.notifyTelegram(ctx, order, fmt.Sprintf(
+		"Order %s rejected automatically: %s", order.ID, reason))
+}
+
 func (s *MagmaService) recordDeferral(ctx context.Context, orderID, reason string) {
 	var lastReason string
 	if err := s.db.QueryRow(ctx,


### PR DESCRIPTION
## O incidente

A ordem `1ad98d50` (1.000.000 sats de inbound, receita de 2.652 sats) foi criada em 20/08 às 21:19:33 e terminou às 23:20:10 com `SELLER_FAILED_TO_REACT`.

O app **não** falhou em vê-la nem em decidir. Ele aceitou, e tentou executar o accept a cada ~95 segundos por duas horas — cerca de 75 tentativas idênticas, todas recusadas pela Amboss com *"Unable to find a route to this destination. Please reach out to support."*

O bloqueio não era nosso:

- o nó tinha **504.165.979 sats de inbound** em 93 canais públicos ativos (bfx-lnd0, ACINQ, LQWD entre eles), zero canais privados — rotear 2.652 sats é trivial;
- a ordem anterior de mesmo formato, `79712ee8` (1M sats, 2.284 sats de receita), foi aceita e paga em **um único ciclo de poll** 36 horas antes, via BitGo Routing Node.

## A falha que era nossa

A trava de prazo construída para a ordem `a8c8bea8` vive em `evaluateMagmaOrder`, que julga os **termos** da ordem e converte adiamento de política em recusa explícita passados 80 minutos.

Aqui a política disse **aceitar**. Quem falhou foi a execução, e esse ramo não consultava prazo nenhum:

```go
case decision.Accept:
    if _, err := s.acceptOrderLocked(ctx, orderID); err != nil {
        s.appendEvent(ctx, orderID, "auto_error", "warning", ...)
        return   // tenta de novo no próximo poll, indefinidamente
    }
```

Setenta e cinco tentativas idênticas já tinham provado que não ia funcionar. Uma recusa explícita em qualquer momento antes das 23:19 teria custado a mesma venda **sem** o registro de falha na conta.

## O que muda

**1. Accept em falha passa a respeitar o mesmo prazo da política.** Passado `magmaApprovalGrace`, um accept que insiste em falhar vira recusa explícita. Com `auto_reject_declined` desligado, ao menos diz que a falha de vendedor está vindo, em vez de arquivar como mais uma tentativa de rotina — ser invisível até tarde demais foi o que doeu.

A decisão saiu para `classifyMagmaAcceptFailure`, função pura, testável sem nó/banco/API — mesma razão de `evaluateMagmaOrder` ser pura. `PendingFor == 0` (idade desconhecida) **sempre** tenta de novo: recusar por idade chutada queimaria uma venda recém-chegada.

**2. Resgate de ordens presas em `accepting`.** Achado durante a investigação; não foi a causa deste incidente, mas é bug real. O estado é gravado antes da fatura ir para a Amboss e nada nunca o lia de volta, enquanto `autoEvaluatePending` só consulta `observed` — um accept interrompido por restart, ou por contexto expirado antes do `failOrder` reverter, tirava a ordem da automação para sempre. O `reconcileExecution` cobria `opening`, `open_broadcast` e `confirming`; `accepting` era o único estado comprometido sem volta.

A recuperação **pergunta à Amboss** em vez de adivinhar: se lá ainda está `WAITING_FOR_SELLER_APPROVAL`, volta para `observed`; se já está `WAITING_FOR_CHANNEL_OPEN`, adota `accepted`. Resetar um accept bem-sucedido re-emitiria fatura para uma ordem já esperando financiamento.

**3.** `magmaWindowRemaining` com piso em zero — a mensagem ao operador não anuncia mais minutos negativos quando a passada roda depois da janela fechada.

## Testes

`internal/server/magma_accept_failure_test.go`, ancorados no incidente: retry antes do prazo (inclusive 1s antes), recusa a partir dele, idade desconhecida nunca recusa, auto-reject desligado só avisa, e piso da janela.

`go test ./...` e `go vet ./internal/server/` verdes.

## Observação

O gatilho continua sendo da Amboss e não há correção nossa para isso. Esta PR não recupera a venda perdida — reduz o custo do próximo episódio de duas perdas (venda + reputação) para uma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)