### PR TITLE
0.5.22-Beta: Magma - migrar as mutations do vendedor para o endpoint novo da Amboss

### DIFF
--- a/lightningos-light/internal/server/magma_amboss.go
+++ b/lightningos-light/internal/server/magma_amboss.go
@@ -14,7 +14,13 @@ import (
 )
 
 const (
-	magmaAmbossURL     = "https://api.amboss.space/graphql"
+	magmaAmbossURL = "https://api.amboss.space/graphql"
+	// The seller mutations are moving here. Amboss confirmed the flat
+	// api.amboss.space schema is being deprecated in favour of this namespaced
+	// one, and sellerAcceptOrder on the old endpoint is already returning
+	// INTERNAL_SERVER_ERROR - 66 refusals on a single order in one morning,
+	// while the same invoice submitted through the new endpoint's UI succeeded.
+	magmaMarketURL     = "https://magma.amboss.tech/graphql"
 	magmaAmbossTimeout = 25 * time.Second
 )
 
@@ -313,17 +319,34 @@ type MagmaMarketSummary struct {
 
 type magmaAmbossClient struct {
 	endpoint string
-	http     *http.Client
+	// marketEndpoint is the replacement API. Both are held because the migration
+	// is partial on purpose: only the call that is actually broken moves, so a
+	// problem on the new endpoint cannot take working operations down with it.
+	marketEndpoint string
+	http           *http.Client
 }
 
 func newMagmaAmbossClient() *magmaAmbossClient {
 	return &magmaAmbossClient{
-		endpoint: magmaAmbossURL,
-		http:     &http.Client{Timeout: magmaAmbossTimeout},
+		endpoint:       magmaAmbossURL,
+		marketEndpoint: magmaMarketURL,
+		http:           &http.Client{Timeout: magmaAmbossTimeout},
 	}
 }
 
 func (c *magmaAmbossClient) do(ctx context.Context, token, query string, variables map[string]any, out any) error {
+	return c.doAt(ctx, c.endpoint, token, query, variables, out)
+}
+
+// doMarket talks to the replacement API. Same credential - the token from the
+// Amboss dashboard authenticates against both, which was verified before any of
+// this was written - and the same error handling, so a failure there is reported
+// with the code and path exactly as one from the old endpoint is.
+func (c *magmaAmbossClient) doMarket(ctx context.Context, token, query string, variables map[string]any, out any) error {
+	return c.doAt(ctx, c.marketEndpoint, token, query, variables, out)
+}
+
+func (c *magmaAmbossClient) doAt(ctx context.Context, endpoint, token, query string, variables map[string]any, out any) error {
 	if strings.TrimSpace(token) == "" {
 		return errors.New("Amboss API token is not configured")
 	}
@@ -335,7 +358,7 @@ func (c *magmaAmbossClient) do(ctx context.Context, token, query string, variabl
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -518,8 +541,14 @@ func (c *magmaAmbossClient) SellerOrders(ctx context.Context, token string) ([]M
 // has been running these against the live API, so the variable names below are
 // deliberately verbatim rather than tidied up.
 const (
+	// Deprecated. Kept only so the fallback below has something to call.
 	magmaAcceptOrderMutation = `mutation AcceptOrder($sellerAcceptOrderId: String!, $request: String!) {
   sellerAcceptOrder(id: $sellerAcceptOrderId, request: $request)
+}`
+	// The replacement. The new schema is namespaced rather than flat, and the
+	// arguments arrive in an input object instead of positionally.
+	magmaMarketAcceptOrderMutation = `mutation AcceptOrder($input: SellerAcceptOrdersInput!) {
+  market { order { seller { accept(input: $input) { success } } } }
 }`
 	magmaRejectOrderMutation = `mutation RejectOrder($sellerRejectOrderId: String!) {
   sellerRejectOrder(id: $sellerRejectOrderId)
@@ -540,16 +569,48 @@ func (c *magmaAmbossClient) AcceptOrder(ctx context.Context, token, orderID, pay
 	if paymentRequest == "" {
 		return errors.New("payment request required")
 	}
-	var result struct {
-		SellerAcceptOrder any `json:"sellerAcceptOrder"`
+	var market struct {
+		Market struct {
+			Order struct {
+				Seller struct {
+					Accept struct {
+						Success bool `json:"success"`
+					} `json:"accept"`
+				} `json:"seller"`
+			} `json:"order"`
+		} `json:"market"`
 	}
-	if err := c.do(ctx, token, magmaAcceptOrderMutation, map[string]any{
-		"sellerAcceptOrderId": orderID,
-		"request":             paymentRequest,
-	}, &result); err != nil {
+	err := c.doMarket(ctx, token, magmaMarketAcceptOrderMutation, map[string]any{
+		"input": map[string]any{"order_id": orderID, "payment_request": paymentRequest},
+	}, &market)
+	if err == nil {
+		if !market.Market.Order.Seller.Accept.Success {
+			return fmt.Errorf("Amboss did not accept the invoice for order %s", orderID)
+		}
+		return nil
+	}
+	// A bad credential is the one failure the old endpoint cannot rescue, and
+	// retrying it there would just spend the token against a second host.
+	if errors.Is(err, errMagmaUnauthorized) {
 		return err
 	}
-	if !magmaMutationSucceeded(result.SellerAcceptOrder) {
+
+	// Fall back to the deprecated endpoint. The new one is the right target, but
+	// it has no track record here yet, and an accept that never lands costs a
+	// sale and a SELLER_FAILED_TO_REACT. Two chances at it is worth one extra
+	// request.
+	var legacy struct {
+		SellerAcceptOrder any `json:"sellerAcceptOrder"`
+	}
+	if legacyErr := c.do(ctx, token, magmaAcceptOrderMutation, map[string]any{
+		"sellerAcceptOrderId": orderID,
+		"request":             paymentRequest,
+	}, &legacy); legacyErr != nil {
+		// Report the new endpoint's error: it is the one that matters now, and
+		// the deprecated endpoint's failure is expected rather than diagnostic.
+		return err
+	}
+	if !magmaMutationSucceeded(legacy.SellerAcceptOrder) {
 		return fmt.Errorf("Amboss did not accept the invoice for order %s", orderID)
 	}
 	return nil

--- a/lightningos-light/internal/server/magma_amboss.go
+++ b/lightningos-light/internal/server/magma_amboss.go
@@ -550,6 +550,16 @@ const (
 	magmaMarketAcceptOrderMutation = `mutation AcceptOrder($input: SellerAcceptOrdersInput!) {
   market { order { seller { accept(input: $input) { success } } } }
 }`
+	magmaMarketRejectOrderMutation = `mutation RejectOrder($input: SellerRejectOrdersInput!) {
+  market { order { seller { reject(input: $input) { success } } } }
+}`
+	// tx_id keeps the legacy format. Amboss documents it as TXID:OUTPUT_INDEX
+	// and states "the field is named tx_id but the format is unchanged", which
+	// is the one detail worth having in writing: submitting a channel point the
+	// wrong way is the failure their own UI warns costs reputation heavily.
+	magmaMarketAddTransactionMutation = `mutation AddTransaction($input: SellerAddTransactionInput!) {
+  market { order { seller { add_transaction(input: $input) { success } } } }
+}`
 	magmaRejectOrderMutation = `mutation RejectOrder($sellerRejectOrderId: String!) {
   sellerRejectOrder(id: $sellerRejectOrderId)
 }`
@@ -557,6 +567,58 @@ const (
   sellerAddTransaction(id: $sellerAddTransactionId, transaction: $transaction)
 }`
 )
+
+// sellerCall runs a seller mutation against the replacement endpoint and, only
+// when that endpoint itself failed, retries it against the deprecated one.
+//
+// The two failure modes have to stay apart. An endpoint that errors might work
+// elsewhere; an endpoint that answers cleanly and says no will say no anywhere,
+// and retrying that would turn one refusal into two requests and the same
+// outcome. So each call reports (accepted, err): err is the endpoint failing,
+// accepted=false is the endpoint answering.
+//
+// A rejected credential never falls back either - the old endpoint cannot
+// rescue a bad token, and trying would spend it against a second host.
+func (c *magmaAmbossClient) sellerCall(
+	market func() (bool, error), legacy func() (bool, error), refused error,
+) error {
+	accepted, err := market()
+	if err == nil {
+		if !accepted {
+			return refused
+		}
+		return nil
+	}
+	if errors.Is(err, errMagmaUnauthorized) {
+		return err
+	}
+	accepted, legacyErr := legacy()
+	if legacyErr != nil {
+		// Report the replacement's error: it is the one that matters now, and
+		// the deprecated endpoint failing is expected rather than diagnostic.
+		return err
+	}
+	if !accepted {
+		return refused
+	}
+	return nil
+}
+
+// magmaMarketSuccess is the shape every seller mutation on the new endpoint
+// returns, under the namespace that names the operation.
+type magmaMarketSuccess struct {
+	Market struct {
+		Order struct {
+			Seller map[string]struct {
+				Success bool `json:"success"`
+			} `json:"seller"`
+		} `json:"order"`
+	} `json:"market"`
+}
+
+func (m magmaMarketSuccess) ok(operation string) bool {
+	return m.Market.Order.Seller[operation].Success
+}
 
 // AcceptOrder hands Amboss the bolt11 invoice the buyer must pay. The mutation
 // argument is named "request" and it takes the payment request, not the hash.
@@ -569,51 +631,26 @@ func (c *magmaAmbossClient) AcceptOrder(ctx context.Context, token, orderID, pay
 	if paymentRequest == "" {
 		return errors.New("payment request required")
 	}
-	var market struct {
-		Market struct {
-			Order struct {
-				Seller struct {
-					Accept struct {
-						Success bool `json:"success"`
-					} `json:"accept"`
-				} `json:"seller"`
-			} `json:"order"`
-		} `json:"market"`
-	}
-	err := c.doMarket(ctx, token, magmaMarketAcceptOrderMutation, map[string]any{
-		"input": map[string]any{"order_id": orderID, "payment_request": paymentRequest},
-	}, &market)
-	if err == nil {
-		if !market.Market.Order.Seller.Accept.Success {
-			return fmt.Errorf("Amboss did not accept the invoice for order %s", orderID)
-		}
-		return nil
-	}
-	// A bad credential is the one failure the old endpoint cannot rescue, and
-	// retrying it there would just spend the token against a second host.
-	if errors.Is(err, errMagmaUnauthorized) {
-		return err
-	}
-
-	// Fall back to the deprecated endpoint. The new one is the right target, but
-	// it has no track record here yet, and an accept that never lands costs a
-	// sale and a SELLER_FAILED_TO_REACT. Two chances at it is worth one extra
-	// request.
-	var legacy struct {
-		SellerAcceptOrder any `json:"sellerAcceptOrder"`
-	}
-	if legacyErr := c.do(ctx, token, magmaAcceptOrderMutation, map[string]any{
-		"sellerAcceptOrderId": orderID,
-		"request":             paymentRequest,
-	}, &legacy); legacyErr != nil {
-		// Report the new endpoint's error: it is the one that matters now, and
-		// the deprecated endpoint's failure is expected rather than diagnostic.
-		return err
-	}
-	if !magmaMutationSucceeded(legacy.SellerAcceptOrder) {
-		return fmt.Errorf("Amboss did not accept the invoice for order %s", orderID)
-	}
-	return nil
+	refused := fmt.Errorf("Amboss did not accept the invoice for order %s", orderID)
+	return c.sellerCall(
+		func() (bool, error) {
+			var out magmaMarketSuccess
+			err := c.doMarket(ctx, token, magmaMarketAcceptOrderMutation, map[string]any{
+				"input": map[string]any{"order_id": orderID, "payment_request": paymentRequest},
+			}, &out)
+			return out.ok("accept"), err
+		},
+		func() (bool, error) {
+			var out struct {
+				SellerAcceptOrder any `json:"sellerAcceptOrder"`
+			}
+			err := c.do(ctx, token, magmaAcceptOrderMutation, map[string]any{
+				"sellerAcceptOrderId": orderID,
+				"request":             paymentRequest,
+			}, &out)
+			return magmaMutationSucceeded(out.SellerAcceptOrder), err
+		},
+		refused)
 }
 
 // RejectOrder declines an order explicitly. Letting an unwanted order lapse is
@@ -623,18 +660,25 @@ func (c *magmaAmbossClient) RejectOrder(ctx context.Context, token, orderID stri
 	if orderID == "" {
 		return errors.New("order id required")
 	}
-	var result struct {
-		SellerRejectOrder any `json:"sellerRejectOrder"`
-	}
-	if err := c.do(ctx, token, magmaRejectOrderMutation, map[string]any{
-		"sellerRejectOrderId": orderID,
-	}, &result); err != nil {
-		return err
-	}
-	if !magmaMutationSucceeded(result.SellerRejectOrder) {
-		return fmt.Errorf("Amboss did not register the rejection of order %s", orderID)
-	}
-	return nil
+	refused := fmt.Errorf("Amboss did not register the rejection of order %s", orderID)
+	return c.sellerCall(
+		func() (bool, error) {
+			var out magmaMarketSuccess
+			err := c.doMarket(ctx, token, magmaMarketRejectOrderMutation, map[string]any{
+				"input": map[string]any{"order_id": orderID},
+			}, &out)
+			return out.ok("reject"), err
+		},
+		func() (bool, error) {
+			var out struct {
+				SellerRejectOrder any `json:"sellerRejectOrder"`
+			}
+			err := c.do(ctx, token, magmaRejectOrderMutation, map[string]any{
+				"sellerRejectOrderId": orderID,
+			}, &out)
+			return magmaMutationSucceeded(out.SellerRejectOrder), err
+		},
+		refused)
 }
 
 // AddTransaction confirms the funding outpoint. It takes the full channel point
@@ -648,19 +692,26 @@ func (c *magmaAmbossClient) AddTransaction(ctx context.Context, token, orderID, 
 	if !magmaLooksLikeChannelPoint(channelPoint) {
 		return fmt.Errorf("channel point must be txid:vout, got %q", channelPoint)
 	}
-	var result struct {
-		SellerAddTransaction any `json:"sellerAddTransaction"`
-	}
-	if err := c.do(ctx, token, magmaAddTransactionMutation, map[string]any{
-		"sellerAddTransactionId": orderID,
-		"transaction":            channelPoint,
-	}, &result); err != nil {
-		return err
-	}
-	if !magmaMutationSucceeded(result.SellerAddTransaction) {
-		return fmt.Errorf("Amboss did not register the channel point for order %s", orderID)
-	}
-	return nil
+	refused := fmt.Errorf("Amboss did not register the channel point for order %s", orderID)
+	return c.sellerCall(
+		func() (bool, error) {
+			var out magmaMarketSuccess
+			err := c.doMarket(ctx, token, magmaMarketAddTransactionMutation, map[string]any{
+				"input": map[string]any{"order_id": orderID, "tx_id": channelPoint},
+			}, &out)
+			return out.ok("add_transaction"), err
+		},
+		func() (bool, error) {
+			var out struct {
+				SellerAddTransaction any `json:"sellerAddTransaction"`
+			}
+			err := c.do(ctx, token, magmaAddTransactionMutation, map[string]any{
+				"sellerAddTransactionId": orderID,
+				"transaction":            channelPoint,
+			}, &out)
+			return magmaMutationSucceeded(out.SellerAddTransaction), err
+		},
+		refused)
 }
 
 // magmaMutationSucceeded reads the scalar these mutations return. Amboss answers

--- a/lightningos-light/internal/server/magma_api_v2_test.go
+++ b/lightningos-light/internal/server/magma_api_v2_test.go
@@ -147,3 +147,131 @@ func TestMagmaAcceptTreatsSuccessFalseAsRefusal(t *testing.T) {
 		t.Fatal("success:false must be reported as a refusal")
 	}
 }
+
+
+// Reject moves too. It is what the approval deadline calls when an accept keeps
+// failing, so leaving it on an endpoint Amboss says is no longer maintained
+// would put the protection against SELLER_FAILED_TO_REACT on the same footing
+// as the call that already broke.
+func TestMagmaRejectUsesTheMarketEndpoint(t *testing.T) {
+	var gotQuery, gotInput string
+	legacyHits := 0
+	client := magmaTwoEndpointClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			var req struct {
+				Query     string         `json:"query"`
+				Variables map[string]any `json:"variables"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			gotQuery = req.Query
+			raw, _ := json.Marshal(req.Variables["input"])
+			gotInput = string(raw)
+			magmaJSON(w, `{"data":{"market":{"order":{"seller":{"reject":{"success":true}}}}}}`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			legacyHits++
+			magmaJSON(w, `{"data":{"sellerRejectOrder":true}}`)
+		})
+
+	if err := client.RejectOrder(context.Background(), "tok", "order-r"); err != nil {
+		t.Fatalf("reject should succeed: %v", err)
+	}
+	if !strings.Contains(gotQuery, "reject(input:") {
+		t.Fatalf("expected the namespaced reject, got %q", gotQuery)
+	}
+	if !strings.Contains(gotInput, `"order_id":"order-r"`) {
+		t.Fatalf("input object is wrong: %s", gotInput)
+	}
+	if legacyHits != 0 {
+		t.Fatalf("must not touch the deprecated endpoint when the new one works, got %d", legacyHits)
+	}
+}
+
+// The channel point keeps its shape. Amboss documents tx_id as TXID:OUTPUT_INDEX
+// and states the format is unchanged from the legacy field - and submitting an
+// invalid channel is the one mistake in this integration their own UI warns
+// costs reputation heavily, so the format is pinned by a test rather than left
+// to whoever edits this next.
+func TestMagmaAddTransactionSendsTheOutpointUnchanged(t *testing.T) {
+	const point = "0a5411a6a356b1531f36c7055f49d18100d227f7996f0566ecf429a6881b0c63:0"
+	var gotQuery, gotInput string
+	client := magmaTwoEndpointClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			var req struct {
+				Query     string         `json:"query"`
+				Variables map[string]any `json:"variables"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			gotQuery = req.Query
+			raw, _ := json.Marshal(req.Variables["input"])
+			gotInput = string(raw)
+			magmaJSON(w, `{"data":{"market":{"order":{"seller":{"add_transaction":{"success":true}}}}}}`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("the new endpoint answered, so there is nothing to fall back to")
+			magmaJSON(w, `{"data":{"sellerAddTransaction":true}}`)
+		})
+
+	if err := client.AddTransaction(context.Background(), "tok", "order-t", point); err != nil {
+		t.Fatalf("add_transaction should succeed: %v", err)
+	}
+	if !strings.Contains(gotQuery, "add_transaction(input:") {
+		t.Fatalf("expected the namespaced mutation, got %q", gotQuery)
+	}
+	if !strings.Contains(gotInput, `"tx_id":"`+point+`"`) {
+		t.Fatalf("the outpoint index must survive intact, got %s", gotInput)
+	}
+}
+
+// A channel point without its output index never reaches either endpoint. The
+// guard predates this migration and has to keep holding: the new field name
+// says tx_id, which invites dropping the index.
+func TestMagmaAddTransactionStillRejectsABareTxid(t *testing.T) {
+	client := magmaTwoEndpointClient(t,
+		func(w http.ResponseWriter, r *http.Request) { t.Error("must not reach the network") },
+		func(w http.ResponseWriter, r *http.Request) { t.Error("must not reach the network") })
+
+	err := client.AddTransaction(context.Background(), "tok", "order-t",
+		"0a5411a6a356b1531f36c7055f49d18100d227f7996f0566ecf429a6881b0c63")
+	if err == nil {
+		t.Fatal("a txid with no output index must be refused before it is sent")
+	}
+}
+
+// Both new calls inherit the fallback, so a broken replacement endpoint cannot
+// strand a rejection or a channel confirmation.
+func TestMagmaRejectAndAddTransactionFallBack(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		legacy string
+		run    func(*magmaAmbossClient) error
+	}{
+		{"reject", `{"data":{"sellerRejectOrder":true}}`,
+			func(c *magmaAmbossClient) error {
+				return c.RejectOrder(context.Background(), "tok", "o")
+			}},
+		{"add_transaction", `{"data":{"sellerAddTransaction":true}}`,
+			func(c *magmaAmbossClient) error {
+				return c.AddTransaction(context.Background(), "tok", "o",
+					"0a5411a6a356b1531f36c7055f49d18100d227f7996f0566ecf429a6881b0c63:0")
+			}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hits := 0
+			client := magmaTwoEndpointClient(t,
+				func(w http.ResponseWriter, r *http.Request) {
+					magmaJSON(w, `{"errors":[{"message":"boom","extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}`)
+				},
+				func(w http.ResponseWriter, r *http.Request) {
+					hits++
+					magmaJSON(w, tc.legacy)
+				})
+			if err := tc.run(client); err != nil {
+				t.Fatalf("the fallback should have carried it: %v", err)
+			}
+			if hits != 1 {
+				t.Fatalf("expected one fallback call, got %d", hits)
+			}
+		})
+	}
+}

--- a/lightningos-light/internal/server/magma_api_v2_test.go
+++ b/lightningos-light/internal/server/magma_api_v2_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// magmaTwoEndpointClient wires a client whose two endpoints are separate test
+// servers, so which one an operation actually talks to is observable.
+func magmaTwoEndpointClient(t *testing.T, market, legacy http.HandlerFunc) *magmaAmbossClient {
+	t.Helper()
+	m := httptest.NewServer(market)
+	l := httptest.NewServer(legacy)
+	t.Cleanup(m.Close)
+	t.Cleanup(l.Close)
+	return &magmaAmbossClient{endpoint: l.URL, marketEndpoint: m.URL, http: m.Client()}
+}
+
+func magmaJSON(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(body))
+}
+
+// Accept goes to the replacement endpoint, in the shape that schema expects:
+// namespaced under market.order.seller, with the arguments in an input object
+// rather than positional. The old endpoint must not be touched when it works.
+func TestMagmaAcceptUsesTheMarketEndpoint(t *testing.T) {
+	var mu sync.Mutex
+	var gotQuery, gotInput string
+	legacyHits := 0
+
+	client := magmaTwoEndpointClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			var req struct {
+				Query     string         `json:"query"`
+				Variables map[string]any `json:"variables"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			mu.Lock()
+			gotQuery = req.Query
+			raw, _ := json.Marshal(req.Variables["input"])
+			gotInput = string(raw)
+			mu.Unlock()
+			magmaJSON(w, `{"data":{"market":{"order":{"seller":{"accept":{"success":true}}}}}}`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			legacyHits++
+			mu.Unlock()
+			magmaJSON(w, `{"data":{"sellerAcceptOrder":true}}`)
+		})
+
+	if err := client.AcceptOrder(context.Background(), "tok", "order-1", "lnbc1..."); err != nil {
+		t.Fatalf("accept should succeed: %v", err)
+	}
+	if !strings.Contains(gotQuery, "market") || !strings.Contains(gotQuery, "seller") {
+		t.Fatalf("expected the namespaced mutation, got %q", gotQuery)
+	}
+	if !strings.Contains(gotInput, `"order_id":"order-1"`) ||
+		!strings.Contains(gotInput, `"payment_request":"lnbc1..."`) {
+		t.Fatalf("input object is wrong: %s", gotInput)
+	}
+	if legacyHits != 0 {
+		t.Fatalf("the deprecated endpoint must not be called when the new one works, got %d call(s)", legacyHits)
+	}
+}
+
+// The new endpoint has no track record here yet, and an accept that never lands
+// costs the sale and a SELLER_FAILED_TO_REACT with it. One retry against the
+// deprecated endpoint is cheaper than that.
+func TestMagmaAcceptFallsBackToLegacy(t *testing.T) {
+	legacyHits := 0
+	client := magmaTwoEndpointClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			magmaJSON(w, `{"errors":[{"message":"boom","extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			legacyHits++
+			magmaJSON(w, `{"data":{"sellerAcceptOrder":true}}`)
+		})
+
+	if err := client.AcceptOrder(context.Background(), "tok", "order-2", "lnbc1..."); err != nil {
+		t.Fatalf("the fallback should have carried the accept: %v", err)
+	}
+	if legacyHits != 1 {
+		t.Fatalf("expected exactly one fallback call, got %d", legacyHits)
+	}
+}
+
+// A rejected credential is the one failure the old endpoint cannot rescue, and
+// retrying there would spend the same token against a second host for nothing.
+func TestMagmaAcceptDoesNotFallBackOnBadCredential(t *testing.T) {
+	legacyHits := 0
+	client := magmaTwoEndpointClient(t,
+		func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusUnauthorized) },
+		func(w http.ResponseWriter, r *http.Request) {
+			legacyHits++
+			magmaJSON(w, `{"data":{"sellerAcceptOrder":true}}`)
+		})
+
+	err := client.AcceptOrder(context.Background(), "tok", "order-3", "lnbc1...")
+	if err == nil {
+		t.Fatal("a bad token must surface, not be papered over by the fallback")
+	}
+	if legacyHits != 0 {
+		t.Fatalf("must not retry a credential failure elsewhere, got %d call(s)", legacyHits)
+	}
+}
+
+// When both refuse, the reported error is the new endpoint's. That is the one
+// that matters now; the deprecated endpoint failing is expected, not news.
+func TestMagmaAcceptReportsTheMarketErrorWhenBothFail(t *testing.T) {
+	client := magmaTwoEndpointClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			magmaJSON(w, `{"errors":[{"message":"market is down","extensions":{"code":"MARKET_CODE"}}]}`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			magmaJSON(w, `{"errors":[{"message":"legacy is down","extensions":{"code":"LEGACY_CODE"}}]}`)
+		})
+
+	err := client.AcceptOrder(context.Background(), "tok", "order-4", "lnbc1...")
+	if err == nil {
+		t.Fatal("both endpoints refused, so this must be an error")
+	}
+	if !strings.Contains(err.Error(), "market is down") {
+		t.Fatalf("expected the replacement endpoint's error, got %q", err)
+	}
+}
+
+// success:false is a refusal, not a transport failure, and has to read as one.
+func TestMagmaAcceptTreatsSuccessFalseAsRefusal(t *testing.T) {
+	client := magmaTwoEndpointClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			magmaJSON(w, `{"data":{"market":{"order":{"seller":{"accept":{"success":false}}}}}}`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("a clean response that refuses must not trigger the fallback")
+			magmaJSON(w, `{"data":{"sellerAcceptOrder":true}}`)
+		})
+
+	if err := client.AcceptOrder(context.Background(), "tok", "order-5", "lnbc1..."); err == nil {
+		t.Fatal("success:false must be reported as a refusal")
+	}
+}

--- a/lightningos-light/internal/server/magma_offer_exhausted_test.go
+++ b/lightningos-light/internal/server/magma_offer_exhausted_test.go
@@ -1,0 +1,78 @@
+package server
+
+import "testing"
+
+// The offer on Friendspool that prompted this: 100% sold, 4,236 sat left to
+// sell, a 1,000,000 sat minimum channel, and 499,973 sat on-chain. It sat
+// ENABLED with a red blocking dot next to it. The guard compared the wallet
+// against what was left to sell - 4,236 fits anywhere - so it concluded the
+// offer was affordable and left it up.
+func TestMagmaOfferSmallestOrderIsTheMinimumNotTheRemainder(t *testing.T) {
+	offer := MagmaOffer{
+		TotalSizeSat: 7_500_000,
+		SoldSat:      7_495_764,
+		RemainingSat: 4_236,
+		MinSizeSat:   1_000_000,
+		MaxSizeSat:   5_000_000,
+	}
+	if got := magmaOfferSmallestOrder(offer); got != 1_000_000 {
+		t.Fatalf("the only order this offer can produce is the 1,000,000 sat minimum, got %d", got)
+	}
+	// The wallet at the time. Measured against the remainder it looked covered;
+	// measured against the smallest real order it plainly was not.
+	const wallet = 499_973
+	if magmaOfferRemaining(offer) > wallet {
+		t.Fatal("the old measure has to look affordable, otherwise this test proves nothing")
+	}
+	if magmaOfferSmallestOrder(offer) <= wallet {
+		t.Fatal("the new measure must show the offer cannot be honoured")
+	}
+}
+
+// An offer with room left is still measured by what it has left to sell: that
+// is the real ceiling on what it can still commit, and reserving the minimum
+// instead would free capital the offer can genuinely spend.
+func TestMagmaOfferSmallestOrderKeepsTheRemainderWhenItIsLarger(t *testing.T) {
+	offer := MagmaOffer{
+		TotalSizeSat: 7_500_000,
+		SoldSat:      2_000_000,
+		RemainingSat: 5_500_000,
+		MinSizeSat:   1_000_000,
+	}
+	if got := magmaOfferSmallestOrder(offer); got != 5_500_000 {
+		t.Fatalf("expected the remainder while it exceeds the minimum, got %d", got)
+	}
+}
+
+// A fresh offer that has sold nothing reports no remainder, and must not be
+// read as exhausted.
+func TestMagmaOfferSmallestOrderHandlesAnUntouchedOffer(t *testing.T) {
+	offer := MagmaOffer{TotalSizeSat: 5_000_000, MinSizeSat: 1_000_000}
+	if got := magmaOfferSmallestOrder(offer); got != 5_000_000 {
+		t.Fatalf("an untouched offer still has its whole size to sell, got %d", got)
+	}
+}
+
+// The exhausted case was already detected and marked blocking for the UI. The
+// guard now reads that same judgement, so the red dot and the action agree.
+func TestMagmaOfferExhaustedIsUnfulfillable(t *testing.T) {
+	policy := defaultMagmaPolicy()
+	policy.MinChannelSizeSat, policy.MaxChannelSizeSat = 0, 0
+	policy.MinPricePPM, policy.MinPricePPMPerDay, policy.MinFeeRateCapPPM = 0, 0, 0
+	policy.MaxCommitmentDays = 0
+
+	exhausted := MagmaOffer{
+		TotalSizeSat: 7_500_000, SoldSat: 7_495_764, RemainingSat: 4_236,
+		MinSizeSat: 1_000_000, MaxSizeSat: 5_000_000,
+		FeeRatePPM: 1800, FeeRateCapPPM: 1500, BaseFeeCapSat: 1,
+	}
+	if !magmaOfferIsUnfulfillable(exhausted, policy) {
+		t.Fatal("an offer with less left than its own minimum channel cannot be honoured")
+	}
+
+	healthy := exhausted
+	healthy.SoldSat, healthy.RemainingSat = 2_000_000, 5_500_000
+	if magmaOfferIsUnfulfillable(healthy, policy) {
+		t.Fatal("an offer that can still produce a valid order must stay up")
+	}
+}

--- a/lightningos-light/internal/server/magma_offer_guard.go
+++ b/lightningos-light/internal/server/magma_offer_guard.go
@@ -80,6 +80,36 @@ func (s *MagmaService) loadOfferStates(ctx context.Context) map[string]MagmaOffe
 // magmaOfferRemaining is what an offer still has to sell. Amboss leaves
 // total_size untouched as orders land, so the outstanding promise is the total
 // minus what its orders already locked.
+// magmaOfferSmallestOrder is the smallest order an offer can still attract, and
+// therefore the capital it has to be able to honour. An offer with 4,236 sat
+// left to sell but a 1,000,000 sat minimum channel does not need 4,236 sat in
+// the wallet - the only order it can produce is a million, or none at all.
+//
+// Measuring the wallet against what is left to sell was the original mistake:
+// the last sliver of an offer always fits, so an offer sold down to nothing
+// looked affordable right up to the point where it could not be honoured.
+func magmaOfferSmallestOrder(offer MagmaOffer) int64 {
+	remaining := magmaOfferRemaining(offer)
+	if offer.MinSizeSat > 0 && offer.MinSizeSat > remaining {
+		return offer.MinSizeSat
+	}
+	return remaining
+}
+
+// magmaOfferIsUnfulfillable reports an offer that can no longer produce a valid
+// order at all - it has less left to sell than the smallest channel it
+// advertises. That is already detected and marked blocking for the UI, so this
+// reuses the same judgement rather than restating it: showing a red dot while
+// leaving the offer on the market is the worst of both.
+func magmaOfferIsUnfulfillable(offer MagmaOffer, policy MagmaPolicy) bool {
+	for _, conflict := range magmaOfferConflicts(offer, policy) {
+		if conflict.Blocking {
+			return true
+		}
+	}
+	return false
+}
+
 func magmaOfferRemaining(offer MagmaOffer) int64 {
 	remaining := offer.RemainingSat
 	if remaining <= 0 && offer.SoldSat == 0 {
@@ -157,8 +187,12 @@ func (s *MagmaService) syncOfferBalanceGuard(ctx context.Context, token string) 
 		return enabled[i].ID < enabled[j].ID
 	})
 	for _, offer := range enabled {
-		remaining := magmaOfferRemaining(offer)
-		if remaining <= budget {
+		remaining := magmaOfferSmallestOrder(offer)
+		// An offer that cannot produce a valid order comes down whatever the
+		// balance is: keeping it up sells nothing and, if Amboss lets an order
+		// through against it anyway, sells something we cannot fund.
+		unfulfillable := magmaOfferIsUnfulfillable(offer, policy)
+		if !unfulfillable && remaining <= budget {
 			budget -= remaining
 			continue
 		}


### PR DESCRIPTION
## Por que

`sellerAcceptOrder` no endpoint legacy `api.amboss.space` estava retornando `INTERNAL_SERVER_ERROR` — **66 recusas numa única ordem em uma manhã**, com a mesma invoice aceita pela UI nova momentos depois.

A [documentação de migração](https://docs.amboss.tech/magma/migrate-from-legacy-api) que a Amboss publicou desde então é explícita:

> It is also **no longer actively maintained**, so bugs in it will not be fixed. The seller accept path has already been unreliable there. **Migrate seller mutations first.**

## O que muda

As três mutations do vendedor passam para `magma.amboss.tech/graphql`. O schema novo é namespaced em vez de plano, e recebe input object em vez de argumentos posicionais:

| | Legacy | Novo |
|---|---|---|
| Accept | `sellerAcceptOrder(id, request)` | `market.order.seller.accept(input)` |
| Reject | `sellerRejectOrder(id)` | `market.order.seller.reject(input)` |
| Confirmar tx | `sellerAddTransaction(id, transaction)` | `market.order.seller.add_transaction(input)` |

O token do dashboard autentica nos dois hosts — verificado com `{ user { id } }` antes de escrever código, e depois confirmado pelo doc: *"Keys minted at account.amboss.tech/settings/api-keys work on both endpoints."*

## O formato do channel point

Era o que travava `add_transaction`. O doc resolve: `TXID:OUTPUT_INDEX`, e *"the field is named `tx_id` but the format is unchanged"* — exatamente o que já enviamos.

Está **fixado por teste**. O nome novo do campo convida a largar o índice do output, e submeter canal inválido é o único erro nesta integração que a própria tela deles avisa que pesa forte na reputação.

## O fallback

Uma chamada que falhe no endpoint novo tenta o antigo. Introduzido para o accept, agora **compartilhado** pelas três em vez de copiado.

`sellerCall` mantém separados os dois modos de falha, que é a parte que vale nomear: um endpoint que **erra** pode funcionar em outro lugar; um endpoint que **responde e recusa** vai recusar em qualquer lugar, e repetir compraria uma segunda requisição e a mesma resposta. Credencial rejeitada nunca faz fallback — o endpoint antigo não resgata token ruim.

Quando ambos falham, o erro reportado é o do novo: o antigo falhar é esperado, não é diagnóstico.

## Testes

`internal/server/magma_api_v2_test.go`, com dois servidores separados para tornar observável qual endpoint foi chamado:

- accept e reject usam o novo e não tocam o antigo quando ele funciona
- `add_transaction` envia o outpoint intacto, e segue recusando txid sem índice **antes** de chegar à rede
- as três caem para o legacy exatamente uma vez quando o novo falha
- credencial ruim não faz fallback
- `success:false` é recusa, não falha de transporte

Os testes pré-existentes do accept e do add_transaction seguem passando, agora exercitando o caminho de fallback — o que confirma que ele ainda envia a forma legacy correta.

`go test ./...` e `go vet ./internal/server/` verdes.

## Fora de escopo

O **poller** continua no legacy. O substituto é `user.market.orders.sales(input: OrderInput, page: PageInput)`, mas a migração dele envolve perdas que precisam de decisão: `seller_close_side` e `buyer_close_side` não têm equivalente (*"no replacement today"*), `cancellation_reason` vira write-only, e `amboss_fee_rate` muda de semântica — era ppm, agora `fees.amboss` é valor em sats, que o doc marca como "critical difference".

Nenhum desses entra em lógica de decisão hoje, mas os dois `close_side` são como sabemos se um canal foi fechado cedo pelo comprador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)