### PR TITLE
0.5.19-Beta: Magma - adotar ordens aprovadas fora do app

### DIFF
--- a/lightningos-light/internal/server/magma_adopt_external_test.go
+++ b/lightningos-light/internal/server/magma_adopt_external_test.go
@@ -1,0 +1,46 @@
+package server
+
+import "testing"
+
+// On 2026-08-21 order 109a4760 was approved through the Amboss web UI after the
+// API had refused the invoice ~30 times. Amboss moved it to
+// WAITING_FOR_CHANNEL_OPEN and the buyer paid, but this app still had it as
+// `observed` - and funding requires `accepted`, so the app refused to open a
+// channel that was already paid for. The only fix at the time was an UPDATE by
+// hand. Left alone it would have become SELLER_FAILED_TO_OPEN_CHANNEL, which is
+// worse than the refusal the automation was trying to avoid.
+func TestMagmaAdoptsOrderApprovedOutsideTheApp(t *testing.T) {
+	if !magmaShouldAdoptExternalAccept(magmaStateObserved, "WAITING_FOR_CHANNEL_OPEN") {
+		t.Fatal("an order Amboss reports as paid, that we never accepted, must be adopted")
+	}
+}
+
+// Every other local state already belongs to a recovery path of its own, so
+// adopting from one would overwrite real progress with a guess. `accepting` in
+// particular has its own reconcile branch that asks Amboss which way the
+// interrupted accept actually went.
+func TestMagmaAdoptionLeavesOtherStatesAlone(t *testing.T) {
+	for _, state := range []string{
+		magmaStateAccepting, magmaStateAccepted, magmaStateOpening,
+		magmaStateOpenBroadcast, magmaStateConfirming, magmaStateConfirmed,
+		magmaStateRejected, magmaStateNeedsAttention,
+	} {
+		if magmaShouldAdoptExternalAccept(state, "WAITING_FOR_CHANNEL_OPEN") {
+			t.Fatalf("local state %s owns itself and must not be adopted", state)
+		}
+	}
+}
+
+// Adoption means "the buyer has paid and we owe a channel". Any earlier status
+// means no such debt exists yet, and promoting on one would mark an order as
+// accepted that nobody has accepted.
+func TestMagmaAdoptionRequiresThePaidStatus(t *testing.T) {
+	for _, status := range []string{
+		"WAITING_FOR_SELLER_APPROVAL", "SELLER_FAILED_TO_REACT", "SELLER_REJECTED",
+		"VALID_CHANNEL_OPENING", "CHANNEL_MONITORING_FINISHED", "",
+	} {
+		if magmaShouldAdoptExternalAccept(magmaStateObserved, status) {
+			t.Fatalf("status %q does not mean the buyer has paid", status)
+		}
+	}
+}

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -810,7 +810,70 @@ func (s *MagmaService) orderByID(ctx context.Context, orderID string) (MagmaOrde
 // what replaces the lock files the production bot uses: instead of blocking every
 // future order until a file is deleted by hand, each order is picked back up from
 // whatever the node and Amboss actually show.
+// magmaShouldAdoptExternalAccept reports whether an order was accepted somewhere
+// other than here. Amboss saying the buyer has paid while our own record still
+// says we never accepted can only mean the approval happened elsewhere - the web
+// UI, another tool, a hand.
+//
+// The pairing is deliberately narrow. Every other local state is already owned by
+// a recovery path of its own, and adopting from one of those would overwrite real
+// progress with a guess.
+func magmaShouldAdoptExternalAccept(localState, magmaStatus string) bool {
+	return localState == magmaStateObserved && magmaStatus == "WAITING_FOR_CHANNEL_OPEN"
+}
+
+// adoptOrdersAcceptedElsewhere brings those orders back under the app's control.
+//
+// Without this the order is stranded in the worst possible way: the open is
+// blocked because funding requires local state `accepted`, so the app refuses to
+// open a channel the buyer has already paid for. That is
+// SELLER_FAILED_TO_OPEN_CHANNEL, which costs more than the refusal we were trying
+// to avoid, and the only way out was editing the database by hand.
+//
+// No call to Amboss is needed: magma_status was refreshed from SellerOrders in
+// this same sync pass, moments ago, so it is already the live answer.
+func (s *MagmaService) adoptOrdersAcceptedElsewhere(ctx context.Context) {
+	rows, err := s.db.Query(ctx, `
+select order_id, local_state, magma_status from magma_orders
+where local_state=$1 and magma_status='WAITING_FOR_CHANNEL_OPEN'
+`, magmaStateObserved)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Printf("magma: adoption query failed: %v", err)
+		}
+		return
+	}
+	type candidate struct{ orderID, localState, magmaStatus string }
+	candidates := make([]candidate, 0, 4)
+	for rows.Next() {
+		var item candidate
+		if err := rows.Scan(&item.orderID, &item.localState, &item.magmaStatus); err == nil {
+			candidates = append(candidates, item)
+		}
+	}
+	rows.Close()
+
+	for _, item := range candidates {
+		if !magmaShouldAdoptExternalAccept(item.localState, item.magmaStatus) {
+			continue
+		}
+		if err := s.setLocalState(ctx, item.orderID, magmaStateAccepted, ""); err != nil {
+			if s.logger != nil {
+				s.logger.Printf("magma: could not adopt order %s: %v", item.orderID, err)
+			}
+			continue
+		}
+		s.appendEvent(ctx, item.orderID, "adopted", "info",
+			"Order was approved outside this app and the buyer has paid; "+
+				"taking it over so the channel can be funded", nil)
+	}
+}
+
 func (s *MagmaService) reconcileExecution(ctx context.Context, token string) {
+	// Runs first: an order approved elsewhere has to be owned before any of the
+	// resume paths below can see it.
+	s.adoptOrdersAcceptedElsewhere(ctx)
+
 	rows, err := s.db.Query(ctx, `
 select order_id, local_state, funding_txid, channel_point, buyer_pubkey, size_sat
 from magma_orders


### PR DESCRIPTION
## O problema, encontrado na prática hoje

A ordem `109a4760` foi aprovada pela UI da Amboss depois que a API recusou a mesma invoice ~30 vezes. A Amboss moveu para `WAITING_FOR_CHANNEL_OPEN` e **o comprador pagou** — mas o app ainda tinha a ordem como `observed`.

Em [magma_execution.go:470](lightningos-light/internal/server/magma_execution.go#L470), estado local diferente de `accepted` é bloqueador de financiamento, no automático **e** no botão manual. Ou seja: o app se recusava a abrir um canal que já estava pago.

A única saída na hora foi `UPDATE` na mão. Sem isso, o desfecho seria `SELLER_FAILED_TO_OPEN_CHANNEL` — mais caro que a recusa que a automação existe para evitar.

## A correção

O reconcile passa a adotar essas ordens. A Amboss reportar o comprador como tendo pago, enquanto o nosso registro diz que nunca aceitamos, só pode significar que a aprovação aconteceu em outro lugar — a UI, outra ferramenta, uma mão.

Nenhuma chamada extra é necessária para estabelecer isso: `magma_status` foi atualizado a partir de `SellerOrders` **nesta mesma passada de sync**, momentos antes, então já é a resposta ao vivo.

Roda antes dos demais caminhos de retomada — uma ordem aprovada em outro lugar precisa ser assumida antes que qualquer um deles consiga enxergá-la.

## O pareamento é estreito de propósito

Só `observed` + `WAITING_FOR_CHANNEL_OPEN`. Nada mais.

Todo outro estado local já pertence a um caminho de recuperação próprio — `accepting`, em particular, tem um ramo que **pergunta à Amboss** para que lado o accept interrompido foi. Adotar a partir de qualquer um deles sobrescreveria progresso real com um palpite.

## Receita

Não precisou mudar nada. `revenue_settled_at` é carimbado a partir da transição de `payment_status` que o poller observa, não de uma invoice que emitimos — então uma venda aprovada fora do app é contabilizada corretamente. Verificado antes de implementar.

## Testes

`internal/server/magma_adopt_external_test.go`: adota o par correto; nunca adota a partir dos outros oito estados locais; e exige o status de pago, recusando `WAITING_FOR_SELLER_APPROVAL`, `VALID_CHANNEL_OPENING`, vazio e os demais.

`go test ./...` e `go vet ./internal/server/` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)