### PR TITLE
0.5.21: harden Sovereign attribution, shadow and exploration telemetry

### DIFF
--- a/docs/03_API_SPEC.md
+++ b/docs/03_API_SPEC.md
@@ -770,6 +770,14 @@ POST /api/rebalance/channel/guaranteed
 - `channel_id_str` is used to preserve uint64 precision in browser clients and is validated against `channel_point`.
 - At most one eligible pool member is queued per automatic scan before the selected scheduler. The job bypasses score and strategic/history gates, but retains the automatic budget, fee cap, channel-busy, target-deficit, and route/source safety checks.
 
+GET /api/rebalance/history
+- Returns completed jobs and attempts from the last 24 hours.
+- Sovereign jobs include their planned economics and realized forwarding attribution. Jobs selected through the adaptive exploration path expose `exploration_slot: true`; the field is omitted for regular jobs.
+
+GET /api/rebalance/overview
+- Includes separate 7-day exploration counters and realized economics under the `sovereign_exploration_*_7d` fields, so exploration can be compared with total Sovereign performance.
+- Exploration attribution starts when the persisted marker is deployed; jobs created by older versions cannot be classified retroactively.
+
 ## Terminal
 
 GET /api/terminal/status

--- a/lightningos-light/docs/rebalance-center.md
+++ b/lightningos-light/docs/rebalance-center.md
@@ -550,8 +550,15 @@ kept as design history and include per-item status notes.
 
 ### R5 — Exploration burnout (track & stop)
 
-**Current status (2026-06-20): done.** The service tracks exploration burnout
-and tests cover the behavior. Keep this section as historical context.
+**Current status (2026-08-22): done and persisted.** The service marks
+exploration jobs in `rebalance_jobs`, restores the 24h failure streak after a
+Manager restart, and exposes the marker in queue/history telemetry. A success
+starts a fresh streak, so five later failures can still trigger the 12h burnout.
+The overview also separates 7d exploration volume, cost, attributed revenue,
+net, and sell-through from the total Sovereign result. This classification only
+fills after deploying the persisted marker; older jobs cannot be backfilled.
+Tests cover both live and restart-recovery behavior. Keep this section as
+historical context.
 
 **Esforço:** ~30 min de código + testes
 **Risco:** baixo
@@ -582,7 +589,7 @@ if stats.Attempts >= 5 && stats.Failures == stats.Attempts {
 
 - ✅ Para de queimar slots em canais comprovadamente quebrados
 - ✅ Outros canais ganham as oportunidades de exploração
-- ⚠️ Mais state pra manter (DB ou em memória)
+- ✅ Estado persistido no DB e recuperado após restart
 - ⚠️ Canais que se recuperam após o burnout só voltam após 12h
 
 ---

--- a/lightningos-light/docs/rebalance-center.md
+++ b/lightningos-light/docs/rebalance-center.md
@@ -100,8 +100,9 @@ dois quando ativada. Centraliza o scoring multi-fator e o orçamento diário.
 
 **Modos:**
 
-- `sovereign_shadow`: **avalia** mas não cria jobs. Telemetria pura, custo zero.
-  Usado para baseline antes de habilitar live.
+- `sovereign_shadow`: **avalia** mas não cria jobs, não cai no rules-auto, não
+  enfileira guaranteed slots e não aplica mudanças do AutoTarget. Telemetria
+  pura, custo zero. Usado para baseline antes de habilitar live.
 - `sovereign_live`: executa os candidatos selecionados.
 - `rules_auto`: desliga sovereign; volta aos loops Auto + Manual Restart
   separados.
@@ -487,6 +488,9 @@ Canal aparece mas não é selecionado:
 - Use `live` quando: configuração estabilizada, métricas saudáveis
 - Transição: rode 6-12h em shadow, compare expected_profit médio e candidate
   count com expectativa antes de flipar para live
+- A receita realizada usa atribuição FIFO por canal de destino: cada forward
+  consome primeiro o lote de liquidez paga elegível mais antigo e não pode ser
+  contado em dois jobs com janelas sobrepostas
 
 ## 12. Histórico de mudanças relevantes
 

--- a/lightningos-light/docs/sovereign-autopilot-audit.md
+++ b/lightningos-light/docs/sovereign-autopilot-audit.md
@@ -126,7 +126,10 @@ Keep `sovereign_live` off unless all are true over at least 24h, preferably 7d:
   through the API remains possible and must be separated from shadow telemetry.
 - `sovereign_exploration_slot_pct` can bypass empirical-history gates. When the
   candidate set is small, the scarcity rule may mark many candidates as
-  exploration, allowing route-dead targets into live execution.
+  exploration, allowing route-dead targets into live execution. This is an
+  intentional discovery mechanism: exploration jobs are persisted and visible
+  through `exploration_slot`, while five consecutive failed exploration jobs in
+  24h apply a 12h target burnout that survives Manager restarts.
 - `sovereign_target_source_quarantine_hours`,
   `fresh_paid_liquidity_lock_enabled`, and `source_min_payback_progress` are the
   direct protections that stop a recently rebalanced channel from immediately

--- a/lightningos-light/docs/sovereign-autopilot-audit.md
+++ b/lightningos-light/docs/sovereign-autopilot-audit.md
@@ -41,9 +41,9 @@ production.
 ### 1. Mode Split
 
 Check the "Mode Split" section first. `sovereign_shadow` records decisions but
-does not execute sovereign jobs. In this codebase, shadow mode still lets the
-normal rules-auto scan run afterward, so actual movement may still happen from
-non-sovereign `auto` jobs.
+does not execute jobs, queue the guaranteed slot, run the rules-auto fallback,
+or apply AutoTarget changes. It is a pure dry run; manual API-triggered jobs are
+outside the scheduler-mode guarantee.
 
 If the last 24h mixes `sovereign_live` and `sovereign_shadow`, split conclusions:
 
@@ -82,7 +82,9 @@ Use the overview and "Sovereign Live Execution" sections:
 
 Positive expected profit in `sovereign_history` is not enough. The live audit is
 passed only when attributed forward fees exceed paid rebalance fees over the
-chosen attribution window.
+chosen attribution window. Forward attribution is FIFO per target channel:
+each forward consumes the oldest eligible paid-liquidity lot and is counted at
+most once, even when multiple jobs have overlapping attribution windows.
 
 ### 4. Source Objective
 
@@ -120,9 +122,8 @@ Keep `sovereign_live` off unless all are true over at least 24h, preferably 7d:
 
 ## Current Design Risks To Watch
 
-- Shadow mode still allows rules-auto execution after recording sovereign
-  decisions. This is useful for comparison, but confusing if shadow is expected
-  to mean "no rebalance execution at all".
+- Shadow mode intentionally blocks all scheduler mutations. A manual job started
+  through the API remains possible and must be separated from shadow telemetry.
 - `sovereign_exploration_slot_pct` can bypass empirical-history gates. When the
   candidate set is small, the scarcity rule may mark many candidates as
   exploration, allowing route-dead targets into live execution.

--- a/lightningos-light/internal/server/rebalance_attribution.go
+++ b/lightningos-light/internal/server/rebalance_attribution.go
@@ -17,6 +17,7 @@ type rebalanceAttributionLot struct {
 	CompletedAt     time.Time
 	SentSat         int64
 	FeePaidSat      int64
+	ExplorationSlot bool
 }
 
 type rebalanceAttributionForward struct {
@@ -167,14 +168,15 @@ select
   coalesce(j.trigger_reason, ''),
   j.completed_at,
   coalesce(sum(a.amount_sat) filter (where a.status='succeeded'), 0) as sent_sat,
-  coalesce(sum(a.fee_paid_sat) filter (where a.status='succeeded'), 0) as fee_paid_sat
+  coalesce(sum(a.fee_paid_sat) filter (where a.status='succeeded'), 0) as fee_paid_sat,
+  j.exploration_slot
 from rebalance_jobs j
 left join rebalance_attempts a on a.job_id = j.id
 where j.completed_at is not null
   and j.completed_at >= $1
   and j.status in ('succeeded','partial','failed')
   and (cardinality($2::bigint[]) = 0 or j.target_channel_id = any($2::bigint[]))
-group by j.id, j.target_channel_id, j.status, j.reason, j.trigger_reason, j.completed_at
+group by j.id, j.target_channel_id, j.status, j.reason, j.trigger_reason, j.completed_at, j.exploration_slot
 order by j.completed_at, j.id
 `, since, ids)
 	if err != nil {
@@ -194,6 +196,7 @@ order by j.completed_at, j.id
 			&lot.CompletedAt,
 			&lot.SentSat,
 			&lot.FeePaidSat,
+			&lot.ExplorationSlot,
 		); err != nil {
 			rows.Close()
 			return nil, nil, err

--- a/lightningos-light/internal/server/rebalance_attribution.go
+++ b/lightningos-light/internal/server/rebalance_attribution.go
@@ -1,0 +1,286 @@
+package server
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+// rebalanceAttributionLot represents paid liquidity made available by one
+// completed rebalance job. Forwards consume these lots FIFO per target.
+type rebalanceAttributionLot struct {
+	JobID           int64
+	TargetChannelID uint64
+	Status          string
+	Reason          string
+	TriggerReason   string
+	CompletedAt     time.Time
+	SentSat         int64
+	FeePaidSat      int64
+}
+
+type rebalanceAttributionForward struct {
+	ID              int64
+	TargetChannelID uint64
+	OccurredAt      time.Time
+	AmountSat       int64
+	FeeMsat         int64
+}
+
+type rebalanceAttributionResult struct {
+	ForwardAmountSat int64
+	ForwardFeeMsat   int64
+}
+
+// attributeRebalanceForwardsFIFO consumes forward volume from the oldest
+// eligible paid-liquidity lot of the same target. A forward may span multiple
+// lots, but every sat and its proportional fee are attributed at most once for
+// a given measurement window.
+func attributeRebalanceForwardsFIFO(lots []rebalanceAttributionLot, forwards []rebalanceAttributionForward, window time.Duration) map[int64]rebalanceAttributionResult {
+	result := make(map[int64]rebalanceAttributionResult, len(lots))
+	if window <= 0 || len(lots) == 0 || len(forwards) == 0 {
+		return result
+	}
+
+	lotsByTarget := make(map[uint64][]rebalanceAttributionLot)
+	for _, lot := range lots {
+		if lot.JobID <= 0 || lot.TargetChannelID == 0 || lot.CompletedAt.IsZero() || lot.SentSat <= 0 {
+			continue
+		}
+		lotsByTarget[lot.TargetChannelID] = append(lotsByTarget[lot.TargetChannelID], lot)
+	}
+	for targetID := range lotsByTarget {
+		sort.SliceStable(lotsByTarget[targetID], func(i, j int) bool {
+			left := lotsByTarget[targetID][i]
+			right := lotsByTarget[targetID][j]
+			if !left.CompletedAt.Equal(right.CompletedAt) {
+				return left.CompletedAt.Before(right.CompletedAt)
+			}
+			return left.JobID < right.JobID
+		})
+	}
+
+	forwardsByTarget := make(map[uint64][]rebalanceAttributionForward)
+	for _, forward := range forwards {
+		if forward.TargetChannelID == 0 || forward.OccurredAt.IsZero() || forward.AmountSat <= 0 {
+			continue
+		}
+		forwardsByTarget[forward.TargetChannelID] = append(forwardsByTarget[forward.TargetChannelID], forward)
+	}
+	for targetID := range forwardsByTarget {
+		sort.SliceStable(forwardsByTarget[targetID], func(i, j int) bool {
+			left := forwardsByTarget[targetID][i]
+			right := forwardsByTarget[targetID][j]
+			if !left.OccurredAt.Equal(right.OccurredAt) {
+				return left.OccurredAt.Before(right.OccurredAt)
+			}
+			return left.ID < right.ID
+		})
+	}
+
+	for targetID, targetLots := range lotsByTarget {
+		targetForwards := forwardsByTarget[targetID]
+		if len(targetForwards) == 0 {
+			continue
+		}
+		remaining := make([]int64, len(targetLots))
+		for i := range targetLots {
+			remaining[i] = targetLots[i].SentSat
+		}
+		lotIndex := 0
+
+		for _, forward := range targetForwards {
+			unassignedSat := forward.AmountSat
+			assignedFromEventSat := int64(0)
+			for unassignedSat > 0 && lotIndex < len(targetLots) {
+				lot := targetLots[lotIndex]
+				if remaining[lotIndex] <= 0 || !forward.OccurredAt.Before(lot.CompletedAt.Add(window)) {
+					lotIndex++
+					continue
+				}
+				if forward.OccurredAt.Before(lot.CompletedAt) {
+					break
+				}
+
+				attributedSat := unassignedSat
+				if attributedSat > remaining[lotIndex] {
+					attributedSat = remaining[lotIndex]
+				}
+				if attributedSat <= 0 {
+					continue
+				}
+
+				feeShareMsat := int64(0)
+				if forward.FeeMsat > 0 {
+					// Difference of cumulative floors preserves the proportional
+					// fee when one event is split across multiple lots.
+					before := (forward.FeeMsat * assignedFromEventSat) / forward.AmountSat
+					after := (forward.FeeMsat * (assignedFromEventSat + attributedSat)) / forward.AmountSat
+					feeShareMsat = after - before
+				}
+
+				current := result[lot.JobID]
+				current.ForwardAmountSat += attributedSat
+				current.ForwardFeeMsat += feeShareMsat
+				result[lot.JobID] = current
+				remaining[lotIndex] -= attributedSat
+				unassignedSat -= attributedSat
+				assignedFromEventSat += attributedSat
+				if remaining[lotIndex] == 0 {
+					lotIndex++
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// loadRebalanceAttributionInputs loads all completed jobs in the context
+// horizon, not only the jobs that will be reported. Older context lots must be
+// allowed to consume forwards first or a reporting-window boundary would move
+// their revenue to newer jobs.
+func (s *RebalanceService) loadRebalanceAttributionInputs(ctx context.Context, since time.Time, targetIDs []uint64) ([]rebalanceAttributionLot, []rebalanceAttributionForward, error) {
+	if s.db == nil {
+		return nil, nil, nil
+	}
+
+	ids := make([]int64, 0, len(targetIDs))
+	seenTargets := make(map[uint64]struct{}, len(targetIDs))
+	for _, targetID := range targetIDs {
+		if targetID == 0 {
+			continue
+		}
+		if _, ok := seenTargets[targetID]; ok {
+			continue
+		}
+		seenTargets[targetID] = struct{}{}
+		ids = append(ids, int64(targetID))
+	}
+
+	rows, err := s.db.Query(ctx, `
+select
+  j.id,
+  j.target_channel_id,
+  j.status,
+  coalesce(j.reason, ''),
+  coalesce(j.trigger_reason, ''),
+  j.completed_at,
+  coalesce(sum(a.amount_sat) filter (where a.status='succeeded'), 0) as sent_sat,
+  coalesce(sum(a.fee_paid_sat) filter (where a.status='succeeded'), 0) as fee_paid_sat
+from rebalance_jobs j
+left join rebalance_attempts a on a.job_id = j.id
+where j.completed_at is not null
+  and j.completed_at >= $1
+  and j.status in ('succeeded','partial','failed')
+  and (cardinality($2::bigint[]) = 0 or j.target_channel_id = any($2::bigint[]))
+group by j.id, j.target_channel_id, j.status, j.reason, j.trigger_reason, j.completed_at
+order by j.completed_at, j.id
+`, since, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lots := make([]rebalanceAttributionLot, 0)
+	for rows.Next() {
+		var lot rebalanceAttributionLot
+		var targetID int64
+		if err := rows.Scan(
+			&lot.JobID,
+			&targetID,
+			&lot.Status,
+			&lot.Reason,
+			&lot.TriggerReason,
+			&lot.CompletedAt,
+			&lot.SentSat,
+			&lot.FeePaidSat,
+		); err != nil {
+			rows.Close()
+			return nil, nil, err
+		}
+		if targetID <= 0 {
+			continue
+		}
+		lot.TargetChannelID = uint64(targetID)
+		lots = append(lots, lot)
+		seenTargets[lot.TargetChannelID] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, nil, err
+	}
+	rows.Close()
+	if len(lots) == 0 {
+		return lots, nil, nil
+	}
+
+	ids = ids[:0]
+	for targetID := range seenTargets {
+		ids = append(ids, int64(targetID))
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	forwardRows, err := s.db.Query(ctx, `
+select
+  id,
+  channel_id,
+  occurred_at,
+  amount_sat,
+  case when fee_msat > 0 then fee_msat else fee_sat * 1000 end as fee_msat
+from notifications
+where type='forward'
+  and occurred_at >= $1
+  and occurred_at <= now()
+  and channel_id = any($2::bigint[])
+order by occurred_at, id
+`, since, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer forwardRows.Close()
+
+	forwards := make([]rebalanceAttributionForward, 0)
+	for forwardRows.Next() {
+		var forward rebalanceAttributionForward
+		var targetID int64
+		if err := forwardRows.Scan(&forward.ID, &targetID, &forward.OccurredAt, &forward.AmountSat, &forward.FeeMsat); err != nil {
+			return nil, nil, err
+		}
+		if targetID <= 0 {
+			continue
+		}
+		forward.TargetChannelID = uint64(targetID)
+		forwards = append(forwards, forward)
+	}
+	if err := forwardRows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return lots, forwards, nil
+}
+
+type sovereignAttributionSnapshot struct {
+	MetricSince time.Time
+	Lots        []rebalanceAttributionLot
+	Fast        map[int64]rebalanceAttributionResult
+	Slow        map[int64]rebalanceAttributionResult
+}
+
+func (s *RebalanceService) loadSovereignAttributionSnapshot(ctx context.Context, cfg RebalanceConfig) (sovereignAttributionSnapshot, error) {
+	metricSince := time.Now().Add(-7 * 24 * time.Hour)
+	fastWindow := time.Duration(sovereignAttributionWindowHoursForConfig(cfg)) * time.Hour
+	slowWindow := time.Duration(sovereignSlowSellerWindowHoursForConfig(cfg)) * time.Hour
+	contextWindow := slowWindow
+	if fastWindow > contextWindow {
+		contextWindow = fastWindow
+	}
+	lots, forwards, err := s.loadRebalanceAttributionInputs(ctx, metricSince.Add(-contextWindow), nil)
+	if err != nil {
+		return sovereignAttributionSnapshot{}, err
+	}
+	return sovereignAttributionSnapshot{
+		MetricSince: metricSince,
+		Lots:        lots,
+		Fast:        attributeRebalanceForwardsFIFO(lots, forwards, fastWindow),
+		Slow:        attributeRebalanceForwardsFIFO(lots, forwards, slowWindow),
+	}, nil
+}

--- a/lightningos-light/internal/server/rebalance_attribution_test.go
+++ b/lightningos-light/internal/server/rebalance_attribution_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAttributeRebalanceForwardsFIFOOverlappingJobsConsumeForwardOnce(t *testing.T) {
+	base := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	lots := []rebalanceAttributionLot{
+		{JobID: 1, TargetChannelID: 10, CompletedAt: base, SentSat: 100},
+		{JobID: 2, TargetChannelID: 10, CompletedAt: base.Add(10 * time.Minute), SentSat: 100},
+	}
+	forwards := []rebalanceAttributionForward{
+		{ID: 50, TargetChannelID: 10, OccurredAt: base.Add(20 * time.Minute), AmountSat: 150, FeeMsat: 1500},
+	}
+
+	got := attributeRebalanceForwardsFIFO(lots, forwards, time.Hour)
+	if got[1].ForwardAmountSat != 100 || got[1].ForwardFeeMsat != 1000 {
+		t.Fatalf("job 1 attribution = %+v, want amount=100 fee_msat=1000", got[1])
+	}
+	if got[2].ForwardAmountSat != 50 || got[2].ForwardFeeMsat != 500 {
+		t.Fatalf("job 2 attribution = %+v, want amount=50 fee_msat=500", got[2])
+	}
+	if total := got[1].ForwardAmountSat + got[2].ForwardAmountSat; total != 150 {
+		t.Fatalf("forward was double counted: total attributed=%d, want 150", total)
+	}
+}
+
+func TestAttributeRebalanceForwardsFIFOCapsAtAvailableLiquidity(t *testing.T) {
+	base := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	lots := []rebalanceAttributionLot{
+		{JobID: 1, TargetChannelID: 10, CompletedAt: base, SentSat: 100},
+		{JobID: 2, TargetChannelID: 10, CompletedAt: base, SentSat: 100},
+	}
+	forwards := []rebalanceAttributionForward{
+		{ID: 50, TargetChannelID: 10, OccurredAt: base.Add(time.Minute), AmountSat: 300, FeeMsat: 3000},
+	}
+
+	got := attributeRebalanceForwardsFIFO(lots, forwards, time.Hour)
+	amount := got[1].ForwardAmountSat + got[2].ForwardAmountSat
+	fee := got[1].ForwardFeeMsat + got[2].ForwardFeeMsat
+	if amount != 200 {
+		t.Fatalf("attributed amount=%d, want available liquidity 200", amount)
+	}
+	if fee != 2000 {
+		t.Fatalf("attributed fee_msat=%d, want proportional fee 2000", fee)
+	}
+}
+
+func TestAttributeRebalanceForwardsFIFOHonorsExpiryAndTarget(t *testing.T) {
+	base := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	lots := []rebalanceAttributionLot{
+		{JobID: 1, TargetChannelID: 10, CompletedAt: base, SentSat: 100},
+		{JobID: 2, TargetChannelID: 10, CompletedAt: base.Add(2 * time.Hour), SentSat: 100},
+		{JobID: 3, TargetChannelID: 20, CompletedAt: base, SentSat: 100},
+	}
+	forwards := []rebalanceAttributionForward{
+		{ID: 50, TargetChannelID: 10, OccurredAt: base.Add(150 * time.Minute), AmountSat: 80, FeeMsat: 800},
+		{ID: 51, TargetChannelID: 20, OccurredAt: base.Add(30 * time.Minute), AmountSat: 60, FeeMsat: 600},
+	}
+
+	got := attributeRebalanceForwardsFIFO(lots, forwards, time.Hour)
+	if got[1].ForwardAmountSat != 0 {
+		t.Fatalf("expired job 1 received attribution: %+v", got[1])
+	}
+	if got[2].ForwardAmountSat != 80 {
+		t.Fatalf("job 2 attribution = %+v, want amount=80", got[2])
+	}
+	if got[3].ForwardAmountSat != 60 {
+		t.Fatalf("target-isolated job 3 attribution = %+v, want amount=60", got[3])
+	}
+}

--- a/lightningos-light/internal/server/rebalance_auto_target.go
+++ b/lightningos-light/internal/server/rebalance_auto_target.go
@@ -344,82 +344,34 @@ func (s *RebalanceService) loadChannelSellThrough7d(ctx context.Context, cfg Reb
 	if s.db == nil {
 		return out, 0
 	}
-	attributionHours := sovereignAttributionWindowHoursForConfig(cfg)
-	rows, err := s.db.Query(ctx, `
-with jobs as (
-  select id, target_channel_id, completed_at
-  from rebalance_jobs
-  where trigger_reason = $1
-    and completed_at is not null
-    and completed_at >= now() - interval '7 days'
-),
-attempt_totals as (
-  select j.id,
-    coalesce(sum(a.amount_sat) filter (where a.status='succeeded'), 0) as sent_sat
-  from jobs j
-  left join rebalance_attempts a on a.job_id = j.id
-  group by j.id
-),
-forward_totals as (
-  select j.id,
-    coalesce(sum(n.amount_sat) filter (where n.occurred_at < j.completed_at + ($2::int * interval '1 hour')), 0) as forward_amount_sat,
-    coalesce(sum(case when n.fee_msat > 0 then n.fee_msat else n.fee_sat * 1000 end) filter (where n.occurred_at < j.completed_at + ($2::int * interval '1 hour')), 0)::bigint as forward_fee_msat
-  from jobs j
-  left join notifications n on n.type='forward'
-    and n.channel_id = j.target_channel_id
-    and n.occurred_at >= j.completed_at
-  group by j.id
-),
-job_raw as (
-  select j.target_channel_id,
-    coalesce(a.sent_sat, 0) as sent_sat,
-    coalesce(f.forward_amount_sat, 0) as forward_amount_sat,
-    coalesce(f.forward_fee_msat, 0) as forward_fee_msat
-  from jobs j
-  left join attempt_totals a on a.id = j.id
-  left join forward_totals f on f.id = j.id
-),
-job_economics as (
-  select target_channel_id,
-    sent_sat,
-    case
-      when sent_sat <= 0 or forward_amount_sat <= 0 then 0
-      when forward_amount_sat > sent_sat then sent_sat
-      else forward_amount_sat
-    end as attributed_forward_sat,
-    case
-      when sent_sat <= 0 or forward_amount_sat <= 0 or forward_fee_msat <= 0 then 0
-      when forward_amount_sat > sent_sat then (forward_fee_msat * sent_sat) / forward_amount_sat
-      else forward_fee_msat
-    end as attributed_forward_fee_msat
-  from job_raw
-)
-select target_channel_id,
-  coalesce(sum(sent_sat), 0) as sent_sat,
-  coalesce(sum(attributed_forward_sat), 0) as forward_sat,
-  coalesce(sum(attributed_forward_fee_msat), 0)::bigint as forward_fee_msat
-from job_economics
-group by target_channel_id`, rebalanceSovereignReason, attributionHours)
+	snapshot, err := s.loadSovereignAttributionSnapshot(ctx, cfg)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Printf("auto-target sell-through load failed: %v", err)
 		}
 		return out, 0
 	}
-	defer rows.Close()
+	feeByTargetMsat := map[uint64]int64{}
 	var totalSent, totalForward int64
-	for rows.Next() {
-		var chID, sent, fwd, fwdFeeMsat int64
-		if err := rows.Scan(&chID, &sent, &fwd, &fwdFeeMsat); err != nil {
-			return out, 0
+	for _, lot := range snapshot.Lots {
+		if lot.TriggerReason != rebalanceSovereignReason || lot.CompletedAt.Before(snapshot.MetricSince) {
+			continue
 		}
-		st := channelSellThrough{SentSat: sent, ForwardSat: fwd, ForwardFeeSat: fwdFeeMsat / 1000}
-		if sent > 0 {
-			st.SellThrough = float64(fwd) / float64(sent)
+		attributed := snapshot.Fast[lot.JobID]
+		stat := out[lot.TargetChannelID]
+		stat.SentSat += lot.SentSat
+		stat.ForwardSat += attributed.ForwardAmountSat
+		feeByTargetMsat[lot.TargetChannelID] += attributed.ForwardFeeMsat
+		out[lot.TargetChannelID] = stat
+		totalSent += lot.SentSat
+		totalForward += attributed.ForwardAmountSat
+	}
+	for targetID, stat := range out {
+		stat.ForwardFeeSat = feeByTargetMsat[targetID] / 1000
+		if stat.SentSat > 0 {
+			stat.SellThrough = float64(stat.ForwardSat) / float64(stat.SentSat)
 		}
-		out[uint64(chID)] = st
-		totalSent += sent
-		totalForward += fwd
+		out[targetID] = stat
 	}
 	node := 0.0
 	if totalSent > 0 {

--- a/lightningos-light/internal/server/rebalance_scheduler_mode_test.go
+++ b/lightningos-light/internal/server/rebalance_scheduler_mode_test.go
@@ -1,0 +1,30 @@
+package server
+
+import "testing"
+
+func TestSovereignShadowIsPureDryRun(t *testing.T) {
+	if !isSovereignSchedulerMode(rebalanceSchedulerModeSovereignShadow) {
+		t.Fatal("shadow mode must be owned exclusively by the sovereign scheduler")
+	}
+	if shouldQueueGuaranteedRebalanceSlot(rebalanceSchedulerModeSovereignShadow) {
+		t.Fatal("shadow mode must not queue a guaranteed rebalance slot")
+	}
+	if shouldEvaluateAutoTarget(rebalanceSchedulerModeSovereignShadow) {
+		t.Fatal("shadow mode must not mutate channel targets")
+	}
+}
+
+func TestLiveAndRulesSchedulerMutationPolicy(t *testing.T) {
+	if !shouldQueueGuaranteedRebalanceSlot(rebalanceSchedulerModeSovereignLive) {
+		t.Fatal("sovereign live mode must retain guaranteed-slot execution")
+	}
+	if !shouldEvaluateAutoTarget(rebalanceSchedulerModeSovereignLive) {
+		t.Fatal("sovereign live mode must retain AutoTarget evaluation")
+	}
+	if !shouldQueueGuaranteedRebalanceSlot(rebalanceSchedulerModeRulesAuto) {
+		t.Fatal("rules-auto mode must retain guaranteed-slot execution")
+	}
+	if shouldEvaluateAutoTarget(rebalanceSchedulerModeRulesAuto) {
+		t.Fatal("rules-auto mode does not run sovereign AutoTarget evaluation")
+	}
+}

--- a/lightningos-light/internal/server/rebalance_service.go
+++ b/lightningos-light/internal/server/rebalance_service.go
@@ -526,6 +526,15 @@ type RebalanceOverview struct {
 	SovereignSellThroughSlow7d          float64                       `json:"sovereign_sellthrough_slow_7d"`
 	SovereignSellThroughWindowHours     int                           `json:"sovereign_sellthrough_window_hours"`
 	SovereignSellThroughSlowWindowHours int                           `json:"sovereign_sellthrough_slow_window_hours"`
+	SovExploreJobs7d                    int64                         `json:"sovereign_exploration_jobs_7d"`
+	SovExploreRebalanceAmount7dSat      int64                         `json:"sovereign_exploration_rebalance_amount_7d_sat"`
+	SovExploreRebalanceCost7dSat        int64                         `json:"sovereign_exploration_rebalance_cost_7d_sat"`
+	SovExploreForwardAmount7dSat        int64                         `json:"sovereign_exploration_forward_amount_7d_sat"`
+	SovExploreForwardFee7dSat           int64                         `json:"sovereign_exploration_forward_fee_7d_sat"`
+	SovExploreRealizedNet7dSat          int64                         `json:"sovereign_exploration_realized_net_7d_sat"`
+	SovExploreSellThrough7d             float64                       `json:"sovereign_exploration_sellthrough_7d"`
+	SovExploreRealizedNetSlow7dSat      int64                         `json:"sovereign_exploration_realized_net_slow_7d_sat"`
+	SovExploreSellThroughSlow7d         float64                       `json:"sovereign_exploration_sellthrough_slow_7d"`
 	Jobs24h                             int64                         `json:"jobs_24h"`
 	SuccessJobs24h                      int64                         `json:"success_jobs_24h"`
 	JobSuccessRate24h                   float64                       `json:"job_success_rate_24h"`
@@ -1144,6 +1153,7 @@ type RebalanceJob struct {
 	SovereignExpectedProfitSat    int64   `json:"sovereign_expected_profit_sat,omitempty"`
 	SovereignBudgetCostSat        int64   `json:"sovereign_budget_cost_sat,omitempty"`
 	SovereignScore                int64   `json:"sovereign_score,omitempty"`
+	ExplorationSlot               bool    `json:"exploration_slot,omitempty"`
 	ActualSentSat                 int64   `json:"actual_sent_sat,omitempty"`
 	ActualRebalanceFeeSat         int64   `json:"actual_rebalance_fee_sat,omitempty"`
 	Forward1hCount                int64   `json:"forward_1h_count,omitempty"`
@@ -1332,6 +1342,7 @@ type rebalanceJobEconomics struct {
 	ExpectedProfitSat int64
 	BudgetCostSat     int64
 	Score             int64
+	ExplorationSlot   bool
 }
 
 type recentTargetCooldownWindows struct {
@@ -1369,6 +1380,7 @@ type rebalanceAttemptTelemetry24h struct {
 }
 
 type rebalanceAutopilotEconomics7d struct {
+	JobCount           int64
 	RebalanceAmountSat int64
 	RebalanceCostSat   int64
 	RebalanceCostPpm   int64
@@ -1388,6 +1400,11 @@ type rebalanceAutopilotEconomics7d struct {
 	// Janelas usadas (vindas da config/UI), pra label dos indicadores.
 	AttributionWindowHours int
 	SlowSellerWindowHours  int
+}
+
+type rebalanceAutopilotEconomicsBreakdown7d struct {
+	Total       rebalanceAutopilotEconomics7d
+	Exploration rebalanceAutopilotEconomics7d
 }
 
 type mppShadowShard struct {
@@ -1552,11 +1569,10 @@ type RebalanceService struct {
 	chCacheData    []lndclient.ChannelInfo
 	chCacheFetchAt time.Time
 
-	// R5 — Exploration burnout (in-memory): tracks recent exploration
-	// attempts per target channel so chronically failing targets stop
-	// burning exploration slots cycle after cycle. State is volatile; on
-	// process restart the system starts fresh, which is acceptable (the
-	// worst case is a known-bad target being tried once more).
+	// R5 — Exploration burnout: the in-memory cache gives immediate updates
+	// while persisted exploration job outcomes restore the 24h window after a
+	// process restart. Chronically failing targets temporarily stop consuming
+	// exploration slots cycle after cycle.
 	explorationStatsMu sync.Mutex
 	explorationStats   map[uint64]*explorationStat
 	explorationJobs    map[int64]uint64 // jobID → channelID (only set for exploration-marked jobs)
@@ -1570,6 +1586,12 @@ type explorationStat struct {
 	AttemptsWindow []time.Time
 	FailuresWindow []time.Time
 	BurnedUntil    time.Time
+}
+
+type explorationOutcome struct {
+	ChannelID  uint64
+	Succeeded  bool
+	FinishedAt time.Time
 }
 
 func NewRebalanceService(db *pgxpool.Pool, lnd *lndclient.Client, logger *log.Logger) *RebalanceService {
@@ -4175,8 +4197,9 @@ func (s *RebalanceService) executeSovereignAutopilotWithReservedSlot(ctx context
 	// ExplorationSlot mark so we stop burning cycles on dead-end channels.
 	candidates := plan.Candidates
 	if cfg.SovereignExplorationSlotPct > 0 && maxJobs > 1 {
+		persistedBurnout := s.loadPersistedExplorationBurnoutTargets(ctx, scanAt)
 		burnoutFn := func(channelID uint64) bool {
-			return s.isInExplorationBurnout(channelID, scanAt)
+			return persistedBurnout[channelID] || s.isInExplorationBurnout(channelID, scanAt)
 		}
 		// Targets that already reached the structural cooldown threshold must
 		// not receive the exploration mark — otherwise the M3 scarcity bypass
@@ -4385,18 +4408,14 @@ func (s *RebalanceService) executeSovereignAutopilotWithReservedSlot(ctx context
 					ExpectedProfitSat: decision.ExpectedProfitSat,
 					BudgetCostSat:     decision.BudgetCostSat,
 					Score:             decision.Score,
+					ExplorationSlot:   target.ExplorationSlot,
 				}
-				jobID, err := s.startJobWithEconomics(target.Channel.ChannelID, "auto", rebalanceSovereignReason, amountOverride, false, false, economics, operatorRebalanceOverrides{})
+				_, err := s.startJobWithEconomics(target.Channel.ChannelID, "auto", rebalanceSovereignReason, amountOverride, false, false, economics, operatorRebalanceOverrides{})
 				if err != nil {
 					decision.Reason = autoStartErrorReason(err)
 					noteSkip(decision.Reason)
 					appendDecision(decision)
 					continue
-				}
-				// R5: mark exploration-slot jobs so finishJob can record the
-				// outcome to update burnout state.
-				if target.ExplorationSlot {
-					s.markExplorationJob(jobID, target.Channel.ChannelID)
 				}
 				s.mu.Lock()
 				s.lastAutoByTarget[target.Channel.ChannelID] = scanAt
@@ -5288,6 +5307,12 @@ func (s *RebalanceService) startJobWithEconomics(targetChannelID uint64, source 
 			TargetChannelID: targetChannelID,
 		}
 		s.mu.Unlock()
+	}
+	// Register the exploration outcome tracker before starting the goroutine.
+	// The old call site marked the job after runJob had already started, so a
+	// fast skip/failure could finish before the marker existed.
+	if economics.ExplorationSlot {
+		s.markExplorationJob(jobID, targetChannelID)
 	}
 
 	go s.runJob(jobID, targetChannelID, amount, targetPct, source, reason, overrides)
@@ -9454,7 +9479,7 @@ where id=$1`, jobID, status, nullableString(reason), completedAt)
 	// against the target channel so the burnout window updates. Partials and
 	// full successes both count as "successful" exploration — they moved
 	// liquidity, which is the whole point.
-	if channelID, ok := s.takeExplorationJob(jobID); ok {
+	if channelID, ok := s.takeExplorationJob(ctx, jobID); ok {
 		succeeded := status == "succeeded" || status == "partial"
 		s.recordExplorationOutcome(channelID, succeeded, completedAt)
 	}
@@ -10864,6 +10889,97 @@ func (s *RebalanceService) isInExplorationBurnout(channelID uint64, now time.Tim
 	return now.Before(stat.BurnedUntil)
 }
 
+func explorationBurnoutTargetsFromOutcomes(outcomes []explorationOutcome, now time.Time) map[uint64]bool {
+	result := map[uint64]bool{}
+	if len(outcomes) == 0 {
+		return result
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	ordered := append([]explorationOutcome(nil), outcomes...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if !ordered[i].FinishedAt.Equal(ordered[j].FinishedAt) {
+			return ordered[i].FinishedAt.Before(ordered[j].FinishedAt)
+		}
+		return ordered[i].ChannelID < ordered[j].ChannelID
+	})
+	stats := map[uint64]*explorationStat{}
+	cutoff := now.Add(-sovereignExplorationBurnoutWindow)
+	for _, outcome := range ordered {
+		if outcome.ChannelID == 0 || outcome.FinishedAt.IsZero() || outcome.FinishedAt.Before(cutoff) || outcome.FinishedAt.After(now) {
+			continue
+		}
+		stat := stats[outcome.ChannelID]
+		if stat == nil {
+			stat = &explorationStat{}
+			stats[outcome.ChannelID] = stat
+		}
+		stat.AttemptsWindow = trimTimeWindow(stat.AttemptsWindow, outcome.FinishedAt.Add(-sovereignExplorationBurnoutWindow))
+		stat.FailuresWindow = trimTimeWindow(stat.FailuresWindow, outcome.FinishedAt.Add(-sovereignExplorationBurnoutWindow))
+		if outcome.Succeeded {
+			stat.AttemptsWindow = nil
+			stat.FailuresWindow = nil
+			stat.BurnedUntil = time.Time{}
+			continue
+		}
+		stat.AttemptsWindow = append(stat.AttemptsWindow, outcome.FinishedAt)
+		stat.FailuresWindow = append(stat.FailuresWindow, outcome.FinishedAt)
+		if len(stat.FailuresWindow) >= sovereignExplorationBurnoutMinAttempts && len(stat.FailuresWindow) == len(stat.AttemptsWindow) {
+			stat.BurnedUntil = outcome.FinishedAt.Add(sovereignExplorationBurnoutDuration)
+		}
+	}
+	for channelID, stat := range stats {
+		if stat != nil && !stat.BurnedUntil.IsZero() && now.Before(stat.BurnedUntil) {
+			result[channelID] = true
+		}
+	}
+	return result
+}
+
+func (s *RebalanceService) loadPersistedExplorationBurnoutTargets(ctx context.Context, now time.Time) map[uint64]bool {
+	if s == nil || s.db == nil {
+		return map[uint64]bool{}
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	rows, err := s.db.Query(ctx, `
+select target_channel_id, status, completed_at
+from rebalance_jobs
+where exploration_slot=true
+  and completed_at is not null
+  and completed_at >= $1
+  and completed_at <= $2
+order by completed_at, id
+`, now.Add(-sovereignExplorationBurnoutWindow), now)
+	if err != nil {
+		return map[uint64]bool{}
+	}
+	defer rows.Close()
+	outcomes := make([]explorationOutcome, 0)
+	for rows.Next() {
+		var channelID int64
+		var status string
+		var finishedAt time.Time
+		if err := rows.Scan(&channelID, &status, &finishedAt); err != nil {
+			return map[uint64]bool{}
+		}
+		if channelID <= 0 {
+			continue
+		}
+		outcomes = append(outcomes, explorationOutcome{
+			ChannelID:  uint64(channelID),
+			Succeeded:  status == "succeeded" || status == "partial",
+			FinishedAt: finishedAt,
+		})
+	}
+	if rows.Err() != nil {
+		return map[uint64]bool{}
+	}
+	return explorationBurnoutTargetsFromOutcomes(outcomes, now)
+}
+
 // recordExplorationOutcome updates the in-memory exploration window for a
 // target channel after one of its exploration-marked jobs finished. When
 // `succeeded` is true, the failure window is cleared and any active burnout
@@ -10893,8 +11009,10 @@ func (s *RebalanceService) recordExplorationOutcome(channelID uint64, succeeded 
 	stat.FailuresWindow = trimTimeWindow(stat.FailuresWindow, cutoff)
 	stat.AttemptsWindow = append(stat.AttemptsWindow, now)
 	if succeeded {
-		// Any success in the window clears the failure streak and lifts the
-		// active burnout — the channel has demonstrated viability.
+		// A success starts a new failure streak and lifts active burnout. Clear
+		// both windows so five later failures can still trigger burnout instead
+		// of being masked by an earlier success for the rest of the 24h window.
+		stat.AttemptsWindow = nil
 		stat.FailuresWindow = nil
 		stat.BurnedUntil = time.Time{}
 		return
@@ -10928,18 +11046,34 @@ func (s *RebalanceService) markExplorationJob(jobID int64, channelID uint64) {
 }
 
 // takeExplorationJob looks up and removes the jobID from the exploration
-// tracking map. Returns the channelID and whether the job was exploration.
-func (s *RebalanceService) takeExplorationJob(jobID int64) (uint64, bool) {
+// tracking map. The persisted flag is the fallback for process restarts and
+// for any completion that raced with volatile tracking.
+func (s *RebalanceService) takeExplorationJob(ctx context.Context, jobID int64) (uint64, bool) {
 	if s == nil || jobID == 0 {
 		return 0, false
 	}
 	s.explorationStatsMu.Lock()
-	defer s.explorationStatsMu.Unlock()
 	channelID, ok := s.explorationJobs[jobID]
 	if ok {
 		delete(s.explorationJobs, jobID)
 	}
-	return channelID, ok
+	s.explorationStatsMu.Unlock()
+	if ok {
+		return channelID, true
+	}
+	if s.db == nil {
+		return 0, false
+	}
+	var persistedChannelID int64
+	err := s.db.QueryRow(ctx, `
+select target_channel_id
+from rebalance_jobs
+where id=$1 and exploration_slot=true
+`, jobID).Scan(&persistedChannelID)
+	if err != nil || persistedChannelID <= 0 {
+		return 0, false
+	}
+	return uint64(persistedChannelID), true
 }
 
 // trimTimeWindow drops timestamps older than cutoff from a sorted-ish slice.
@@ -12369,7 +12503,8 @@ create table if not exists rebalance_jobs (
   sovereign_estimated_cost_sat bigint not null default 0,
   sovereign_expected_profit_sat bigint not null default 0,
   sovereign_budget_cost_sat bigint not null default 0,
-  sovereign_score bigint not null default 0
+  sovereign_score bigint not null default 0,
+  exploration_slot boolean not null default false
 );
 
 alter table if exists rebalance_jobs
@@ -12386,6 +12521,11 @@ alter table if exists rebalance_jobs
   add column if not exists sovereign_budget_cost_sat bigint not null default 0;
 alter table if exists rebalance_jobs
   add column if not exists sovereign_score bigint not null default 0;
+alter table if exists rebalance_jobs
+  add column if not exists exploration_slot boolean not null default false;
+create index if not exists rebalance_jobs_exploration_completed_idx
+  on rebalance_jobs (completed_at, target_channel_id)
+  where exploration_slot=true;
 -- Backfill: jobs com reason='delegated-fast-path' são por definição sucessos via fast-path,
 -- então marcamos retroativamente para que o telemetry não subconte (idempotente).
 update rebalance_jobs set fast_path_attempted=true where reason='delegated-fast-path' and not fast_path_attempted;
@@ -14207,11 +14347,13 @@ func (s *RebalanceService) insertJob(ctx context.Context, target *lndclient.Chan
 	err := s.db.QueryRow(ctx, `
 insert into rebalance_jobs (
   source, status, trigger_reason, reason, target_channel_id, target_channel_point, target_outbound_pct, target_amount_sat, config_snapshot,
-  sovereign_expected_gain_sat, sovereign_estimated_cost_sat, sovereign_expected_profit_sat, sovereign_budget_cost_sat, sovereign_score
-) values ($1,'queued',$2,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+  sovereign_expected_gain_sat, sovereign_estimated_cost_sat, sovereign_expected_profit_sat, sovereign_budget_cost_sat, sovereign_score,
+  exploration_slot
+) values ($1,'queued',$2,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
  returning id
 `, source, nullableString(reason), int64(target.ChannelID), target.ChannelPoint, targetPct, amount, nil,
-		economics.ExpectedGainSat, economics.EstimatedCostSat, economics.ExpectedProfitSat, economics.BudgetCostSat, economics.Score).Scan(&jobID)
+		economics.ExpectedGainSat, economics.EstimatedCostSat, economics.ExpectedProfitSat, economics.BudgetCostSat, economics.Score,
+		economics.ExplorationSlot).Scan(&jobID)
 	return jobID, err
 }
 
@@ -14416,9 +14558,9 @@ select
 	}, nil
 }
 
-func (s *RebalanceService) fetchSovereignAutopilotEconomics7d(ctx context.Context, cfg RebalanceConfig) (rebalanceAutopilotEconomics7d, error) {
+func (s *RebalanceService) fetchSovereignAutopilotEconomics7d(ctx context.Context, cfg RebalanceConfig) (rebalanceAutopilotEconomicsBreakdown7d, error) {
 	if s.db == nil {
-		return rebalanceAutopilotEconomics7d{}, nil
+		return rebalanceAutopilotEconomicsBreakdown7d{}, nil
 	}
 	// Duas janelas, ambas vindas da config (UI): attribution_window mede a
 	// venda "rápida" (velocidade) e slow_seller_window mede a realização
@@ -14429,8 +14571,16 @@ func (s *RebalanceService) fetchSovereignAutopilotEconomics7d(ctx context.Contex
 	slowHours := sovereignSlowSellerWindowHoursForConfig(cfg)
 	snapshot, err := s.loadSovereignAttributionSnapshot(ctx, cfg)
 	if err != nil {
-		return rebalanceAutopilotEconomics7d{}, err
+		return rebalanceAutopilotEconomicsBreakdown7d{}, err
 	}
+	return rebalanceAutopilotEconomicsBreakdown7d{
+		Total:       sovereignAutopilotEconomicsFromSnapshot(snapshot, attributionHours, slowHours, false),
+		Exploration: sovereignAutopilotEconomicsFromSnapshot(snapshot, attributionHours, slowHours, true),
+	}, nil
+}
+
+func sovereignAutopilotEconomicsFromSnapshot(snapshot sovereignAttributionSnapshot, attributionHours, slowHours int, explorationOnly bool) rebalanceAutopilotEconomics7d {
+	var jobCount int64
 	var sentSat int64
 	var costSat int64
 	var forwardSat int64
@@ -14441,6 +14591,10 @@ func (s *RebalanceService) fetchSovereignAutopilotEconomics7d(ctx context.Contex
 		if lot.TriggerReason != rebalanceSovereignReason || lot.CompletedAt.Before(snapshot.MetricSince) {
 			continue
 		}
+		if explorationOnly && !lot.ExplorationSlot {
+			continue
+		}
+		jobCount++
 		sentSat += lot.SentSat
 		costSat += lot.FeePaidSat
 		fast := snapshot.Fast[lot.JobID]
@@ -14453,6 +14607,7 @@ func (s *RebalanceService) fetchSovereignAutopilotEconomics7d(ctx context.Contex
 	forwardFeeSat := forwardFeeMsat / 1000
 	forwardSlowFeeSat := forwardSlowFeeMsat / 1000
 	result := rebalanceAutopilotEconomics7d{
+		JobCount:               jobCount,
 		RebalanceAmountSat:     sentSat,
 		RebalanceCostSat:       costSat,
 		RebalanceCostPpm:       satToPpm(costSat, sentSat),
@@ -14471,7 +14626,7 @@ func (s *RebalanceService) fetchSovereignAutopilotEconomics7d(ctx context.Contex
 		result.SellThrough = float64(forwardSat) / float64(sentSat)
 		result.SellThroughSlow = float64(forwardSlowSat) / float64(sentSat)
 	}
-	return result, nil
+	return result
 }
 
 const (
@@ -14858,7 +15013,7 @@ where type='rebalance' and occurred_at >= now() - interval '1 day'
 	paybackProgress := 0.0
 	paybackProgressRebalanced := 0.0
 	attemptTelemetry := rebalanceAttemptTelemetry24h{}
-	sovereignEconomics7d := rebalanceAutopilotEconomics7d{}
+	sovereignEconomics7d := rebalanceAutopilotEconomicsBreakdown7d{}
 	mppShadowTelemetry := mppShadowTelemetry24h{}
 	mppStructuralAbortJobs := int64(0)
 	topFailureReasons30m := []RebalanceReasonStat{}
@@ -15052,20 +15207,29 @@ where report_date >= current_date - interval '6 days'
 		JobsWithoutAttempt7d:                jobsWithoutAttemptCount,
 		JobsWithoutAttemptRate7d:            jobsWithoutAttemptRate,
 		ROI7d:                               roi,
-		SovereignRebalanceAmount7dSat:       sovereignEconomics7d.RebalanceAmountSat,
-		SovereignRebalanceCost7dSat:         sovereignEconomics7d.RebalanceCostSat,
-		SovereignRebalanceCost7dPpm:         sovereignEconomics7d.RebalanceCostPpm,
-		SovereignForwardAmount7dSat:         sovereignEconomics7d.ForwardAmountSat,
-		SovereignForwardFee7dSat:            sovereignEconomics7d.ForwardFeeSat,
-		SovereignForwardFee7dPpm:            sovereignEconomics7d.ForwardFeePpm,
-		SovereignRealizedNet7dSat:           sovereignEconomics7d.RealizedNetSat,
-		SovereignSellThrough7d:              sovereignEconomics7d.SellThrough,
-		SovereignForwardAmountSlow7dSat:     sovereignEconomics7d.ForwardAmountSlowSat,
-		SovereignForwardFeeSlow7dSat:        sovereignEconomics7d.ForwardFeeSlowSat,
-		SovereignRealizedNetSlow7dSat:       sovereignEconomics7d.RealizedNetSlowSat,
-		SovereignSellThroughSlow7d:          sovereignEconomics7d.SellThroughSlow,
-		SovereignSellThroughWindowHours:     sovereignEconomics7d.AttributionWindowHours,
-		SovereignSellThroughSlowWindowHours: sovereignEconomics7d.SlowSellerWindowHours,
+		SovereignRebalanceAmount7dSat:       sovereignEconomics7d.Total.RebalanceAmountSat,
+		SovereignRebalanceCost7dSat:         sovereignEconomics7d.Total.RebalanceCostSat,
+		SovereignRebalanceCost7dPpm:         sovereignEconomics7d.Total.RebalanceCostPpm,
+		SovereignForwardAmount7dSat:         sovereignEconomics7d.Total.ForwardAmountSat,
+		SovereignForwardFee7dSat:            sovereignEconomics7d.Total.ForwardFeeSat,
+		SovereignForwardFee7dPpm:            sovereignEconomics7d.Total.ForwardFeePpm,
+		SovereignRealizedNet7dSat:           sovereignEconomics7d.Total.RealizedNetSat,
+		SovereignSellThrough7d:              sovereignEconomics7d.Total.SellThrough,
+		SovereignForwardAmountSlow7dSat:     sovereignEconomics7d.Total.ForwardAmountSlowSat,
+		SovereignForwardFeeSlow7dSat:        sovereignEconomics7d.Total.ForwardFeeSlowSat,
+		SovereignRealizedNetSlow7dSat:       sovereignEconomics7d.Total.RealizedNetSlowSat,
+		SovereignSellThroughSlow7d:          sovereignEconomics7d.Total.SellThroughSlow,
+		SovereignSellThroughWindowHours:     sovereignEconomics7d.Total.AttributionWindowHours,
+		SovereignSellThroughSlowWindowHours: sovereignEconomics7d.Total.SlowSellerWindowHours,
+		SovExploreJobs7d:                    sovereignEconomics7d.Exploration.JobCount,
+		SovExploreRebalanceAmount7dSat:      sovereignEconomics7d.Exploration.RebalanceAmountSat,
+		SovExploreRebalanceCost7dSat:        sovereignEconomics7d.Exploration.RebalanceCostSat,
+		SovExploreForwardAmount7dSat:        sovereignEconomics7d.Exploration.ForwardAmountSat,
+		SovExploreForwardFee7dSat:           sovereignEconomics7d.Exploration.ForwardFeeSat,
+		SovExploreRealizedNet7dSat:          sovereignEconomics7d.Exploration.RealizedNetSat,
+		SovExploreSellThrough7d:             sovereignEconomics7d.Exploration.SellThrough,
+		SovExploreRealizedNetSlow7dSat:      sovereignEconomics7d.Exploration.RealizedNetSlowSat,
+		SovExploreSellThroughSlow7d:         sovereignEconomics7d.Exploration.SellThroughSlow,
 		Jobs24h:                             jobs24h,
 		SuccessJobs24h:                      successJobs24h,
 		JobSuccessRate24h:                   jobSuccessRate24h,
@@ -15332,7 +15496,7 @@ func (s *RebalanceService) Queue(ctx context.Context) ([]RebalanceJob, []Rebalan
 	}
 	rows, err := s.db.Query(ctx, `
 select id, created_at, completed_at, source, status, trigger_reason, reason, target_channel_id,
-  target_channel_point, target_outbound_pct, target_amount_sat
+  target_channel_point, target_outbound_pct, target_amount_sat, exploration_slot
 from rebalance_jobs
 where status in ('running','queued')
    or completed_at >= now() - ($1::int * interval '1 second')
@@ -15350,7 +15514,7 @@ order by created_at desc
 		var reason pgtype.Text
 		var targetChannelID int64
 		if err := rows.Scan(&job.ID, &created, &completed, &job.Source, &job.Status, &triggerReason, &reason, &targetChannelID,
-			&job.TargetChannelPoint, &job.TargetOutboundPct, &job.TargetAmountSat); err != nil {
+			&job.TargetChannelPoint, &job.TargetOutboundPct, &job.TargetAmountSat, &job.ExplorationSlot); err != nil {
 			return jobs, attempts, err
 		}
 		job.CreatedAt = created.UTC().Format(time.RFC3339)
@@ -15510,7 +15674,7 @@ func (s *RebalanceService) History(ctx context.Context, limit int) ([]RebalanceJ
 select id, created_at, completed_at, source, status, trigger_reason, reason, target_channel_id,
   target_channel_point, target_outbound_pct, target_amount_sat,
   sovereign_expected_gain_sat, sovereign_estimated_cost_sat, sovereign_expected_profit_sat,
-  sovereign_budget_cost_sat, sovereign_score
+  sovereign_budget_cost_sat, sovereign_score, exploration_slot
 from rebalance_jobs
 where status in ('succeeded','failed','cancelled','partial','skipped')
   and completed_at >= now() - interval '1 day'
@@ -15535,7 +15699,7 @@ order by created_at desc`
 		if err := rows.Scan(&job.ID, &created, &completed, &job.Source, &job.Status, &triggerReason, &reason, &targetChannelID,
 			&job.TargetChannelPoint, &job.TargetOutboundPct, &job.TargetAmountSat,
 			&job.SovereignExpectedGainSat, &job.SovereignEstimatedCostSat, &job.SovereignExpectedProfitSat,
-			&job.SovereignBudgetCostSat, &job.SovereignScore); err != nil {
+			&job.SovereignBudgetCostSat, &job.SovereignScore, &job.ExplorationSlot); err != nil {
 			return jobs, attempts, err
 		}
 		job.CreatedAt = created.UTC().Format(time.RFC3339)

--- a/lightningos-light/internal/server/rebalance_service.go
+++ b/lightningos-light/internal/server/rebalance_service.go
@@ -2479,6 +2479,14 @@ func isSovereignSchedulerMode(mode string) bool {
 	return mode == rebalanceSchedulerModeSovereignShadow || mode == rebalanceSchedulerModeSovereignLive
 }
 
+func shouldQueueGuaranteedRebalanceSlot(mode string) bool {
+	return normalizeRebalanceSchedulerMode(mode) != rebalanceSchedulerModeSovereignShadow
+}
+
+func shouldEvaluateAutoTarget(mode string) bool {
+	return normalizeRebalanceSchedulerMode(mode) == rebalanceSchedulerModeSovereignLive
+}
+
 func freshPaidLiquidityLockDuration(cfg RebalanceConfig) time.Duration {
 	hours := cfg.FreshPaidLiquidityLockHours
 	if hours <= 0 {
@@ -3523,8 +3531,9 @@ func (s *RebalanceService) runManualRestartWatch() {
 	if !cfg.AutoEnabled || !cfg.ManualRestartWatch {
 		return
 	}
-	if normalizeRebalanceSchedulerMode(cfg.SchedulerMode) == rebalanceSchedulerModeSovereignLive {
-		s.recordManualRestartWatch(time.Now(), 0, map[string]int{"sovereign_live": 1})
+	schedulerMode := normalizeRebalanceSchedulerMode(cfg.SchedulerMode)
+	if isSovereignSchedulerMode(schedulerMode) {
+		s.recordManualRestartWatch(time.Now(), 0, map[string]int{schedulerMode: 1})
 		return
 	}
 	if s.lnd == nil {
@@ -3716,11 +3725,15 @@ func (s *RebalanceService) runAutoScan() {
 		snapshot := s.buildChannelSnapshot(ctx, cfg, criticalActive, ch, setting, ledger[ch.ChannelID], revenueByChannel[ch.ChannelID], costByChannel[ch.ChannelID], drainRateByChannel[ch.ChannelID], exclusions[ch.ChannelID])
 		snapshots = append(snapshots, snapshot)
 	}
-	guaranteedSlot = s.queueGuaranteedRebalanceSlot(ctx, cfg, snapshots, settings, lastAutoByTarget, lastGuaranteedByTarget, scanAt)
-	if guaranteedSlot.Queued {
-		queuedCount = 1
-	}
 	schedulerMode := normalizeRebalanceSchedulerMode(cfg.SchedulerMode)
+	// Shadow mode is a pure dry run: guaranteed slots and AutoTarget both
+	// mutate state, so neither may run while only observing sovereign choices.
+	if shouldQueueGuaranteedRebalanceSlot(schedulerMode) {
+		guaranteedSlot = s.queueGuaranteedRebalanceSlot(ctx, cfg, snapshots, settings, lastAutoByTarget, lastGuaranteedByTarget, scanAt)
+		if guaranteedSlot.Queued {
+			queuedCount = 1
+		}
+	}
 	if isSovereignSchedulerMode(schedulerMode) {
 		sovereignTargetIDs := make([]uint64, 0, len(snapshots))
 		includeManualRestartTargets := cfg.SovereignCandidateScope == rebalanceSovereignScopeAutoAndManualRestart
@@ -3762,7 +3775,7 @@ func (s *RebalanceService) runAutoScan() {
 		// raise the target of the strong sellers among them (supply-limited by
 		// construction) and lower channels that stopped selling. Reuses the
 		// snapshots, pair stats and structural cooldowns already loaded above.
-		if cfg.AutoTargetEnabled {
+		if cfg.AutoTargetEnabled && shouldEvaluateAutoTarget(schedulerMode) {
 			s.evaluateAutoTarget(ctx, cfg, scanAt, snapshots, settings, sovereignPlan.Candidates, sovereignPairStats, sovereignStructuralCooldowns)
 		}
 		reservedSlots := 0
@@ -3773,16 +3786,18 @@ func (s *RebalanceService) runAutoScan() {
 		sovereignResult = includeGuaranteedRebalanceSlot(sovereignResult, guaranteedSlot)
 		s.recordRebalanceIntentEffects(ctx, sovereignPlan, cfg, scanAt, schedulerMode, sovereignResult.Decisions)
 		s.recordSovereignAutopilot(ctx, scanAt, schedulerMode, sovereignResult)
+		scanStatus = sovereignResult.Status
+		scanDetail = sovereignResult.Detail
+		scanCandidates = sovereignResult.Candidates
+		scanRemainingBudget = sovereignResult.BudgetRemainingSat
+		scanReasons = copyReasonCounts(sovereignResult.SkipReasons)
+		topScore = sovereignPlan.TopScore
 		if schedulerMode == rebalanceSchedulerModeSovereignLive {
-			scanStatus = sovereignResult.Status
-			scanDetail = sovereignResult.Detail
-			scanCandidates = sovereignResult.Candidates
-			scanRemainingBudget = sovereignResult.BudgetRemainingSat
-			scanReasons = copyReasonCounts(sovereignResult.SkipReasons)
-			topScore = sovereignPlan.TopScore
 			queuedCount = sovereignResult.Selected
-			return
+		} else {
+			queuedCount = 0
 		}
+		return
 	}
 	candidatePlan := buildAndOrderRebalanceCandidates(rebalanceAutoScanCandidateInput{
 		Channels:                      snapshots,
@@ -8517,192 +8532,79 @@ func (s *RebalanceService) loadRecentSovereignTargetStats(ctx context.Context, c
 		recentWindow = slowWindow
 	}
 	since := now.Add(-recentWindow)
-	rows, err := s.db.Query(ctx, `
-with recent_jobs as (
-  select id, target_channel_id, status, reason, completed_at
-  from rebalance_jobs
-  where target_channel_id = any($1::bigint[])
-    and completed_at is not null
-    and completed_at >= $2
-    and status in ('succeeded','partial','failed')
-),
-attempt_totals as (
-  select
-    r.id,
-    coalesce(sum(a.amount_sat) filter (where a.status='succeeded'), 0) as sent_sat,
-    coalesce(sum(a.fee_paid_sat) filter (where a.status='succeeded'), 0) as fee_paid_sat
-  from recent_jobs r
-  left join rebalance_attempts a on a.job_id = r.id
-  group by r.id
-),
-forward_totals as (
-  select
-    r.id,
-    coalesce(sum(n.amount_sat) filter (where n.occurred_at < r.completed_at + interval '24 hours'), 0) as forward_24h_amount_sat,
-    coalesce(sum(case when n.fee_msat > 0 then n.fee_msat else n.fee_sat * 1000 end) filter (where n.occurred_at < r.completed_at + interval '24 hours'), 0)::bigint as forward_24h_fee_msat,
-    coalesce(sum(n.amount_sat) filter (where n.occurred_at < r.completed_at + ($3::int * interval '1 hour')), 0) as forward_window_amount_sat,
-    coalesce(sum(case when n.fee_msat > 0 then n.fee_msat else n.fee_sat * 1000 end) filter (where n.occurred_at < r.completed_at + ($3::int * interval '1 hour')), 0)::bigint as forward_window_fee_msat,
-    coalesce(sum(n.amount_sat), 0) as forward_slow_amount_sat,
-    coalesce(sum(case when n.fee_msat > 0 then n.fee_msat else n.fee_sat * 1000 end), 0)::bigint as forward_slow_fee_msat
-  from recent_jobs r
-  left join notifications n on n.type='forward'
-    and n.channel_id = r.target_channel_id
-    and n.occurred_at >= r.completed_at
-    and n.occurred_at < r.completed_at + ($4::int * interval '1 hour')
-  group by r.id
-),
-job_raw as (
-  select
-    r.target_channel_id,
-    r.status,
-    r.reason,
-    r.completed_at,
-    coalesce(a.sent_sat, 0) as sent_sat,
-    coalesce(a.fee_paid_sat, 0) as fee_paid_sat,
-    coalesce(f.forward_24h_amount_sat, 0) as forward_24h_amount_sat,
-    coalesce(f.forward_24h_fee_msat, 0) as forward_24h_fee_msat,
-    coalesce(f.forward_window_amount_sat, 0) as forward_window_amount_sat,
-    coalesce(f.forward_window_fee_msat, 0) as forward_window_fee_msat,
-    coalesce(f.forward_slow_amount_sat, 0) as forward_slow_amount_sat,
-    coalesce(f.forward_slow_fee_msat, 0) as forward_slow_fee_msat
-  from recent_jobs r
-  left join attempt_totals a on a.id = r.id
-  left join forward_totals f on f.id = r.id
-),
-job_economics as (
-  select
-    target_channel_id,
-    status,
-    reason,
-    completed_at,
-    sent_sat,
-    fee_paid_sat,
-    case
-      when sent_sat <= 0 or forward_24h_amount_sat <= 0 then 0
-      when forward_24h_amount_sat > sent_sat then sent_sat
-      else forward_24h_amount_sat
-    end as attributed_forward_24h_sat,
-    case
-      when sent_sat <= 0 or forward_24h_amount_sat <= 0 or forward_24h_fee_msat <= 0 then 0
-      when forward_24h_amount_sat > sent_sat then (forward_24h_fee_msat * sent_sat) / forward_24h_amount_sat
-      else forward_24h_fee_msat
-    end as attributed_forward_24h_fee_msat,
-    case
-      when sent_sat <= 0 or forward_window_amount_sat <= 0 then 0
-      when forward_window_amount_sat > sent_sat then sent_sat
-      else forward_window_amount_sat
-    end as attributed_forward_window_sat,
-    case
-      when sent_sat <= 0 or forward_window_amount_sat <= 0 or forward_window_fee_msat <= 0 then 0
-      when forward_window_amount_sat > sent_sat then (forward_window_fee_msat * sent_sat) / forward_window_amount_sat
-      else forward_window_fee_msat
-    end as attributed_forward_window_fee_msat,
-    case
-      when sent_sat <= 0 or forward_slow_amount_sat <= 0 then 0
-      when forward_slow_amount_sat > sent_sat then sent_sat
-      else forward_slow_amount_sat
-    end as attributed_forward_slow_sat,
-    case
-      when sent_sat <= 0 or forward_slow_amount_sat <= 0 or forward_slow_fee_msat <= 0 then 0
-      when forward_slow_amount_sat > sent_sat then (forward_slow_fee_msat * sent_sat) / forward_slow_amount_sat
-      else forward_slow_fee_msat
-    end as attributed_forward_slow_fee_msat
-  from job_raw
-)
-select
-  target_channel_id,
-  count(*) filter (where status in ('succeeded','partial','failed')) as jobs,
-  count(*) filter (where status in ('succeeded','partial')) as success_jobs,
-  count(*) filter (where status='failed') as failed_jobs,
-  count(*) filter (where status='failed' and reason='all sources failed') as all_sources_failed_jobs,
-  max(completed_at) filter (where status in ('succeeded','partial')) as last_success_at,
-  max(completed_at) filter (where status='failed') as last_fail_at,
-  count(*) filter (where sent_sat > 0) as sent_jobs,
-  coalesce(sum(sent_sat), 0) as sent_sat,
-  coalesce(sum(fee_paid_sat), 0) as fee_paid_sat,
-  coalesce(sum(attributed_forward_24h_sat), 0) as attributed_forward_24h_sat,
-  coalesce(sum(attributed_forward_24h_fee_msat), 0)::bigint as attributed_forward_24h_fee_msat,
-  coalesce(sum(attributed_forward_window_sat), 0) as attributed_forward_window_sat,
-  coalesce(sum(attributed_forward_window_fee_msat), 0)::bigint as attributed_forward_window_fee_msat,
-  coalesce(sum(attributed_forward_slow_sat), 0) as attributed_forward_slow_sat,
-  coalesce(sum(attributed_forward_slow_fee_msat), 0)::bigint as attributed_forward_slow_fee_msat
-from job_economics
-group by target_channel_id
-`, ids, since, attributionHours, slowHours)
+	attributionWindow := time.Duration(attributionHours) * time.Hour
+	contextWindow := slowWindow
+	if attributionWindow > contextWindow {
+		contextWindow = attributionWindow
+	}
+	if 24*time.Hour > contextWindow {
+		contextWindow = 24 * time.Hour
+	}
+	lots, forwards, err := s.loadRebalanceAttributionInputs(ctx, since.Add(-contextWindow), targetIDs)
 	if err != nil {
 		return summaries
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var targetID int64
-		var attempts int64
-		var successes int64
-		var failures int64
-		var allSourcesFailed int64
-		var lastSuccess pgtype.Timestamptz
-		var lastFail pgtype.Timestamptz
-		var sentJobs int64
-		var sentSat int64
-		var feePaidSat int64
-		var forward24hSat int64
-		var forward24hFeeMsat int64
-		var forwardWindowSat int64
-		var forwardWindowFeeMsat int64
-		var forwardSlowSat int64
-		var forwardSlowFeeMsat int64
-		if err := rows.Scan(
-			&targetID,
-			&attempts,
-			&successes,
-			&failures,
-			&allSourcesFailed,
-			&lastSuccess,
-			&lastFail,
-			&sentJobs,
-			&sentSat,
-			&feePaidSat,
-			&forward24hSat,
-			&forward24hFeeMsat,
-			&forwardWindowSat,
-			&forwardWindowFeeMsat,
-			&forwardSlowSat,
-			&forwardSlowFeeMsat,
-		); err != nil {
-			return summaries
-		}
-		if targetID <= 0 {
+	attributed24h := attributeRebalanceForwardsFIFO(lots, forwards, 24*time.Hour)
+	attributedWindow := attributeRebalanceForwardsFIFO(lots, forwards, attributionWindow)
+	attributedSlow := attributeRebalanceForwardsFIFO(lots, forwards, slowWindow)
+	type targetFeeTotals struct {
+		forward24hMsat    int64
+		forwardWindowMsat int64
+		forwardSlowMsat   int64
+	}
+	feeTotals := map[uint64]targetFeeTotals{}
+	for _, lot := range lots {
+		if lot.CompletedAt.Before(since) {
 			continue
 		}
-		key := uint64(targetID)
-		stat := summaries[key]
-		stat.TargetChannelID = key
+		stat, ok := summaries[lot.TargetChannelID]
+		if !ok {
+			continue
+		}
 		stat.RecentStatsLoaded = true
-		stat.RecentAttempts = int(attempts)
-		stat.RecentSuccesses = int(successes)
-		stat.RecentFailures = int(failures)
-		stat.RecentAllSourcesFailed = int(allSourcesFailed)
-		stat.RecentSentJobs = int(sentJobs)
-		stat.RecentSentSat = sentSat
-		stat.RecentRebalanceFeeSat = feePaidSat
-		stat.RecentForward24hAmountSat = forward24hSat
-		forward24hFeeSat := forward24hFeeMsat / 1000
-		stat.RecentForward24hFeeSat = forward24hFeeSat
-		stat.RecentRealizedNet24hSat = forward24hFeeSat - feePaidSat
-		stat.RecentForwardAmountSat = forwardWindowSat
-		forwardWindowFeeSat := forwardWindowFeeMsat / 1000
-		stat.RecentForwardFeeSat = forwardWindowFeeSat
-		stat.RecentRealizedNetSat = forwardWindowFeeSat - feePaidSat
-		stat.RecentForwardSlowAmountSat = forwardSlowSat
-		forwardSlowFeeSat := forwardSlowFeeMsat / 1000
-		stat.RecentForwardSlowFeeSat = forwardSlowFeeSat
-		stat.RecentRealizedNetSlowSat = forwardSlowFeeSat - feePaidSat
-		if lastSuccess.Valid {
-			stat.RecentLastSuccessAt = lastSuccess.Time
+		stat.RecentAttempts++
+		switch lot.Status {
+		case "succeeded", "partial":
+			stat.RecentSuccesses++
+			if stat.RecentLastSuccessAt.IsZero() || lot.CompletedAt.After(stat.RecentLastSuccessAt) {
+				stat.RecentLastSuccessAt = lot.CompletedAt
+			}
+		case "failed":
+			stat.RecentFailures++
+			if lot.Reason == "all sources failed" {
+				stat.RecentAllSourcesFailed++
+			}
+			if stat.RecentLastFailAt.IsZero() || lot.CompletedAt.After(stat.RecentLastFailAt) {
+				stat.RecentLastFailAt = lot.CompletedAt
+			}
 		}
-		if lastFail.Valid {
-			stat.RecentLastFailAt = lastFail.Time
+		if lot.SentSat > 0 {
+			stat.RecentSentJobs++
 		}
-		summaries[key] = stat
+		stat.RecentSentSat += lot.SentSat
+		stat.RecentRebalanceFeeSat += lot.FeePaidSat
+		attr24h := attributed24h[lot.JobID]
+		attrWindow := attributedWindow[lot.JobID]
+		attrSlow := attributedSlow[lot.JobID]
+		stat.RecentForward24hAmountSat += attr24h.ForwardAmountSat
+		stat.RecentForwardAmountSat += attrWindow.ForwardAmountSat
+		stat.RecentForwardSlowAmountSat += attrSlow.ForwardAmountSat
+		fees := feeTotals[lot.TargetChannelID]
+		fees.forward24hMsat += attr24h.ForwardFeeMsat
+		fees.forwardWindowMsat += attrWindow.ForwardFeeMsat
+		fees.forwardSlowMsat += attrSlow.ForwardFeeMsat
+		feeTotals[lot.TargetChannelID] = fees
+		summaries[lot.TargetChannelID] = stat
+	}
+	for targetID, stat := range summaries {
+		fees := feeTotals[targetID]
+		stat.RecentForward24hFeeSat = fees.forward24hMsat / 1000
+		stat.RecentRealizedNet24hSat = stat.RecentForward24hFeeSat - stat.RecentRebalanceFeeSat
+		stat.RecentForwardFeeSat = fees.forwardWindowMsat / 1000
+		stat.RecentRealizedNetSat = stat.RecentForwardFeeSat - stat.RecentRebalanceFeeSat
+		stat.RecentForwardSlowFeeSat = fees.forwardSlowMsat / 1000
+		stat.RecentRealizedNetSlowSat = stat.RecentForwardSlowFeeSat - stat.RecentRebalanceFeeSat
+		summaries[targetID] = stat
 	}
 	return summaries
 }
@@ -14518,12 +14420,6 @@ func (s *RebalanceService) fetchSovereignAutopilotEconomics7d(ctx context.Contex
 	if s.db == nil {
 		return rebalanceAutopilotEconomics7d{}, nil
 	}
-	var sentSat int64
-	var costSat int64
-	var forwardSat int64
-	var forwardFeeMsat int64
-	var forwardSlowSat int64
-	var forwardSlowFeeMsat int64
 	// Duas janelas, ambas vindas da config (UI): attribution_window mede a
 	// venda "rápida" (velocidade) e slow_seller_window mede a realização
 	// incluindo slow movers. O denominador (rebalance 7d) é o mesmo; muda só
@@ -14531,85 +14427,28 @@ func (s *RebalanceService) fetchSovereignAutopilotEconomics7d(ctx context.Contex
 	// garante slow_seller >= attribution.
 	attributionHours := sovereignAttributionWindowHoursForConfig(cfg)
 	slowHours := sovereignSlowSellerWindowHoursForConfig(cfg)
-	err := s.db.QueryRow(ctx, `
-with jobs as (
-  select id, target_channel_id, completed_at
-  from rebalance_jobs
-  where trigger_reason = $1
-    and completed_at is not null
-    and completed_at >= now() - interval '7 days'
-),
-attempt_totals as (
-  select
-    j.id,
-    coalesce(sum(a.amount_sat) filter (where a.status='succeeded'), 0) as sent_sat,
-    coalesce(sum(a.fee_paid_sat) filter (where a.status='succeeded'), 0) as fee_paid_sat
-  from jobs j
-  left join rebalance_attempts a on a.job_id = j.id
-  group by j.id
-),
-forward_totals as (
-  select
-    j.id,
-    coalesce(sum(n.amount_sat) filter (where n.occurred_at < j.completed_at + ($2::int * interval '1 hour')), 0) as forward_amount_sat,
-    coalesce(sum(case when n.fee_msat > 0 then n.fee_msat else n.fee_sat * 1000 end) filter (where n.occurred_at < j.completed_at + ($2::int * interval '1 hour')), 0)::bigint as forward_fee_msat,
-    coalesce(sum(n.amount_sat) filter (where n.occurred_at < j.completed_at + ($3::int * interval '1 hour')), 0) as forward_slow_amount_sat,
-    coalesce(sum(case when n.fee_msat > 0 then n.fee_msat else n.fee_sat * 1000 end) filter (where n.occurred_at < j.completed_at + ($3::int * interval '1 hour')), 0)::bigint as forward_slow_fee_msat
-  from jobs j
-  left join notifications n on n.type='forward'
-    and n.channel_id = j.target_channel_id
-    and n.occurred_at >= j.completed_at
-  group by j.id
-),
-job_raw as (
-  select
-    coalesce(a.sent_sat, 0) as sent_sat,
-    coalesce(a.fee_paid_sat, 0) as fee_paid_sat,
-    coalesce(f.forward_amount_sat, 0) as forward_amount_sat,
-    coalesce(f.forward_fee_msat, 0) as forward_fee_msat,
-    coalesce(f.forward_slow_amount_sat, 0) as forward_slow_amount_sat,
-    coalesce(f.forward_slow_fee_msat, 0) as forward_slow_fee_msat
-  from jobs j
-  left join attempt_totals a on a.id = j.id
-  left join forward_totals f on f.id = j.id
-),
-job_economics as (
-  select
-    sent_sat,
-    fee_paid_sat,
-    case
-      when sent_sat <= 0 or forward_amount_sat <= 0 then 0
-      when forward_amount_sat > sent_sat then sent_sat
-      else forward_amount_sat
-    end as attributed_forward_sat,
-    case
-      when sent_sat <= 0 or forward_amount_sat <= 0 or forward_fee_msat <= 0 then 0
-      when forward_amount_sat > sent_sat then (forward_fee_msat * sent_sat) / forward_amount_sat
-      else forward_fee_msat
-    end as attributed_forward_fee_msat,
-    case
-      when sent_sat <= 0 or forward_slow_amount_sat <= 0 then 0
-      when forward_slow_amount_sat > sent_sat then sent_sat
-      else forward_slow_amount_sat
-    end as attributed_forward_slow_sat,
-    case
-      when sent_sat <= 0 or forward_slow_amount_sat <= 0 or forward_slow_fee_msat <= 0 then 0
-      when forward_slow_amount_sat > sent_sat then (forward_slow_fee_msat * sent_sat) / forward_slow_amount_sat
-      else forward_slow_fee_msat
-    end as attributed_forward_slow_fee_msat
-  from job_raw
-)
-select
-  coalesce(sum(sent_sat), 0) as sent_sat,
-  coalesce(sum(fee_paid_sat), 0) as cost_sat,
-  coalesce(sum(attributed_forward_sat), 0) as forward_sat,
-  coalesce(sum(attributed_forward_fee_msat), 0)::bigint as forward_fee_msat,
-  coalesce(sum(attributed_forward_slow_sat), 0) as forward_slow_sat,
-  coalesce(sum(attributed_forward_slow_fee_msat), 0)::bigint as forward_slow_fee_msat
-from job_economics
-`, rebalanceSovereignReason, attributionHours, slowHours).Scan(&sentSat, &costSat, &forwardSat, &forwardFeeMsat, &forwardSlowSat, &forwardSlowFeeMsat)
+	snapshot, err := s.loadSovereignAttributionSnapshot(ctx, cfg)
 	if err != nil {
 		return rebalanceAutopilotEconomics7d{}, err
+	}
+	var sentSat int64
+	var costSat int64
+	var forwardSat int64
+	var forwardFeeMsat int64
+	var forwardSlowSat int64
+	var forwardSlowFeeMsat int64
+	for _, lot := range snapshot.Lots {
+		if lot.TriggerReason != rebalanceSovereignReason || lot.CompletedAt.Before(snapshot.MetricSince) {
+			continue
+		}
+		sentSat += lot.SentSat
+		costSat += lot.FeePaidSat
+		fast := snapshot.Fast[lot.JobID]
+		forwardSat += fast.ForwardAmountSat
+		forwardFeeMsat += fast.ForwardFeeMsat
+		slow := snapshot.Slow[lot.JobID]
+		forwardSlowSat += slow.ForwardAmountSat
+		forwardSlowFeeMsat += slow.ForwardFeeMsat
 	}
 	forwardFeeSat := forwardFeeMsat / 1000
 	forwardSlowFeeSat := forwardSlowFeeMsat / 1000
@@ -15866,46 +15705,46 @@ group by j.id
 		jobs[idx].Forward24hCount = forward24hCount
 		jobs[idx].Forward24hAmountSat = forward24hAmount
 		jobs[idx].Forward24hFeeSat = fee24hMsat / 1000
-		job := &jobs[idx]
-		job.AttributedForward1hAmountSat, job.AttributedForward1hFeeSat, job.RealizedNet1hSat = attributedForwardEconomics(
-			job.ActualSentSat,
-			job.ActualRebalanceFeeSat,
-			job.Forward1hAmountSat,
-			job.Forward1hFeeSat,
-		)
-		job.AttributedForward6hAmountSat, job.AttributedForward6hFeeSat, job.RealizedNet6hSat = attributedForwardEconomics(
-			job.ActualSentSat,
-			job.ActualRebalanceFeeSat,
-			job.Forward6hAmountSat,
-			job.Forward6hFeeSat,
-		)
-		job.AttributedForward24hAmountSat, job.AttributedForward24hFeeSat, job.RealizedNet24hSat = attributedForwardEconomics(
-			job.ActualSentSat,
-			job.ActualRebalanceFeeSat,
-			job.Forward24hAmountSat,
-			job.Forward24hFeeSat,
-		)
+	}
+
+	var earliestCompleted time.Time
+	targetIDs := make([]uint64, 0, len(jobs))
+	for _, job := range jobs {
+		completedAt, err := time.Parse(time.RFC3339, job.CompletedAt)
+		if err != nil {
+			continue
+		}
+		if earliestCompleted.IsZero() || completedAt.Before(earliestCompleted) {
+			earliestCompleted = completedAt
+		}
+		targetIDs = append(targetIDs, job.TargetChannelID)
+	}
+	if earliestCompleted.IsZero() {
+		return jobs
+	}
+	lots, forwards, err := s.loadRebalanceAttributionInputs(ctx, earliestCompleted.Add(-24*time.Hour), targetIDs)
+	if err != nil {
+		return jobs
+	}
+	attributed1h := attributeRebalanceForwardsFIFO(lots, forwards, time.Hour)
+	attributed6h := attributeRebalanceForwardsFIFO(lots, forwards, 6*time.Hour)
+	attributed24h := attributeRebalanceForwardsFIFO(lots, forwards, 24*time.Hour)
+	for i := range jobs {
+		job := &jobs[i]
+		attr1h := attributed1h[job.ID]
+		job.AttributedForward1hAmountSat = attr1h.ForwardAmountSat
+		job.AttributedForward1hFeeSat = attr1h.ForwardFeeMsat / 1000
+		job.RealizedNet1hSat = job.AttributedForward1hFeeSat - job.ActualRebalanceFeeSat
+		attr6h := attributed6h[job.ID]
+		job.AttributedForward6hAmountSat = attr6h.ForwardAmountSat
+		job.AttributedForward6hFeeSat = attr6h.ForwardFeeMsat / 1000
+		job.RealizedNet6hSat = job.AttributedForward6hFeeSat - job.ActualRebalanceFeeSat
+		attr24h := attributed24h[job.ID]
+		job.AttributedForward24hAmountSat = attr24h.ForwardAmountSat
+		job.AttributedForward24hFeeSat = attr24h.ForwardFeeMsat / 1000
+		job.RealizedNet24hSat = job.AttributedForward24hFeeSat - job.ActualRebalanceFeeSat
 	}
 	return jobs
-}
-
-func attributedForwardEconomics(sentSat int64, feePaidSat int64, forwardAmountSat int64, forwardFeeSat int64) (int64, int64, int64) {
-	if sentSat <= 0 {
-		return 0, 0, 0
-	}
-	if forwardAmountSat <= 0 || forwardFeeSat <= 0 {
-		return 0, 0, -feePaidSat
-	}
-	attributedAmountSat := forwardAmountSat
-	attributedFeeSat := forwardFeeSat
-	if forwardAmountSat > sentSat {
-		attributedAmountSat = sentSat
-		attributedFeeSat = (forwardFeeSat * sentSat) / forwardAmountSat
-	}
-	if attributedFeeSat < 0 {
-		attributedFeeSat = 0
-	}
-	return attributedAmountSat, attributedFeeSat, attributedFeeSat - feePaidSat
 }
 
 func (s *RebalanceService) SetChannelTarget(ctx context.Context, channelID uint64, channelPoint string, targetPct float64) error {

--- a/lightningos-light/internal/server/rebalance_service_test.go
+++ b/lightningos-light/internal/server/rebalance_service_test.go
@@ -1100,19 +1100,86 @@ func TestMarkAndTakeExplorationJob(t *testing.T) {
 	svc := NewRebalanceService(nil, nil, nil)
 	svc.markExplorationJob(123, 456)
 
-	channelID, ok := svc.takeExplorationJob(123)
+	channelID, ok := svc.takeExplorationJob(context.Background(), 123)
 	if !ok || channelID != 456 {
 		t.Fatalf("expected (456, true), got (%d, %v)", channelID, ok)
 	}
 	// Second take returns false.
-	_, ok = svc.takeExplorationJob(123)
+	_, ok = svc.takeExplorationJob(context.Background(), 123)
 	if ok {
 		t.Fatalf("expected take to be one-shot")
 	}
 	// Non-existent job returns false.
-	_, ok = svc.takeExplorationJob(999)
+	_, ok = svc.takeExplorationJob(context.Background(), 999)
 	if ok {
 		t.Fatalf("expected unmarked job to return false")
+	}
+}
+
+func TestExplorationBurnoutCanRecurAfterSuccess(t *testing.T) {
+	svc := NewRebalanceService(nil, nil, nil)
+	const channelID uint64 = 77
+	base := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	svc.recordExplorationOutcome(channelID, true, base)
+	for i := 1; i <= sovereignExplorationBurnoutMinAttempts; i++ {
+		svc.recordExplorationOutcome(channelID, false, base.Add(time.Duration(i)*time.Minute))
+	}
+	if !svc.isInExplorationBurnout(channelID, base.Add(10*time.Minute)) {
+		t.Fatal("five failures after a success must start a fresh burnout window")
+	}
+}
+
+func TestExplorationBurnoutTargetsFromPersistedOutcomes(t *testing.T) {
+	const channelID uint64 = 88
+	base := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	outcomes := []explorationOutcome{{ChannelID: channelID, Succeeded: true, FinishedAt: base}}
+	for i := 1; i <= sovereignExplorationBurnoutMinAttempts; i++ {
+		outcomes = append(outcomes, explorationOutcome{
+			ChannelID:  channelID,
+			Succeeded:  false,
+			FinishedAt: base.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	got := explorationBurnoutTargetsFromOutcomes(outcomes, base.Add(10*time.Minute))
+	if !got[channelID] {
+		t.Fatal("persisted failures after the last success must restore burnout after restart")
+	}
+	got = explorationBurnoutTargetsFromOutcomes(outcomes, base.Add(sovereignExplorationBurnoutDuration+time.Hour))
+	if got[channelID] {
+		t.Fatal("persisted burnout must expire after its configured duration")
+	}
+}
+
+func TestSovereignExplorationEconomicsAreSeparatedFromTotal(t *testing.T) {
+	base := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	snapshot := sovereignAttributionSnapshot{
+		MetricSince: base.Add(-time.Hour),
+		Lots: []rebalanceAttributionLot{
+			{JobID: 1, TriggerReason: rebalanceSovereignReason, CompletedAt: base, SentSat: 100_000, FeePaidSat: 100},
+			{JobID: 2, TriggerReason: rebalanceSovereignReason, CompletedAt: base, SentSat: 50_000, FeePaidSat: 80, ExplorationSlot: true},
+		},
+		Fast: map[int64]rebalanceAttributionResult{
+			1: {ForwardAmountSat: 80_000, ForwardFeeMsat: 200_000},
+			2: {ForwardAmountSat: 10_000, ForwardFeeMsat: 40_000},
+		},
+		Slow: map[int64]rebalanceAttributionResult{
+			1: {ForwardAmountSat: 90_000, ForwardFeeMsat: 240_000},
+			2: {ForwardAmountSat: 25_000, ForwardFeeMsat: 100_000},
+		},
+	}
+	total := sovereignAutopilotEconomicsFromSnapshot(snapshot, 72, 168, false)
+	exploration := sovereignAutopilotEconomicsFromSnapshot(snapshot, 72, 168, true)
+	if total.JobCount != 2 || total.RebalanceAmountSat != 150_000 || total.RealizedNetSat != 60 {
+		t.Fatalf("unexpected total economics: %+v", total)
+	}
+	if exploration.JobCount != 1 || exploration.RebalanceAmountSat != 50_000 || exploration.RebalanceCostSat != 80 {
+		t.Fatalf("unexpected exploration economics: %+v", exploration)
+	}
+	if exploration.ForwardAmountSat != 10_000 || exploration.RealizedNetSat != -40 || exploration.SellThrough != 0.2 {
+		t.Fatalf("unexpected exploration realized economics: %+v", exploration)
+	}
+	if exploration.RealizedNetSlowSat != 20 || exploration.SellThroughSlow != 0.5 {
+		t.Fatalf("unexpected exploration slow economics: %+v", exploration)
 	}
 }
 

--- a/lightningos-light/internal/server/rebalance_service_test.go
+++ b/lightningos-light/internal/server/rebalance_service_test.go
@@ -3681,24 +3681,6 @@ func TestApplySovereignRiskAdjustedScoresUsesRealizedEconomics(t *testing.T) {
 	}
 }
 
-func TestAttributedForwardEconomicsCapsForwardProfitToSentAmount(t *testing.T) {
-	amount, fee, net := attributedForwardEconomics(100_000, 50, 1_000_000, 500)
-	if amount != 100_000 {
-		t.Fatalf("expected attributed amount capped to sent sats, got %d", amount)
-	}
-	if fee != 50 {
-		t.Fatalf("expected proportional attributed fee, got %d", fee)
-	}
-	if net != 0 {
-		t.Fatalf("expected capped net to pay back cost exactly, got %d", net)
-	}
-
-	amount, fee, net = attributedForwardEconomics(0, 0, 1_000_000, 500)
-	if amount != 0 || fee != 0 || net != 0 {
-		t.Fatalf("expected failed no-send job to have no attributed economics, got amount=%d fee=%d net=%d", amount, fee, net)
-	}
-}
-
 func TestExecuteSovereignAutopilotSkipsUnsoldPaidLiquidityAndContinues(t *testing.T) {
 	svc := NewRebalanceService(nil, nil, nil)
 	cfg := defaultRebalanceConfig()

--- a/lightningos-light/ui/src/components/rebalance/types.ts
+++ b/lightningos-light/ui/src/components/rebalance/types.ts
@@ -240,6 +240,15 @@ export type RebalanceOverview = {
   sovereign_sellthrough_slow_7d?: number
   sovereign_sellthrough_window_hours?: number
   sovereign_sellthrough_slow_window_hours?: number
+  sovereign_exploration_jobs_7d?: number
+  sovereign_exploration_rebalance_amount_7d_sat?: number
+  sovereign_exploration_rebalance_cost_7d_sat?: number
+  sovereign_exploration_forward_amount_7d_sat?: number
+  sovereign_exploration_forward_fee_7d_sat?: number
+  sovereign_exploration_realized_net_7d_sat?: number
+  sovereign_exploration_sellthrough_7d?: number
+  sovereign_exploration_realized_net_slow_7d_sat?: number
+  sovereign_exploration_sellthrough_slow_7d?: number
   jobs_24h?: number
   success_jobs_24h?: number
   job_success_rate_24h?: number
@@ -420,6 +429,7 @@ export type RebalanceJob = {
   sovereign_expected_profit_sat?: number
   sovereign_budget_cost_sat?: number
   sovereign_score?: number
+  exploration_slot?: boolean
   actual_sent_sat?: number
   actual_rebalance_fee_sat?: number
   forward_1h_count?: number

--- a/lightningos-light/ui/src/i18n/en.json
+++ b/lightningos-light/ui/src/i18n/en.json
@@ -5052,6 +5052,7 @@
         "autopilotForwardFeePpm": "Autopilot forward fee 7d",
         "autopilotForwardFee": "{{fee}} over {{amount}} sold",
         "autopilotRealized7d": "Autopilot realized 7d: {{net}} · sell-through {{sellthrough}}",
+        "autopilotExplorationRealized7d": "Exploration 7d ({{jobs}} jobs): {{moved}} moved · {{net}} net · {{sellthrough}} sell-through",
         "successAttempts24h": "Success attempts: {{value}}",
         "successAmount24h": "Moved on success: {{value}}",
         "successAvgAmount24h": "Avg success size: {{value}}",
@@ -5565,6 +5566,7 @@
       "title": "Recent History",
       "last24h": "Last 24h",
       "details": "Details",
+      "explorationSlot": "exploration",
       "source": {
         "auto": "auto",
         "manual": "manual"

--- a/lightningos-light/ui/src/i18n/pt-BR.json
+++ b/lightningos-light/ui/src/i18n/pt-BR.json
@@ -5052,6 +5052,7 @@
         "autopilotForwardFeePpm": "Fee média forwards 7d",
         "autopilotForwardFee": "{{fee}} em {{amount}} vendidos",
         "autopilotRealized7d": "Realizado autopilot 7d: {{net}} · sell-through {{sellthrough}}",
+        "autopilotExplorationRealized7d": "Exploração 7d ({{jobs}} jobs): {{moved}} movidos · líquido {{net}} · sell-through {{sellthrough}}",
         "successAttempts24h": "Tentativas com sucesso: {{value}}",
         "successAmount24h": "Movido em sucessos: {{value}}",
         "successAvgAmount24h": "Tamanho médio de sucesso: {{value}}",
@@ -5565,6 +5566,7 @@
       "title": "Histórico recente",
       "last24h": "Últimas 24h",
       "details": "Detalhes",
+      "explorationSlot": "exploração",
       "source": {
         "auto": "auto",
         "manual": "manual"

--- a/lightningos-light/ui/src/pages/RebalanceCenter.tsx
+++ b/lightningos-light/ui/src/pages/RebalanceCenter.tsx
@@ -2042,6 +2042,14 @@ export default function RebalanceCenter() {
                 sellthrough: formatPct((overview.sovereign_sellthrough_7d ?? 0) * 100)
               })}
             </p>
+            <p className="text-xs text-violet-200/75">
+              {t('rebalanceCenter.overview.autopilotExplorationRealized7d', {
+                jobs: formatter.format(overview.sovereign_exploration_jobs_7d ?? 0),
+                moved: formatSats(overview.sovereign_exploration_rebalance_amount_7d_sat ?? 0),
+                net: formatSats(overview.sovereign_exploration_realized_net_7d_sat ?? 0),
+                sellthrough: formatPct((overview.sovereign_exploration_sellthrough_7d ?? 0) * 100)
+              })}
+            </p>
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
               <div className="rounded-xl border border-white/10 bg-white/5 p-2.5 space-y-1">
                 <p className="text-[10px] uppercase tracking-wide text-fog/60">{t('rebalanceCenter.overview.paybackGroupRebalanced')}</p>
@@ -4568,6 +4576,11 @@ export default function RebalanceCenter() {
                         : job.source === 'manual'
                           ? t('rebalanceCenter.history.source.manual')
                           : job.source}{' '}
+                      {job.exploration_slot && (
+                        <span className="rounded-full border border-violet-300/30 bg-violet-300/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-violet-200">
+                          {t('rebalanceCenter.history.explorationSlot')}
+                        </span>
+                      )}{' '}
                       <span className="text-xs text-fog/50">
                          · {formatTimestamp(job.completed_at || job.created_at)}
                       </span>


### PR DESCRIPTION
## Summary

- attributes forward revenue FIFO per target so overlapping jobs cannot count the same forward twice
- makes `sovereign_shadow` a pure scheduler dry-run
- persists the Sovereign exploration marker before execution, removing a completion race
- restores exploration burnout across Manager restarts and fixes streak reset after a success
- exposes exploration jobs in queue/history and separate 7-day exploration economics in Overview/UI

The adaptive scarcity/exploration behavior is intentionally preserved: exploration still expands when candidate supply is small, while repeated dead-end targets receive the existing temporary burnout.

## Validation

- `go test -p 1 ./...`
- `npm.cmd run build`
- LOS-TEST2: Linux binary checksum verified, schema migration/startup completed, Manager active with zero restarts, authenticated Overview and History endpoints healthy
- LOS-TEST2 rollback binary retained as `/opt/lightningos/manager/lightningos-manager.pre-963be80a`

## Rollout

Operational effectiveness must be measured on `jvx-minipc01`. The exploration-specific 7-day series begins filling only after deployment because older jobs do not carry the persisted marker. No production code deployment was performed during this validation.