### PR TITLE
0.5.19-Beta: Magma - registrar (não exigir) conexão com o comprador antes do accept

### DIFF
--- a/lightningos-light/internal/server/magma_buyer_reach_test.go
+++ b/lightningos-light/internal/server/magma_buyer_reach_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"lightningos-light/internal/lndclient"
+)
+
+// magmaReachLND is the smallest fake that satisfies magmaLND. Only the peer
+// calls carry behaviour; the rest exist so the interface is satisfied.
+type magmaReachLND struct {
+	peers    []lndclient.PeerInfo
+	dialErrs map[string]error
+	dialed   []string
+}
+
+func (f *magmaReachLND) ListPeers(context.Context) ([]lndclient.PeerInfo, error) {
+	return f.peers, nil
+}
+
+func (f *magmaReachLND) ConnectPeerWithTimeout(
+	_ context.Context, _ string, host string, _ bool, _ uint64,
+) error {
+	f.dialed = append(f.dialed, host)
+	if err, ok := f.dialErrs[host]; ok {
+		return err
+	}
+	return nil
+}
+
+func (f *magmaReachLND) CreateInvoice(context.Context, int64, string, int64, *lndclient.CreateInvoiceOptions) (lndclient.CreatedInvoice, error) {
+	return lndclient.CreatedInvoice{}, errors.New("not used")
+}
+func (f *magmaReachLND) GetBalances(context.Context) (lndclient.BalanceSummary, error) {
+	return lndclient.BalanceSummary{}, nil
+}
+func (f *magmaReachLND) GetNodeDetails(context.Context, string) (lndclient.NodeDetails, error) {
+	return lndclient.NodeDetails{}, nil
+}
+func (f *magmaReachLND) OpenChannelWithOutpoints(context.Context, lndclient.OpenChannelParams) (string, error) {
+	return "", errors.New("not used")
+}
+func (f *magmaReachLND) PreviewOpenChannel(context.Context, int64, int64, int64) (lndclient.OpenChannelPreview, error) {
+	return lndclient.OpenChannelPreview{}, nil
+}
+func (f *magmaReachLND) ListPendingChannels(context.Context) ([]lndclient.PendingChannelInfo, error) {
+	return nil, nil
+}
+func (f *magmaReachLND) ListChannels(context.Context) ([]lndclient.ChannelInfo, error) {
+	return nil, nil
+}
+
+// A buyer we are already connected to is reached. ConnectPeer errors for a peer
+// that is already there, so reading that error as unreachable would refuse every
+// buyer we are already talking to - the worst possible way for this gate to fail.
+func TestMagmaBuyerAlreadyConnectedCountsAsReached(t *testing.T) {
+	const buyer = "033035870d69d43fae1c8019d1f31358768e0b67fed2f68ce7f2cdcf603c891488"
+	lnd := &magmaReachLND{peers: []lndclient.PeerInfo{{PubKey: strings.ToUpper(buyer)}}}
+	s := &MagmaService{lnd: lnd}
+
+	if err := s.reachBuyer(context.Background(), "token", buyer); err != nil {
+		t.Fatalf("an already-connected buyer must count as reached, got %v", err)
+	}
+	if len(lnd.dialed) != 0 {
+		t.Fatalf("no dial should be needed, got %v", lnd.dialed)
+	}
+}
+
+// A node can advertise both Tor and clearnet with only one of them working, so
+// one failed dial settles nothing: every address gets tried.
+func TestMagmaBuyerDialTriesEveryAddress(t *testing.T) {
+	tor := "abc.onion:9735"
+	clear := "1.2.3.4:9735"
+	lnd := &magmaReachLND{dialErrs: map[string]error{tor: errors.New("dial timeout")}}
+	s := &MagmaService{lnd: lnd}
+
+	if err := s.dialBuyer(context.Background(), "pub", []string{tor, clear}, 5*time.Second); err != nil {
+		t.Fatalf("clearnet worked, so the buyer is reachable: %v", err)
+	}
+	if len(lnd.dialed) != 2 || lnd.dialed[0] != tor || lnd.dialed[1] != clear {
+		t.Fatalf("expected Tor then clearnet, got %v", lnd.dialed)
+	}
+}
+
+// Tor dials fail spuriously and a node can be seconds from coming back, so the
+// whole address set is retried until the budget is spent rather than concluding
+// from a single pass.
+func TestMagmaBuyerDialRetriesUntilBudgetSpent(t *testing.T) {
+	addr := "abc.onion:9735"
+	lnd := &magmaReachLND{dialErrs: map[string]error{addr: errors.New("dial timeout")}}
+	s := &MagmaService{lnd: lnd}
+
+	err := s.dialBuyer(context.Background(), "pub", []string{addr}, 150*time.Millisecond)
+	if err == nil {
+		t.Fatal("every dial failed, so the buyer must be reported unreachable")
+	}
+	if len(lnd.dialed) < 2 {
+		t.Fatalf("one failed dial must not settle it, got %d attempt(s)", len(lnd.dialed))
+	}
+	if !strings.Contains(err.Error(), "attempt(s)") {
+		t.Fatalf("the error should say how hard we tried, got %q", err)
+	}
+}

--- a/lightningos-light/internal/server/magma_buyer_reach_test.go
+++ b/lightningos-light/internal/server/magma_buyer_reach_test.go
@@ -105,3 +105,25 @@ func TestMagmaBuyerDialRetriesUntilBudgetSpent(t *testing.T) {
 		t.Fatalf("the error should say how hard we tried, got %q", err)
 	}
 }
+
+
+// The check informs, it does not decide. Order 109a4760 was bought by a node we
+// could not see connected, the accept was refused 75 times with a routing error,
+// and the buyer paid in full and took the channel. Reachability turned out not to
+// predict fulfilment, so a failed check must never be able to refuse an order -
+// only to record what it saw.
+func TestMagmaBuyerReachabilityIsAdvisoryNotAGate(t *testing.T) {
+	if magmaReachBudget > 30*time.Second {
+		t.Fatalf("an advisory check must not spend a poll cycle, budget is %s", magmaReachBudget)
+	}
+	addr := "abc.onion:9735"
+	lnd := &magmaReachLND{dialErrs: map[string]error{addr: errors.New("dial timeout")}}
+	s := &MagmaService{lnd: lnd}
+
+	// The unreachable result is reported, and reporting is all it may do: the
+	// caller records an event and carries on to build the invoice.
+	err := s.dialBuyer(context.Background(), "pub", []string{addr}, 120*time.Millisecond)
+	if err == nil {
+		t.Fatal("an unreachable buyer must still be reported so it can be recorded")
+	}
+}

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -54,6 +54,7 @@ type magmaLND interface {
 	PreviewOpenChannel(ctx context.Context, localFundingSat int64, pushSat int64, satPerVbyte int64) (lndclient.OpenChannelPreview, error)
 	ListPendingChannels(ctx context.Context) ([]lndclient.PendingChannelInfo, error)
 	ListChannels(ctx context.Context) ([]lndclient.ChannelInfo, error)
+	ListPeers(ctx context.Context) ([]lndclient.PeerInfo, error)
 }
 
 // magmaOnchainTxLister is split out because only the P&L needs it; keeping it
@@ -296,6 +297,15 @@ func (s *MagmaService) acceptOrderLocked(ctx context.Context, orderID string) (M
 	}
 	if live.RevenueSat <= 0 {
 		return MagmaOrder{}, errors.New("Amboss reported a non-positive invoice amount")
+	}
+
+	// Amboss's own seller flow makes this step 2 of 3, before the invoice is
+	// submitted: "Make sure you can connect to this node". A buyer we cannot
+	// reach is a buyer whose channel we cannot open, so accepting promises a
+	// delivery we cannot make - and the reputation hit for approving and not
+	// opening is worse than the refusal.
+	if err := s.reachBuyer(ctx, token, live.BuyerPubkey); err != nil {
+		return MagmaOrder{}, err
 	}
 
 	// Balance is verified here, not at open time. Accepting is a promise: once the
@@ -716,21 +726,77 @@ func (s *MagmaService) existingChannelFor(ctx context.Context, order MagmaOrder)
 	return "", nil
 }
 
+// magmaReachBudget bounds one reachability attempt. It is deliberately short:
+// the real persistence comes from the poll loop, which repeats this every cycle
+// for the whole approval window, so a single pass never has to be exhaustive.
+const magmaReachBudget = 60 * time.Second
+
 // connectToBuyer is best effort, exactly as in the production bot: the peer may
 // already be connected, and openchannel can succeed regardless.
 func (s *MagmaService) connectToBuyer(ctx context.Context, token, pubkey string) {
-	addresses := s.buyerAddresses(ctx, token, pubkey)
-	for _, address := range addresses {
-		connectCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
-		err := s.lnd.ConnectPeerWithTimeout(connectCtx, pubkey, address, false, 30)
-		cancel()
-		if err == nil {
-			return
-		}
-		if s.logger != nil {
-			s.logger.Printf("magma: connect to %s via %s failed: %v", magmaShortPubkey(pubkey), address, err)
+	_ = s.reachBuyer(ctx, token, pubkey)
+}
+
+// reachBuyer reports whether the buyer's node can be reached, and is the one
+// place that decides it. One failed dial proves nothing: a node may advertise
+// both Tor and clearnet with only one of them working, Tor dials are slow and
+// fail spuriously, and a node can be a few seconds from coming back. So every
+// advertised address is tried, and the whole set is retried until the budget is
+// spent rather than concluding from a single miss.
+//
+// Being already connected counts as reached and is checked first, because
+// ConnectPeer returns an error for a peer that is already there and reading
+// that as unreachable would refuse every buyer we are already talking to.
+func (s *MagmaService) reachBuyer(ctx context.Context, token, pubkey string) error {
+	if peers, err := s.lnd.ListPeers(ctx); err == nil {
+		for _, peer := range peers {
+			if strings.EqualFold(peer.PubKey, pubkey) {
+				return nil
+			}
 		}
 	}
+
+	addresses := s.buyerAddresses(ctx, token, pubkey)
+	if len(addresses) == 0 {
+		return fmt.Errorf("the buyer's node advertises no address we can reach (%s)",
+			magmaShortPubkey(pubkey))
+	}
+
+	return s.dialBuyer(ctx, pubkey, addresses, magmaReachBudget)
+}
+
+// dialBuyer walks every address in turn and keeps walking them until the budget
+// is spent. Split out from reachBuyer so the retry behaviour can be tested
+// without a node or a network: the rule that matters is that no single failed
+// dial is allowed to settle the question.
+func (s *MagmaService) dialBuyer(
+	ctx context.Context, pubkey string, addresses []string, budget time.Duration,
+) error {
+	deadline := time.Now().Add(budget)
+	attempts := 0
+	var lastErr error
+	for time.Now().Before(deadline) {
+		for _, address := range addresses {
+			if time.Now().After(deadline) {
+				break
+			}
+			attempts++
+			connectCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+			err := s.lnd.ConnectPeerWithTimeout(connectCtx, pubkey, address, false, 15)
+			cancel()
+			if err == nil {
+				return nil
+			}
+			lastErr = err
+			if s.logger != nil {
+				s.logger.Printf("magma: connect to %s via %s failed: %v",
+					magmaShortPubkey(pubkey), address, err)
+			}
+		}
+	}
+	return fmt.Errorf(
+		"could not connect to the buyer's node after %d attempt(s) across %d address(es): %v",
+		attempts, len(addresses), lastErr)
 }
 
 // buyerAddresses prefers our own gossip and falls back to Amboss, which may know

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -300,12 +300,16 @@ func (s *MagmaService) acceptOrderLocked(ctx context.Context, orderID string) (M
 	}
 
 	// Amboss's own seller flow makes this step 2 of 3, before the invoice is
-	// submitted: "Make sure you can connect to this node". A buyer we cannot
-	// reach is a buyer whose channel we cannot open, so accepting promises a
-	// delivery we cannot make - and the reputation hit for approving and not
-	// opening is worse than the refusal.
+	// submitted: "Make sure you can connect to this node". It is recorded rather
+	// than enforced, and that distinction was paid for: order 109a4760 was bought
+	// by a node with one channel that we could not see connected, the accept was
+	// refused 75 times with a routing error, and the buyer then paid in full. A
+	// gate here would have refused a sale that completed. Unreachable is worth
+	// knowing - the channel open does need the peer - but it does not predict
+	// whether the order can be fulfilled, so it must not decide.
 	if err := s.reachBuyer(ctx, token, live.BuyerPubkey); err != nil {
-		return MagmaOrder{}, err
+		s.appendEvent(ctx, record.OrderID, "buyer_unreachable", "info", fmt.Sprintf(
+			"could not connect to the buyer before accepting: %v", err), nil)
 	}
 
 	// Balance is verified here, not at open time. Accepting is a promise: once the
@@ -726,10 +730,10 @@ func (s *MagmaService) existingChannelFor(ctx context.Context, order MagmaOrder)
 	return "", nil
 }
 
-// magmaReachBudget bounds one reachability attempt. It is deliberately short:
-// the real persistence comes from the poll loop, which repeats this every cycle
-// for the whole approval window, so a single pass never has to be exhaustive.
-const magmaReachBudget = 60 * time.Second
+// magmaReachBudget bounds one reachability attempt. It is short because the
+// result is advisory: nothing is refused on it, so it must not spend a poll
+// cycle being thorough. The poll loop repeats the check every cycle anyway.
+const magmaReachBudget = 25 * time.Second
 
 // connectToBuyer is best effort, exactly as in the production bot: the peer may
 // already be connected, and openchannel can succeed regardless.

--- a/lightningos-light/ui/src/pages/Reports.tsx
+++ b/lightningos-light/ui/src/pages/Reports.tsx
@@ -194,12 +194,13 @@ const chartGranularityOptions: ChartGranularity[] = ['day', 'week', 'month']
 
 const COLORS = {
   net: '#34d399',
-  // Revenue series are tones of one blue and cost series tones of one warm
-  // range, so a stacked bar says revenue-or-cost by colour before the legend
-  // is read. Keysend sent was lime green, which read as revenue.
-  keysend: '#7dd3fc',
-  revenueSales: '#0ea5e9',
-  revenueMarked: '#22d3ee',
+  // Revenue series are cool and cost series warm, so a stacked bar says
+  // revenue-or-cost by colour before the legend is read. The four cool tones are
+  // spread across the range rather than clustered - four neighbouring skies were
+  // indistinguishable at the size that has to work, a legend swatch.
+  keysend: '#a5f3fc',
+  revenueSales: '#0369a1',
+  revenueMarked: '#818cf8',
   costKeysendSent: '#fb923c',
   costOnchain: '#c2410c',
   netNegative: '#f87171',
@@ -1384,7 +1385,7 @@ export default function Reports() {
                       itemStyle={tooltipItemStyle}
                       formatter={(value) => formatSats(Number(value))}
                     />
-                    <Legend verticalAlign="top" height={24} formatter={(value) => <span className="text-xs text-fog/60">{value}</span>} />
+                    <Legend verticalAlign="top" formatter={(value) => <span className="text-xs text-fog/60">{value}</span>} />
                     {/* Revenue is stacked the way cost is, so every source is
                         visible and named instead of vanishing into one bar. */}
                     <Bar dataKey="forwardRevenue" stackId="live" name={t('reports.forwards')} fill={COLORS.revenue} radius={[8, 8, 8, 8]} />
@@ -1403,8 +1404,10 @@ export default function Reports() {
                       <Bar dataKey="onchainCost" stackId="live" name={t('reports.onchainCost')} fill={COLORS.costOnchain} radius={[8, 8, 8, 8]} />
                     )}
                     {/* Carries revenue minus cost, so it is the node total - the
-                        key name is historical and the label must not repeat it. */}
-                    <Bar dataKey="netRouting" stackId="live" name={t('reports.netTotalLabel')} fill={COLORS.net} radius={[8, 8, 8, 8]}>
+                        key name is historical. No legend entry: the axis already
+                        labels the column, and a fixed green swatch would contradict
+                        the bar itself, which turns red when the total is negative. */}
+                    <Bar dataKey="netRouting" stackId="live" name={t('reports.netTotalLabel')} legendType="none" fill={COLORS.net} radius={[8, 8, 8, 8]}>
                       {liveChartData.map((entry) => (
                         <Cell key={entry.name} fill={entry.netRoutingColor ?? COLORS.net} />
                       ))}
@@ -1735,7 +1738,7 @@ export default function Reports() {
                   <CartesianGrid stroke="rgba(255,255,255,0.08)" vertical={false} />
                   <XAxis dataKey="label" tick={{ fill: '#cbd5f5', fontSize: 11 }} axisLine={false} tickLine={false} />
                   <YAxis tick={{ fill: '#cbd5f5', fontSize: 11 }} tickFormatter={formatCompact} axisLine={false} tickLine={false} />
-                  <Legend verticalAlign="top" height={24} formatter={(value) => <span className="text-xs text-fog/60">{value}</span>} />
+                  <Legend verticalAlign="top" formatter={(value) => <span className="text-xs text-fog/60">{value}</span>} />
                   {/* The cost stack has five series and most days carry only one
                       or two. Listing the empty ones turns the tooltip into a
                       column of zeroes that hides the number being hovered. */}


### PR DESCRIPTION
> **Nota:** esta PR abriu com um gate e foi reescrita como aviso. O diagnóstico
> original estava errado e o histórico abaixo registra por quê.

## O diagnóstico que motivou a PR — e que se provou falso

Duas ordens falharam com `Unable to find a route to this destination`. Os compradores tinham **1 e 2 canais**; as cinco ordens que completaram antes tinham de 7 a 171. A separação era limpa e o mecanismo parecia óbvio: comprador pequeno demais não consegue rotear até nós.

Estava errado. A ordem `109a4760` — comprador com **1 canal**, peer que não víamos conectado — **pagou 4.271 sats integralmente** e ficou com um canal de 2.214.569 sats. A correlação tinha n=2 e era coincidência.

Um gate teria recusado uma venda que se concretizou.

## O que a PR faz agora

A checagem continua, porque a observação vale: a abertura do canal **precisa** do peer, e a própria UI da Amboss pede isso no passo 2 de 3 (*"Make sure you can connect to this node"*). Mas ela agora **registra** e deixa o accept seguir.

- resultado vira evento `buyer_unreachable`, nível `info`
- orçamento cai de 60s para 25s: nada é decidido com isso, então não pode gastar um ciclo de poll sendo minucioso

A lógica de tentativa continua correta e testada — todos os endereços anunciados, Tor e clearnet, repetidos até o orçamento acabar, porque um dial falho não prova nada. Já-conectado é verificado primeiro e conta como alcançado: `ConnectPeer` retorna erro para peer já conectado, e ler isso como inalcançável recusaria todo comprador com quem já falamos.

## Testes

`internal/server/magma_buyer_reach_test.go`: já-conectado não disca; todos os endereços são tentados; um dial falho não encerra a questão; e a checagem é advisory — o teste falha se o orçamento voltar a crescer para escala de gate.

`go test ./...` e `go vet ./internal/server/` verdes.

## O que continua em aberto

A causa de `109a4760` não é esta. Descartados: nossa mutation (intocada desde a 0.4.27), o schema da Amboss (idêntico ao que enviamos), a liquidez do nó, e o comprador. A PR #88 preserva `code` e `path` dos erros GraphQL para que o próximo episódio chegue com a informação que faltou neste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)