### PR TITLE
0.5.19-Beta: Magma - preservar code e path dos erros GraphQL da Amboss

### DIFF
--- a/lightningos-light/internal/server/magma_amboss.go
+++ b/lightningos-light/internal/server/magma_amboss.go
@@ -26,13 +26,78 @@ var errMagmaUnauthorized = errors.New("Amboss rejected the API token (401)")
 // magmaAPIError carries the messages Amboss returns inside a 200 response.
 // Amboss reports business failures as HTTP 200 with a populated errors[] array,
 // so status-code-only checks read those failures as success.
-type magmaAPIError struct{ Messages []string }
+// magmaAPIError carries what Amboss actually returned. Messages is what a human
+// reads; Details is the part that used to be thrown away.
+//
+// A GraphQL error is a message plus a `path` naming the field that failed and an
+// `extensions` object that normally carries a machine-readable `code`. Keeping
+// only the message cost real time: "Unable to find a route to this destination"
+// repeated 75 times says nothing about whether the resolver crashed, rejected
+// the input, or genuinely probed and failed - and those need different answers.
+type magmaAPIError struct {
+	Messages []string
+	Details  []magmaAPIErrorDetail
+}
+
+// magmaAPIErrorDetail is one GraphQL error with the parts that identify it.
+type magmaAPIErrorDetail struct {
+	Message string `json:"message"`
+	Path    string `json:"path,omitempty"`
+	Code    string `json:"code,omitempty"`
+}
 
 func (e *magmaAPIError) Error() string {
 	if len(e.Messages) == 0 {
 		return "Amboss returned an unspecified error"
 	}
 	return strings.Join(e.Messages, "; ")
+}
+
+// Diagnostic is the full error for logs and order events. It stays off Error()
+// so the UI and Telegram keep the plain sentence, while the record that gets
+// investigated later keeps the code that identifies the failure.
+func (e *magmaAPIError) Diagnostic() string {
+	parts := make([]string, 0, len(e.Details))
+	for _, detail := range e.Details {
+		text := detail.Message
+		if detail.Code != "" {
+			text += " [code=" + detail.Code + "]"
+		}
+		if detail.Path != "" {
+			text += " [path=" + detail.Path + "]"
+		}
+		parts = append(parts, text)
+	}
+	if len(parts) == 0 {
+		return e.Error()
+	}
+	return strings.Join(parts, "; ")
+}
+
+// magmaJoinJSONPath renders a GraphQL error path, whose elements are field names
+// or list indices, in the familiar dotted form.
+func magmaJoinJSONPath(path []json.RawMessage) string {
+	parts := make([]string, 0, len(path))
+	for _, item := range path {
+		if value := magmaUnquoteJSON(item); value != "" {
+			parts = append(parts, value)
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+// magmaUnquoteJSON returns a JSON string's contents, or the raw token for
+// anything else, so a numeric code or list index survives instead of being lost.
+func magmaUnquoteJSON(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return strings.TrimSpace(text)
+	}
+	return trimmed
 }
 
 // magmaNumber decodes Amboss numeric fields. The API is inconsistent by design:
@@ -294,6 +359,13 @@ func (c *magmaAmbossClient) do(ctx context.Context, token, query string, variabl
 		Data   json.RawMessage `json:"data"`
 		Errors []struct {
 			Message string `json:"message"`
+			// Path elements are strings or ints and extensions vary by server, so
+			// both are decoded loosely rather than assuming a shape Amboss never
+			// promised.
+			Path       []json.RawMessage `json:"path"`
+			Extensions struct {
+				Code json.RawMessage `json:"code"`
+			} `json:"extensions"`
 		} `json:"errors"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
@@ -301,16 +373,22 @@ func (c *magmaAmbossClient) do(ctx context.Context, token, query string, variabl
 	}
 	if len(envelope.Errors) > 0 {
 		messages := make([]string, 0, len(envelope.Errors))
+		details := make([]magmaAPIErrorDetail, 0, len(envelope.Errors))
 		for _, item := range envelope.Errors {
 			message := strings.TrimSpace(item.Message)
 			if message != "" {
 				messages = append(messages, message)
 			}
+			details = append(details, magmaAPIErrorDetail{
+				Message: message,
+				Path:    magmaJoinJSONPath(item.Path),
+				Code:    magmaUnquoteJSON(item.Extensions.Code),
+			})
 		}
 		if magmaMessagesIndicateAuthFailure(messages) {
 			return errMagmaUnauthorized
 		}
-		return &magmaAPIError{Messages: messages}
+		return &magmaAPIError{Messages: messages, Details: details}
 	}
 	if out == nil {
 		return nil

--- a/lightningos-light/internal/server/magma_api_error_test.go
+++ b/lightningos-light/internal/server/magma_api_error_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Order 109a4760 produced "Unable to find a route to this destination" 75 times
+// and the record kept only that sentence. It cannot distinguish a crashed
+// resolver from a rejected input from a real probe that failed, and those need
+// different answers - so the code and path are kept alongside it.
+func TestMagmaAPIErrorKeepsCodeAndPath(t *testing.T) {
+	body := `{"errors":[{"message":"Unable to find a route to this destination.",` +
+		`"path":["sellerAcceptOrder"],"extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}`
+	var envelope struct {
+		Errors []struct {
+			Message    string            `json:"message"`
+			Path       []json.RawMessage `json:"path"`
+			Extensions struct {
+				Code json.RawMessage `json:"code"`
+			} `json:"extensions"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	item := envelope.Errors[0]
+	apiErr := &magmaAPIError{
+		Messages: []string{item.Message},
+		Details: []magmaAPIErrorDetail{{
+			Message: item.Message,
+			Path:    magmaJoinJSONPath(item.Path),
+			Code:    magmaUnquoteJSON(item.Extensions.Code),
+		}},
+	}
+
+	// Error() stays the plain sentence: it is what reaches the UI and Telegram.
+	if apiErr.Error() != "Unable to find a route to this destination." {
+		t.Fatalf("the operator-facing message must not grow noise, got %q", apiErr.Error())
+	}
+	diag := apiErr.Diagnostic()
+	for _, want := range []string{"code=INTERNAL_SERVER_ERROR", "path=sellerAcceptOrder"} {
+		if !strings.Contains(diag, want) {
+			t.Fatalf("diagnostic must carry %s, got %q", want, diag)
+		}
+	}
+}
+
+// An error with nothing but a message must still read as that message rather
+// than as an empty diagnostic.
+func TestMagmaAPIErrorWithoutExtensionsFallsBack(t *testing.T) {
+	apiErr := &magmaAPIError{Messages: []string{"boom"}}
+	if got := apiErr.Diagnostic(); got != "boom" {
+		t.Fatalf("expected the message itself, got %q", got)
+	}
+}
+
+// Path elements may be list indices, and a numeric code is legal. Decoding only
+// JSON strings would silently drop both.
+func TestMagmaJSONPathKeepsNonStringElements(t *testing.T) {
+	path := []json.RawMessage{json.RawMessage(`"orders"`), json.RawMessage(`0`), json.RawMessage(`"id"`)}
+	if got := magmaJoinJSONPath(path); got != "orders.0.id" {
+		t.Fatalf("expected orders.0.id, got %q", got)
+	}
+	if got := magmaUnquoteJSON(json.RawMessage(`503`)); got != "503" {
+		t.Fatalf("a numeric code must survive, got %q", got)
+	}
+	if got := magmaUnquoteJSON(json.RawMessage(`null`)); got != "" {
+		t.Fatalf("null must read as absent, got %q", got)
+	}
+}

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -327,6 +327,17 @@ update magma_orders set invoice_payment_request=$2, invoice_hash=$3, updated_at=
 		// The invoice stays on the node unpaid and expires on its own; going back
 		// to observed lets the operator retry cleanly.
 		s.failOrder(ctx, record.OrderID, magmaStateObserved, fmt.Sprintf("Amboss rejected the invoice: %v", err))
+		// The plain sentence goes to the operator; the identifying detail goes to
+		// the record, along with what we actually sent. Order 109a4760 produced
+		// the same sentence 75 times and never once said which of the resolver's
+		// failure modes it was, or whether our invoice was the one at fault.
+		s.appendEvent(ctx, record.OrderID, "amboss_error", "info",
+			"Amboss error detail: "+magmaErrorDiagnostic(err),
+			map[string]any{
+				"invoice_sat":  live.RevenueSat,
+				"expiry_sec":   magmaInvoiceExpirySeconds,
+				"invoice_hash": invoice.PaymentHash,
+			})
 		return MagmaOrder{}, err
 	}
 
@@ -757,6 +768,16 @@ func (s *MagmaService) buyerAddresses(ctx context.Context, token, pubkey string)
 		}
 	}
 	return addresses
+}
+
+// magmaErrorDiagnostic returns the fullest description an error carries. Amboss
+// errors know their own code and path; anything else is reported as it is.
+func magmaErrorDiagnostic(err error) string {
+	var apiErr *magmaAPIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Diagnostic()
+	}
+	return err.Error()
 }
 
 func (s *MagmaService) failOrder(ctx context.Context, orderID, state, message string) {


### PR DESCRIPTION
## Por que

A ordem `109a4760` devolveu *"Unable to find a route to this destination"* **75 vezes** e o registro guardou só essa frase.

Ela não distingue três coisas que pedem respostas diferentes: resolver que quebrou, entrada recusada, ou sonda de rota que rodou de verdade e falhou. Um dia de investigação foi gasto estreitando à mão o que **um código de erro** teria respondido.

## O que muda

Erros GraphQL carregam `path` (o campo que falhou) e `extensions`, que normalmente traz um `code` legível por máquina. Nós decodificávamos só `message` e jogávamos o resto fora. Agora ambos são preservados.

`Error()` fica intocado — a UI e o Telegram continuam recebendo a frase limpa. O detalhe vai para o evento da ordem, via novo `Diagnostic()`:

```
Unable to find a route to this destination. [code=INTERNAL_SERVER_ERROR] [path=sellerAcceptOrder]
```

Junto vai **o que nós mandamos** (valor da invoice, expiração, hash), para que a próxima investigação consiga descartar ou incriminar a nossa própria requisição sem precisar consultar o banco — que foi exatamente o que travou esta.

## Decodificação defensiva

`path` e `code` são lidos como `json.RawMessage`. Elementos de path podem ser índices de lista e um `code` pode ser numérico; assumir string JSON descartaria os dois em silêncio. `null` é lido como ausente.

## Testes

`internal/server/magma_api_error_test.go`: envelope real preserva code e path; `Error()` continua sendo só a frase; erro sem extensions cai de volta na mensagem; índices numéricos e códigos numéricos sobrevivem.

`go test ./...` e `go vet ./internal/server/` verdes.

## Contexto da investigação

Descartado até aqui, para o caso `109a4760`: nossa mutation (intocada desde a 0.4.27), o schema da Amboss (`sellerAcceptOrder(id: String!, request: String!)`, idêntico ao que enviamos), a liquidez do nó (504M de inbound, 157 forwards no dia) e o comprador (pagou 4.271 sats e ficou com o canal de 2.214.569).

A causa exata segue em aberto. Esta PR não a resolve — garante que o próximo episódio chegue com a informação que faltou neste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)