### PR TITLE
0.5.22-Beta: piso econômico integrado entre AutoFee e Rebalance

### DIFF
--- a/docs/03_API_SPEC.md
+++ b/docs/03_API_SPEC.md
@@ -752,6 +752,11 @@ POST /api/reports/reconciliation
 
 ## Rebalance channel automation
 
+GET /api/rebalance/channels
+- Returns live channel balances, local/peer policies, targets, eligibility and recent economics.
+- Economic diagnostics include `initiator`, `peer_policy_known`, `effective_econ_ratio`, `fee_budget_ppm`, `economic_fee_floor_ppm`, `economic_required_cost_ppm`, `economic_reference_amount_sat`, `economic_floor_reason`, and `economic_blocked_reason`.
+- For remote-opened channels that need paid refill, `economic_fee_floor_ppm` is the minimum outbound rate whose proportional budget can cover the peer's amount-normalized policy. Fresh total rebalance cost takes precedence when it is higher.
+
 POST /api/rebalance/run/preview
 - Resolves the effective amount and fee cap for an operator-triggered Manual Rebal In without creating a job.
 - Body: `{"channel_point":"txid:index","target_outbound_pct":10,"amount_sat":10000,"fee_limit_ppm":1200}`.

--- a/docs/19_BACKLOG.md
+++ b/docs/19_BACKLOG.md
@@ -38,7 +38,10 @@ Current product backlog, after checking the repository against the docs:
    supports `off`/`shadow`/`enforce`: AutoFee publishes `refill_target` for
    drained eligible channels, both Rules Auto and Sovereign consume it without
    bypassing existing gates, and successful rebalances publish a directional
-   `protect_fee_floor` consumed by AutoFee. Settling windows remain as fallback.
+   `protect_fee_floor` consumed by AutoFee. Rebalance also refreshes this intent
+   prospectively for remote-opened channels below target, using the peer policy,
+   real cost history and effective per-channel econ ratio. AutoFee can enforce
+   the floor upward or downward; settling windows remain as fallback.
    A dedicated Automation Interlock page exposes rollout mode, profiles,
    calibration provenance, active intents, bounded tuning, and event history.
    Source preference and explicit rebalance-to-AutoFee upward-pressure intents

--- a/docs/23_REBALANCE_CENTER_COURSE_PT_BR.md
+++ b/docs/23_REBALANCE_CENTER_COURSE_PT_BR.md
@@ -12,7 +12,7 @@ Um canal vira **target** quando precisa receber liquidez local. O cálculo bási
 target_outbound_pct - local_pct = deficit
 ```
 
-Se o déficit passa o `deadband_pct`, o canal é ativo e `outgoing_fee_ppm > peer_fee_ppm`, ele pode ser target manual. Para virar target automático, ainda precisa passar por filtros econômicos: cost gate, ROI, profit guardrail, cooldowns e orçamento.
+Se o déficit passa o `deadband_pct`, o canal é ativo e o budget efetivo da rota cobre ao menos o custo efetivo do peer, ele pode ser target manual. Para virar target automático, ainda precisa passar por filtros econômicos: cost gate, ROI, profit guardrail, cooldowns e orçamento.
 
 Um canal vira **source** quando tem liquidez local acima de `source_min_local_pct`, não está excluído como source e não está protegido por payback. O sistema tenta não usar como source um canal que ainda está no vermelho por rebalance anterior.
 
@@ -45,8 +45,8 @@ Para comparação objetiva, use `/api/rebalance/metrics/baseline?days=1` após 2
 Na linha do canal, observe nesta ordem:
 
 1. `local_pct / remote_pct`: se local está muito baixo, pode precisar de inbound local.
-2. `outgoing ppm - peer ppm = spread`: spread positivo é a base econômica.
-3. `spread efetivo`: spread multiplicado pelo econ ratio.
+2. `fee_budget_ppm`: custo máximo efetivo permitido para a rota.
+3. `economic_fee_floor_ppm`: menor fee outbound que mantém esse budget capaz de pagar o peer/custo conhecido.
 4. `target_outbound_pct`: quanto local você quer manter.
 5. `local liquidity to add`: amount necessário.
 6. `payback`: se ainda não pagou rebalances anteriores.
@@ -76,9 +76,9 @@ Comece conservador:
 
 ## 7. Parâmetros Econômicos
 
-- `econ_ratio`: default 0.6. Define quanto da vantagem econômica você aceita gastar em fee. Subir deixa passar mais rotas e aumenta custo; baixar fica mais seletivo.
+- `econ_ratio`: default 0.6. Define quanto da fee outbound você aceita gastar no custo total do rebalance. Com peer a 500 ppm e ratio 0,75, a fee outbound precisa ser pelo menos 667 ppm. Subir deixa passar mais rotas e aumenta custo; baixar fica mais seletivo.
 - `econ_ratio_override` por canal: use para canais estratégicos sem enfraquecer o global.
-- `bypass cost gate`: use só por canal. Ele ignora o filtro `spread efetivo > custo esperado`, mas ROI/profit continuam protegendo depois.
+- `bypass cost gate`: use só por canal. Ele ignora o filtro `budget efetivo >= custo total esperado`, mas ROI/profit continuam protegendo depois.
 - `roi_min`: default 1.1. Se há muitos `roi_guardrail`, o sistema está dizendo que o alvo ainda não compensa.
 - `rebalance_cost_floor_ppm`: default 250 ppm. É o custo esperado mínimo quando não há histórico.
 - `gain_model_version`: v1 usa receita histórica; v2 usa spread efetivo e velocidade. Ative v2 quando quiser priorizar demanda real.

--- a/docs/24_REBALANCE_CENTER_COURSE_EN.md
+++ b/docs/24_REBALANCE_CENTER_COURSE_EN.md
@@ -12,7 +12,7 @@ A channel becomes a **target** when it needs to receive local liquidity. The bas
 target_outbound_pct - local_pct = deficit
 ```
 
-If the deficit exceeds `deadband_pct`, the channel is active, and `outgoing_fee_ppm > peer_fee_ppm`, it can be a manual target. To become an automatic target, it also needs to pass economic filters: cost gate, ROI, profit guardrail, cooldowns, and budget.
+If the deficit exceeds `deadband_pct`, the channel is active, and the effective route budget covers at least the peer's effective cost, it can be a manual target. To become an automatic target, it also needs to pass economic filters: cost gate, ROI, profit guardrail, cooldowns, and budget.
 
 A channel becomes a **source** when it has local liquidity above `source_min_local_pct`, is not excluded as a source, and is not protected by payback. The system tries not to use a channel as a source while that channel is still in the red from a previous rebalance.
 
@@ -45,8 +45,8 @@ For an objective comparison, use `/api/rebalance/metrics/baseline?days=1` after 
 In the channel row, read these fields in this order:
 
 1. `local_pct / remote_pct`: if local is too low, the channel may need local inbound.
-2. `outgoing ppm - peer ppm = spread`: positive spread is the economic base.
-3. `effective spread`: spread multiplied by the econ ratio.
+2. `fee_budget_ppm`: the effective maximum cost allowed for the route.
+3. `economic_fee_floor_ppm`: the minimum outbound fee that keeps this budget able to pay the peer/known cost.
 4. `target_outbound_pct`: how much local liquidity you want to keep.
 5. `local liquidity to add`: required amount.
 6. `payback`: whether previous rebalances are still unpaid.
@@ -76,9 +76,9 @@ Start conservatively:
 
 ## 7. Economic Parameters
 
-- `econ_ratio`: default 0.6. Defines how much of the economic advantage you are willing to spend on fees. Raising it lets more routes pass and increases cost; lowering it makes selection stricter.
+- `econ_ratio`: default 0.6. Defines how much of the outbound fee may be spent on the total rebalance cost. With a peer at 500 ppm and a 0.75 ratio, the outbound fee must be at least 667 ppm. Raising it lets more routes pass and increases cost; lowering it makes selection stricter.
 - `econ_ratio_override` per channel: use it for strategic channels without weakening the global setting.
-- `bypass cost gate`: use only per channel. It skips the `effective spread > expected cost` filter, but ROI/profit still protect the job afterward.
+- `bypass cost gate`: use only per channel. It skips the `effective budget >= expected total cost` filter, but ROI/profit still protect the job afterward.
 - `roi_min`: default 1.1. If there are many `roi_guardrail` skips, the system is saying the target still does not pay enough.
 - `rebalance_cost_floor_ppm`: default 250 ppm. This is the minimum expected cost when there is no history.
 - `gain_model_version`: v1 uses historical revenue; v2 uses effective spread and velocity. Enable v2 when you want to prioritize real demand.

--- a/lightningos-light/docs/rebalance-center.md
+++ b/lightningos-light/docs/rebalance-center.md
@@ -53,8 +53,9 @@ lucrativos a cada ciclo de scan.
 
 **Filtros aplicados:**
 
-- `Active && deficit > deadband && outFee > peerFee`
-- **Cost gate 1.4:** `(outFee − peerFee) × econ_ratio > expectedCost`
+- `Active && deficit > deadband && routeBudget >= peerEffectiveCost`
+- **Cost gate:** `routeBudget >= expectedTotalCost`, where proportional
+  `routeBudget = outgoingPolicy × econ_ratio`
 - ROI guardrail: `roi >= roi_min`
 - Profit guardrail: `gain >= cost` (suprimido se `roi_min < 1`)
 - Cooldowns recentes de falhas estruturais
@@ -165,8 +166,8 @@ A ordem importa porque cada um é **eliminação imediata** (`continue`):
 
 | # | Filtro | Critério | Skip reason |
 |---|---|---|---|
-| 1 | EligibleAsTarget | `Active && deficit > deadband && outFee > peerFee` | (não exposto) |
-| 2 | Cost gate 1.4 | `(outFee − peerFee) × econ_ratio > expectedCost` | (não exposto) |
+| 1 | EligibleAsTarget | `Active && deficit > deadband && routeBudget >= peerEffectiveCost` | `economic_blocked_reason` |
+| 2 | Cost gate | `routeBudget >= expectedTotalCost` | `fee_budget_ppm` |
 | 3 | Target cooldown | `shouldCooldownTargetRecentFailures` | `target_cooldown` |
 | 4 | Below min execute | `targetAmount < minExecuteSat` | `below_execute_min` |
 | 5 | ROI guardrail | `ROI < roi_min` (se `roiValid`) | `roi_guardrail` |
@@ -411,7 +412,7 @@ Cleanup loops não geram jobs — apenas manutenção de dados.
 - `setting.ManualRestartEnabled` — canal entra no pool manual_restart
   *(exclusivos — só um pode estar ligado por canal)*
 - `setting.TargetOutboundPct` — % de outbound desejado (default 30)
-- `setting.UseDefaultEconRatio` / `EconRatioOverride` — multiplicador no spread
+- `setting.UseDefaultEconRatio` / `EconRatioOverride` — fração da policy outbound disponível como budget de rota
 - `setting.AutoBypassCostGate` — bypassa cost gate per canal
 
 ### 10.4 Budget & guardrails
@@ -450,7 +451,7 @@ Canal não aparece como candidato:
 
 1. **Verifique `EligibleAsTarget`** via channel ranking — se false, ver
    `active`, `deficit`, `outFee > peerFee`
-2. **Cost gate**: compare `(outFee − peerFee) × econ_ratio` com `rebal_ppm_7d`
+2. **Cost gate**: compare o `fee_budget_ppm` efetivo com o custo total `rebal_ppm_7d`
    - Se gate falha mas matemática parece OK, considere `auto_bypass_cost_gate`
 3. **ROI guardrail**: ROI = gain/cost. Veja `expected_roi` em
    sovereign-history → decisions
@@ -844,12 +845,14 @@ empurrando sources antigas de volta ao pool.
 
 ### R8 — AutoFee ↔ Rebalance interlock bidirecional
 
-**Current status (2026-07-14): MVP implemented, phase 2 open.** Timing-based
+**Current status (2026-08-27): economic floor enforcement implemented, phase 2 open.** Timing-based
 settling remains as a fallback. The shared layer now supports persisted,
 expiring `refill_target` and `protect_fee_floor` intents with
 `off`/`shadow`/`enforce` rollout modes. Both Rules Auto and Sovereign consume the
 same target intent after eligibility/economic gates and before final ordering.
-Source preference and explicit upward fee-pressure intents remain phase-2 work.
+Rebalance now publishes amount-aware fee floors before the first paid refill and
+after observed costs; AutoFee can enforce them upward or downward. Source
+preference remains phase-2 work.
 Operational control and intent history live in the dedicated **Automation
 Interlock** page; Rebalance Center keeps only a contextual mode/count summary.
 

--- a/lightningos-light/internal/server/autofee_service.go
+++ b/lightningos-light/internal/server/autofee_service.go
@@ -409,9 +409,9 @@ type AutofeeRefreshItem struct {
 	// MagmaCapped marks a target the Magma commitment pulled down, so the preview
 	// and the log show the fee that will actually be written, not the one the
 	// reference asked for.
-	MagmaCapped bool `json:"magma_capped,omitempty"`
-	Reason                 string `json:"reason,omitempty"`
-	Error                  string `json:"error,omitempty"`
+	MagmaCapped bool   `json:"magma_capped,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+	Error       string `json:"error,omitempty"`
 }
 
 type AutofeeRefreshResult struct {
@@ -4331,7 +4331,7 @@ func selectProtectFeeFloorIntent(intents []AutomationIntent, minConfidence float
 }
 
 func applyProtectFeeFloorIntent(localPpm, finalPpm int, apply bool, intents []AutomationIntent, cfg AutomationIntentConfig, minPpm, maxPpm int) (int, bool, *AutomationIntent, bool) {
-	if !apply || finalPpm >= localPpm || normalizeAutomationIntentMode(cfg.Mode) == automationIntentModeOff {
+	if normalizeAutomationIntentMode(cfg.Mode) == automationIntentModeOff {
 		return finalPpm, apply, nil, false
 	}
 	intent := selectProtectFeeFloorIntent(intents, cfg.MinConfidence)
@@ -4339,9 +4339,6 @@ func applyProtectFeeFloorIntent(localPpm, finalPpm int, apply bool, intents []Au
 		return finalPpm, apply, nil, false
 	}
 	adjusted := clampInt(int(intent.FeeFloorPPM), minPpm, maxPpm)
-	if adjusted > localPpm {
-		adjusted = localPpm
-	}
 	if cfg.Mode == automationIntentModeShadow {
 		return adjusted, apply, intent, true
 	}
@@ -11480,10 +11477,15 @@ func (e *autofeeEngine) evaluateChannel(ch lndclient.ChannelInfo, st *autofeeCha
 	}
 	var appliedAutomationIntent *AutomationIntent
 	intentShadow := false
+	intentHardRaise := false
 	intentEffectBefore := finalPpm
 	intentEffectAfter := finalPpm
+	intentMaxPpm := e.cfg.MaxPpm
+	if _, magmaMaxPpm, capped := magmaClampChannelFees(ch.ChannelID, ch.ChannelPoint, 0, int64(intentMaxPpm)); capped && magmaMaxPpm < int64(intentMaxPpm) {
+		intentMaxPpm = int(magmaMaxPpm)
+	}
 	if adjustedPpm, adjustedApply, intent, shadow := applyProtectFeeFloorIntent(
-		localPpm, finalPpm, apply, e.automationIntents[ch.ChannelID], e.automationIntentConfig, e.cfg.MinPpm, e.cfg.MaxPpm,
+		localPpm, finalPpm, apply, e.automationIntents[ch.ChannelID], e.automationIntentConfig, e.cfg.MinPpm, intentMaxPpm,
 	); intent != nil {
 		intentEffectBefore = finalPpm
 		intentEffectAfter = adjustedPpm
@@ -11493,19 +11495,25 @@ func (e *autofeeEngine) evaluateChannel(ch lndclient.ChannelInfo, st *autofeeCha
 		} else {
 			finalPpm = adjustedPpm
 			apply = adjustedApply
+			intentHardRaise = finalPpm > localPpm
 			tags = appendAutofeeTagOnce(tags, "intent-protect-fee-floor")
+			if int64(intentMaxPpm) < intent.FeeFloorPPM {
+				tags = appendAutofeeTagOnce(tags, "intent-protect-fee-contract-cap")
+			}
 		}
 		intentCopy := *intent
 		appliedAutomationIntent = &intentCopy
 	}
-	if apply && finalPpm != localPpm {
+	if apply && finalPpm != localPpm && !intentHardRaise {
 		if churnTags := shouldHoldForAutofeeChurn(e.profile, e.recentChanges[ch.ChannelID], localPpm, finalPpm, recentRebalanceCount, htlcLiquidityHot); len(churnTags) > 0 {
 			apply = false
 			tags = append(tags, churnTags...)
 		}
 	}
 	if apply && finalPpm != localPpm && shouldHoldAutofeeForRebalanceSettling(rebalanceTouch, e.now, autofeeRebalanceSettlingWindow) {
-		if recentRebalanceHardFloorApplied && finalPpm > localPpm {
+		if intentHardRaise {
+			tags = appendAutofeeTagOnce(tags, "intent-protect-fee-settling-bypass")
+		} else if recentRebalanceHardFloorApplied && finalPpm > localPpm {
 			tags = appendAutofeeTagOnce(tags, "rebal-recent-settling-bypass")
 		} else if shouldBypassAutofeeSettlingForDrainedFailedRebalanceUp(
 			outRatio,

--- a/lightningos-light/internal/server/automation_intent_service_test.go
+++ b/lightningos-light/internal/server/automation_intent_service_test.go
@@ -76,7 +76,7 @@ func TestApplyRefillTargetIntentsHonorsModeProfileAndConfidence(t *testing.T) {
 	}
 }
 
-func TestApplyProtectFeeFloorIntentIsDirectional(t *testing.T) {
+func TestApplyProtectFeeFloorIntentEnforcesUpwardAndDownwardFloor(t *testing.T) {
 	intent := AutomationIntent{ID: 7, Kind: automationIntentKindProtectFeeFloor, Confidence: 0.9, FeeFloorPPM: 400}
 	cfg := AutomationIntentConfig{Mode: automationIntentModeEnforce, MinConfidence: 0.7}
 
@@ -85,12 +85,20 @@ func TestApplyProtectFeeFloorIntentIsDirectional(t *testing.T) {
 		t.Fatalf("expected downward decision capped at 400: ppm=%d apply=%v selected=%v shadow=%v", ppm, apply, selected, shadow)
 	}
 	ppm, apply, selected, _ = applyProtectFeeFloorIntent(350, 300, true, []AutomationIntent{intent}, cfg, 1, 2000)
-	if ppm != 350 || apply || selected == nil {
-		t.Fatalf("floor above local fee should hold current fee: ppm=%d apply=%v selected=%v", ppm, apply, selected)
+	if ppm != 400 || !apply || selected == nil {
+		t.Fatalf("floor above local fee should raise current fee: ppm=%d apply=%v selected=%v", ppm, apply, selected)
 	}
 	ppm, apply, selected, _ = applyProtectFeeFloorIntent(300, 450, true, []AutomationIntent{intent}, cfg, 1, 2000)
 	if ppm != 450 || !apply || selected != nil {
 		t.Fatalf("upward decision must remain untouched: ppm=%d apply=%v selected=%v", ppm, apply, selected)
+	}
+	ppm, apply, selected, _ = applyProtectFeeFloorIntent(350, 350, false, []AutomationIntent{intent}, cfg, 1, 2000)
+	if ppm != 400 || !apply || selected == nil {
+		t.Fatalf("floor must repair a held decision below the economic minimum: ppm=%d apply=%v selected=%v", ppm, apply, selected)
+	}
+	ppm, apply, selected, _ = applyProtectFeeFloorIntent(350, 300, true, []AutomationIntent{intent}, cfg, 1, 375)
+	if ppm != 375 || !apply || selected == nil {
+		t.Fatalf("external fee ceiling must clamp the floor: ppm=%d apply=%v selected=%v", ppm, apply, selected)
 	}
 
 	cfg.Mode = automationIntentModeShadow

--- a/lightningos-light/internal/server/rebalance_service.go
+++ b/lightningos-light/internal/server/rebalance_service.go
@@ -1076,6 +1076,15 @@ type RebalanceChannel struct {
 	PeerFeeRatePpm             int64    `json:"peer_fee_rate_ppm"`
 	PeerBaseMsat               int64    `json:"peer_base_msat"`
 	SpreadPpm                  int64    `json:"spread_ppm"`
+	Initiator                  bool     `json:"initiator"`
+	PeerPolicyKnown            bool     `json:"peer_policy_known"`
+	EffectiveEconRatio         float64  `json:"effective_econ_ratio"`
+	FeeBudgetPpm               int64    `json:"fee_budget_ppm"`
+	EconomicFeeFloorPpm        int64    `json:"economic_fee_floor_ppm"`
+	EconomicRequiredCostPpm    int64    `json:"economic_required_cost_ppm"`
+	EconomicReferenceAmountSat int64    `json:"economic_reference_amount_sat"`
+	EconomicFloorReason        string   `json:"economic_floor_reason,omitempty"`
+	EconomicBlockedReason      string   `json:"economic_blocked_reason,omitempty"`
 	TargetOutboundPct          float64  `json:"target_outbound_pct"`
 	TargetAmountSat            int64    `json:"target_amount_sat"`
 	AutoEnabled                bool     `json:"auto_enabled"`
@@ -3452,8 +3461,124 @@ func effectiveConfigForTarget(cfg RebalanceConfig, setting channelSetting) Rebal
 	return effective
 }
 
-func passesAutoTargetCostGate(setting channelSetting, expectedCostPpm int64, effectiveSpreadPpm int64) bool {
-	return setting.AutoBypassCostGate || expectedCostPpm <= 0 || effectiveSpreadPpm > expectedCostPpm
+type rebalanceEconomicEnvelope struct {
+	EffectiveEconRatio float64
+	ReferenceAmountSat int64
+	PeerCostPpm        int64
+	RequiredCostPpm    int64
+	FeeBudgetPpm       int64
+	FeeFloorPpm        int64
+	FloorReason        string
+	BlockedReason      string
+}
+
+func effectivePolicyPpm(ratePpm, baseMsat, amountSat int64) int64 {
+	if amountSat <= 0 {
+		if ratePpm > 0 {
+			return ratePpm
+		}
+		return 0
+	}
+	basePpm := int64(0)
+	if baseMsat > 0 {
+		basePpm = (baseMsat*1000 + amountSat - 1) / amountSat
+	}
+	if ratePpm < 0 {
+		ratePpm = 0
+	}
+	return ratePpm + basePpm
+}
+
+func deriveRebalanceEconomicEnvelope(
+	cfg RebalanceConfig,
+	setting channelSetting,
+	initiator bool,
+	active bool,
+	parked bool,
+	peerPolicyKnown bool,
+	localPct float64,
+	targetPct float64,
+	outgoingFeePpm int64,
+	outgoingBaseMsat int64,
+	peerFeePpm int64,
+	peerBaseMsat int64,
+	rebalanceCostPpm int64,
+) rebalanceEconomicEnvelope {
+	feeCfg := effectiveConfigForTarget(cfg, setting)
+	referenceAmountSat := effectiveMinExecuteSat(feeCfg)
+	if referenceAmountSat <= 0 {
+		referenceAmountSat = effectiveStartAmountSat(feeCfg)
+	}
+	if referenceAmountSat <= 0 {
+		referenceAmountSat = 1
+	}
+
+	envelope := rebalanceEconomicEnvelope{
+		EffectiveEconRatio: feeCfg.EconRatio,
+		ReferenceAmountSat: referenceAmountSat,
+	}
+	if peerPolicyKnown {
+		envelope.PeerCostPpm = effectivePolicyPpm(peerFeePpm, peerBaseMsat, referenceAmountSat)
+	}
+	policy := lndclient.ChannelPolicySnapshot{FeeRatePpm: outgoingFeePpm, BaseFeeMsat: outgoingBaseMsat}
+	if feeMsat, err := calcFeeLimitMsat(referenceAmountSat*1000, policy, nil, feeCfg); err == nil {
+		envelope.FeeBudgetPpm = feeMsatToPpm(feeMsat, referenceAmountSat)
+	}
+
+	needsRefill := active && !parked && targetPct-localPct > cfg.DeadbandPct
+	paidCostKnown := rebalanceCostPpm > 0
+	remoteInboundColdStart := !initiator && needsRefill && (setting.AutoEnabled || setting.ManualRestartEnabled)
+	if !paidCostKnown && !remoteInboundColdStart {
+		return envelope
+	}
+	if remoteInboundColdStart && !peerPolicyKnown && !paidCostKnown {
+		envelope.BlockedReason = "peer_policy_unavailable"
+		return envelope
+	}
+
+	envelope.RequiredCostPpm = envelope.PeerCostPpm
+	if rebalanceCostPpm > envelope.RequiredCostPpm {
+		envelope.RequiredCostPpm = rebalanceCostPpm
+	}
+	if envelope.RequiredCostPpm <= 0 {
+		return envelope
+	}
+	if paidCostKnown && envelope.RequiredCostPpm == rebalanceCostPpm {
+		envelope.FloorReason = "rebalance_cost_budget"
+	} else {
+		envelope.FloorReason = "peer_fee_budget"
+	}
+
+	// A fixed fee limit is independent of our advertised fee, so raising the
+	// AutoFee target cannot repair an insufficient route budget.
+	if feeCfg.FeeLimitPpm > 0 {
+		if feeCfg.FeeLimitPpm < envelope.RequiredCostPpm {
+			envelope.BlockedReason = "fixed_fee_budget_below_cost"
+		}
+		return envelope
+	}
+	if feeCfg.EconRatio <= 0 {
+		envelope.BlockedReason = "invalid_econ_ratio"
+		return envelope
+	}
+	if feeCfg.EconRatioMaxPpm > 0 && feeCfg.EconRatioMaxPpm < envelope.RequiredCostPpm {
+		envelope.BlockedReason = "econ_ratio_cap_below_cost"
+		return envelope
+	}
+
+	// Solve ratio * (our rate + amount-normalized base fee) >= required cost.
+	// math.Ceil keeps the advertised fee on the feasible side of the boundary.
+	ourBasePpm := effectivePolicyPpm(0, outgoingBaseMsat, referenceAmountSat)
+	floor := int64(math.Ceil(float64(envelope.RequiredCostPpm)/feeCfg.EconRatio - float64(ourBasePpm)))
+	if floor < 0 {
+		floor = 0
+	}
+	envelope.FeeFloorPpm = floor
+	return envelope
+}
+
+func passesAutoTargetCostGate(setting channelSetting, expectedCostPpm int64, feeBudgetPpm int64) bool {
+	return setting.AutoBypassCostGate || expectedCostPpm <= 0 || feeBudgetPpm >= expectedCostPpm
 }
 
 func (s *RebalanceService) reconcileNewChannelDefaults(ctx context.Context, channels []lndclient.ChannelInfo, settings map[uint64]channelSetting, exclusions map[uint64]bool) {
@@ -3701,7 +3826,7 @@ func (s *RebalanceService) runAutoScan() {
 	}()
 
 	revenueByChannel, _ := s.fetchChannelRevenue7d(ctx)
-	costByChannel, _ := s.fetchChannelRebalanceCost7d(ctx)
+	costByChannel, costByChannelErr := s.fetchChannelRebalanceCost7d(ctx)
 	drainRateByChannel := s.fetchChannelDrainRate24h(ctx)
 	autofeeAdjustments := s.fetchRecentAutofeeAdjustments(ctx, scanAt, time.Duration(cfg.AutofeeSettlingWindowSec)*time.Second)
 	intentCfg := defaultAutomationIntentConfig()
@@ -3746,6 +3871,11 @@ func (s *RebalanceService) runAutoScan() {
 		setting := settings[ch.ChannelID]
 		snapshot := s.buildChannelSnapshot(ctx, cfg, criticalActive, ch, setting, ledger[ch.ChannelID], revenueByChannel[ch.ChannelID], costByChannel[ch.ChannelID], drainRateByChannel[ch.ChannelID], exclusions[ch.ChannelID])
 		snapshots = append(snapshots, snapshot)
+	}
+	if costByChannelErr == nil && intentCfg.Mode != automationIntentModeOff {
+		if err := s.syncEconomicFeeFloorIntents(ctx, cfg, snapshots, scanAt, intentCfg); err != nil && s.logger != nil {
+			s.logger.Printf("rebalance economic fee floor intent sync failed: %v", err)
+		}
 	}
 	schedulerMode := normalizeRebalanceSchedulerMode(cfg.SchedulerMode)
 	// Shadow mode is a pure dry run: guaranteed slots and AutoTarget both
@@ -9496,6 +9626,83 @@ where id=$1`, jobID, status, nullableString(reason), completedAt)
 	}
 }
 
+func (s *RebalanceService) syncEconomicFeeFloorIntents(ctx context.Context, cfg RebalanceConfig, channels []RebalanceChannel, scanAt time.Time, intentCfg AutomationIntentConfig) error {
+	if s == nil || s.automationIntents == nil || normalizeAutomationIntentMode(intentCfg.Mode) == automationIntentModeOff {
+		return nil
+	}
+	if scanAt.IsZero() {
+		scanAt = time.Now().UTC()
+	}
+	ttl := time.Duration(intentCfg.ProtectFeeFloorTTLSec) * time.Second
+	if ttl <= 0 {
+		ttl = 6 * time.Hour
+	}
+	runID := fmt.Sprintf("rebalance-scan-%d", scanAt.UnixNano())
+	desired := make([]AutomationIntent, 0)
+	for _, channel := range channels {
+		if !channel.Active || channel.ChannelID == 0 {
+			continue
+		}
+		reasonCode := "rebalance_peer_fee_budget"
+		confidence := 0.92
+		feeFloorPpm := channel.EconomicFeeFloorPpm
+		if channel.EconomicFloorReason == "rebalance_cost_budget" {
+			reasonCode = "rebalance_cost_budget"
+			confidence = 0.95
+		}
+		if channel.EconomicBlockedReason == "peer_policy_unavailable" {
+			// A missing policy must never be interpreted as a zero-cost peer. Hold
+			// the current advertised fee until a fresh policy can replace it.
+			reasonCode = "rebalance_peer_policy_unavailable_hold"
+			confidence = 0.85
+			feeFloorPpm = channel.OutgoingFeePpm
+		} else if channel.EconomicBlockedReason != "" {
+			continue
+		}
+		if feeFloorPpm <= 0 {
+			continue
+		}
+		if confidence < intentCfg.MinConfidence {
+			continue
+		}
+		desired = append(desired, AutomationIntent{
+			ChannelID:       channel.ChannelID,
+			ChannelPoint:    channel.ChannelPoint,
+			Producer:        automationIntentProducerRebalance,
+			Consumer:        automationIntentProducerAutofee,
+			Kind:            automationIntentKindProtectFeeFloor,
+			Confidence:      confidence,
+			ReasonCode:      reasonCode,
+			FeeFloorPPM:     feeFloorPpm,
+			SourceRunID:     runID,
+			ProducerProfile: cfg.Profile,
+			ExpiresAt:       scanAt.Add(ttl),
+			Evidence: map[string]any{
+				"initiator":               channel.Initiator,
+				"current_outgoing_ppm":    channel.OutgoingFeePpm,
+				"peer_fee_rate_ppm":       channel.PeerFeeRatePpm,
+				"peer_base_msat":          channel.PeerBaseMsat,
+				"peer_effective_cost_ppm": effectivePolicyPpm(channel.PeerFeeRatePpm, channel.PeerBaseMsat, channel.EconomicReferenceAmountSat),
+				"rebalance_cost_7d_ppm":   channel.RebalanceCost7dPpm,
+				"required_cost_ppm":       channel.EconomicRequiredCostPpm,
+				"economic_fee_floor_ppm":  feeFloorPpm,
+				"effective_econ_ratio":    channel.EffectiveEconRatio,
+				"reference_amount_sat":    channel.EconomicReferenceAmountSat,
+				"current_fee_below_floor": channel.OutgoingFeePpm < channel.EconomicFeeFloorPpm,
+				"economic_floor_reason":   channel.EconomicFloorReason,
+			},
+		})
+	}
+	return s.automationIntents.SyncProducerKind(ctx,
+		automationIntentProducerRebalance,
+		automationIntentProducerAutofee,
+		automationIntentKindProtectFeeFloor,
+		runID,
+		scanAt,
+		desired,
+	)
+}
+
 func (s *RebalanceService) publishProtectFeeFloorIntent(jobID int64, status string, completedAt time.Time) {
 	if s == nil || s.db == nil || s.automationIntents == nil || jobID <= 0 {
 		return
@@ -9541,6 +9748,15 @@ group by j.target_channel_id, j.target_channel_point, j.source, j.target_amount_
 		ttl = 6 * time.Hour
 	}
 	rebalanceCfg, _ := s.GetConfig(ctx)
+	effectiveEconRatio := rebalanceCfg.EconRatio
+	if settings, settingsErr := s.loadChannelSettings(ctx); settingsErr == nil {
+		feeCfg := effectiveConfigForTarget(rebalanceCfg, settings[uint64(channelID)])
+		effectiveEconRatio = feeCfg.EconRatio
+	}
+	feeFloorPPM := costPPM
+	if rebalanceCfg.FeeLimitPpm <= 0 && effectiveEconRatio > 0 {
+		feeFloorPPM = int64(math.Ceil(float64(costPPM) / effectiveEconRatio))
+	}
 	nodeCalibration := RebalanceNodeCalibration{NodeClass: "unknown", LiquidityClass: "balanced"}
 	if channels, channelsErr := s.listChannelsCached(ctx); channelsErr == nil {
 		nodeCalibration = classifyRebalanceNode(channels)
@@ -9553,7 +9769,7 @@ group by j.target_channel_id, j.target_channel_point, j.source, j.target_amount_
 		Kind:                   automationIntentKindProtectFeeFloor,
 		Confidence:             confidence,
 		ReasonCode:             "rebalance_paid_liquidity",
-		FeeFloorPPM:            costPPM,
+		FeeFloorPPM:            feeFloorPPM,
 		SourceRunID:            fmt.Sprintf("job-%d", jobID),
 		SourceJobID:            jobID,
 		ProducerProfile:        rebalanceCfg.Profile,
@@ -9561,13 +9777,15 @@ group by j.target_channel_id, j.target_channel_point, j.source, j.target_amount_
 		ProducerLiquidityClass: nodeCalibration.LiquidityClass,
 		ExpiresAt:              completedAt.Add(ttl),
 		Evidence: map[string]any{
-			"job_status":        status,
-			"job_source":        source,
-			"moved_sat":         movedSat,
-			"fee_paid_sat":      feePaidSat,
-			"cost_ppm":          costPPM,
-			"target_amount_sat": targetAmountSat,
-			"node_local_ratio":  nodeCalibration.LocalRatio,
+			"job_status":             status,
+			"job_source":             source,
+			"moved_sat":              movedSat,
+			"fee_paid_sat":           feePaidSat,
+			"cost_ppm":               costPPM,
+			"economic_fee_floor_ppm": feeFloorPPM,
+			"effective_econ_ratio":   effectiveEconRatio,
+			"target_amount_sat":      targetAmountSat,
+			"node_local_ratio":       nodeCalibration.LocalRatio,
 		},
 	}
 	if err := s.automationIntents.UpsertIntent(ctx, intent, completedAt); err != nil && s.logger != nil {
@@ -9809,11 +10027,13 @@ func (s *RebalanceService) buildChannelSnapshot(ctx context.Context, cfg Rebalan
 	outgoingBaseMsat := int64(0)
 	peerFeeRate := int64(0)
 	peerBaseMsat := int64(0)
+	peerPolicyKnown := false
 	if ch.FeeRatePpm != nil {
 		outgoingFee = *ch.FeeRatePpm
 	}
 	policies, err := s.lnd.GetChannelPolicies(ctx, ch.ChannelID)
 	if err == nil {
+		peerPolicyKnown = true
 		outgoingFee = policies.Local.FeeRatePpm
 		outgoingBaseMsat = policies.Local.BaseFeeMsat
 		peerFeeRate = policies.Remote.FeeRatePpm
@@ -9852,22 +10072,14 @@ func (s *RebalanceService) buildChannelSnapshot(ctx context.Context, cfg Rebalan
 	}
 	timeToPaybackHours, timeToPaybackValid := estimateTimeToPaybackHours(paidRevenue, paidCost, revenue7dSat)
 
-	// Wave 1.4: per-channel econ ratio (defaults to global cfg.EconRatio).
-	effectiveEconRatio := cfg.EconRatio
-	if !setting.UseDefaultEconRatio && setting.EconRatioOverrideSet {
-		effectiveEconRatio = setting.EconRatioOverride
-	}
-	if effectiveEconRatio <= 0 {
-		effectiveEconRatio = cfg.EconRatio
-	}
 	expectedCostPpm := cost7d.FeePpm
 	if expectedCostPpm <= 0 {
 		expectedCostPpm = cfg.RebalanceCostFloorPpm
 	}
-	effectiveSpreadPpm := int64(0)
-	if spread > 0 && effectiveEconRatio > 0 {
-		effectiveSpreadPpm = int64(float64(spread) * effectiveEconRatio)
-	}
+	economicEnvelope := deriveRebalanceEconomicEnvelope(
+		cfg, setting, ch.Initiator, ch.Active, parked, peerPolicyKnown,
+		localPct, target, outgoingFee, outgoingBaseMsat, peerFeeRate, peerBaseMsat, cost7d.FeePpm,
+	)
 
 	eligibleTarget := false
 	deficitPct := target - localPct
@@ -9877,14 +10089,15 @@ func (s *RebalanceService) buildChannelSnapshot(ctx context.Context, cfg Rebalan
 	// economic filter and the ROI guardrail — those are auto/auto-restart
 	// only — so the UI should not disable the "Manual Rebal In" button just
 	// because EligibleAsTarget is false.
-	eligibleManualTarget := ch.Active && !parked && deficitPct > cfg.DeadbandPct && outgoingFee > peerFeeRate
+	pricingFeasible := peerPolicyKnown && economicEnvelope.FeeBudgetPpm >= economicEnvelope.PeerCostPpm
+	eligibleManualTarget := ch.Active && !parked && deficitPct > cfg.DeadbandPct && pricingFeasible
 	if eligibleManualTarget {
-		// Wave 1.4: require effective spread to clear the expected rebalance
+		// Require the actual route budget to clear the expected total rebalance
 		// cost (historical 7d ppm, or cfg.RebalanceCostFloorPpm fallback).
 		// auto_bypass_cost_gate is a per-channel operator override for cases
 		// where explicit strategy should win over this conservative gate. It
 		// does not bypass ROI/profit guardrails later in the auto scan.
-		if passesAutoTargetCostGate(setting, expectedCostPpm, effectiveSpreadPpm) {
+		if passesAutoTargetCostGate(setting, expectedCostPpm, economicEnvelope.FeeBudgetPpm) {
 			eligibleTarget = true
 		}
 	}
@@ -9987,6 +10200,15 @@ func (s *RebalanceService) buildChannelSnapshot(ctx context.Context, cfg Rebalan
 		PeerFeeRatePpm:             peerFeeRate,
 		PeerBaseMsat:               peerBaseMsat,
 		SpreadPpm:                  spread,
+		Initiator:                  ch.Initiator,
+		PeerPolicyKnown:            peerPolicyKnown,
+		EffectiveEconRatio:         economicEnvelope.EffectiveEconRatio,
+		FeeBudgetPpm:               economicEnvelope.FeeBudgetPpm,
+		EconomicFeeFloorPpm:        economicEnvelope.FeeFloorPpm,
+		EconomicRequiredCostPpm:    economicEnvelope.RequiredCostPpm,
+		EconomicReferenceAmountSat: economicEnvelope.ReferenceAmountSat,
+		EconomicFloorReason:        economicEnvelope.FloorReason,
+		EconomicBlockedReason:      economicEnvelope.BlockedReason,
 		TargetOutboundPct:          target,
 		TargetAmountSat:            targetAmount,
 		AutoEnabled:                setting.AutoEnabled,

--- a/lightningos-light/internal/server/rebalance_service_test.go
+++ b/lightningos-light/internal/server/rebalance_service_test.go
@@ -1827,22 +1827,72 @@ func TestApplyRebalanceConfigPayloadOnlyTouchesProvidedFields(t *testing.T) {
 	}
 }
 
-func TestAutoTargetCostGateRequiresSpreadAboveExpectedCost(t *testing.T) {
+func TestAutoTargetCostGateRequiresRouteBudgetAtExpectedCost(t *testing.T) {
 	if passesAutoTargetCostGate(channelSetting{}, 131, 88) {
-		t.Fatalf("expected cost gate to block when effective spread is below expected cost")
+		t.Fatalf("expected cost gate to block when route budget is below expected cost")
 	}
-	if !passesAutoTargetCostGate(channelSetting{}, 131, 132) {
-		t.Fatalf("expected cost gate to pass when effective spread is above expected cost")
+	if !passesAutoTargetCostGate(channelSetting{}, 131, 131) {
+		t.Fatalf("expected cost gate to pass when route budget covers expected cost")
 	}
 	if !passesAutoTargetCostGate(channelSetting{}, 0, 0) {
 		t.Fatalf("expected zero expected cost to pass")
 	}
 }
 
-func TestAutoTargetCostGateBypassAllowsBelowCostSpread(t *testing.T) {
+func TestAutoTargetCostGateBypassAllowsBelowCostBudget(t *testing.T) {
 	setting := channelSetting{AutoBypassCostGate: true}
 	if !passesAutoTargetCostGate(setting, 131, 88) {
-		t.Fatalf("expected auto cost gate bypass to allow below-cost effective spread")
+		t.Fatalf("expected auto cost gate bypass to allow a below-cost route budget")
+	}
+}
+
+func TestDeriveRebalanceEconomicEnvelope(t *testing.T) {
+	baseCfg := RebalanceConfig{
+		DeadbandPct:     3,
+		EconRatio:       0.75,
+		MinAmountSat:    50_000,
+		MinSplitEnabled: true,
+		MinExecuteSat:   10_000,
+	}
+	baseSetting := channelSetting{AutoEnabled: true, UseDefaultEconRatio: true}
+
+	tests := []struct {
+		name             string
+		cfg              RebalanceConfig
+		setting          channelSetting
+		initiator        bool
+		policyKnown      bool
+		outgoingBaseMsat int64
+		peerRatePpm      int64
+		peerBaseMsat     int64
+		costPpm          int64
+		wantPeerPpm      int64
+		wantRequiredPpm  int64
+		wantFloorPpm     int64
+		wantBlocked      string
+	}{
+		{name: "new outbound remains seed driven", cfg: baseCfg, setting: baseSetting, initiator: true, policyKnown: true, peerRatePpm: 500, wantPeerPpm: 500},
+		{name: "new inbound peer 500 at ratio 075", cfg: baseCfg, setting: baseSetting, policyKnown: true, peerRatePpm: 500, wantPeerPpm: 500, wantRequiredPpm: 500, wantFloorPpm: 667},
+		{name: "peer base fee uses minimum shard", cfg: baseCfg, setting: baseSetting, policyKnown: true, peerRatePpm: 725, peerBaseMsat: 1000, wantPeerPpm: 825, wantRequiredPpm: 825, wantFloorPpm: 1100},
+		{name: "current peer dominates stale lower cost", cfg: baseCfg, setting: baseSetting, policyKnown: true, peerRatePpm: 553, costPpm: 332, wantPeerPpm: 553, wantRequiredPpm: 553, wantFloorPpm: 738},
+		{name: "observed total cost dominates peer", cfg: baseCfg, setting: baseSetting, initiator: true, policyKnown: true, peerRatePpm: 100, costPpm: 900, wantPeerPpm: 100, wantRequiredPpm: 900, wantFloorPpm: 1200},
+		{name: "our base fee contributes to revenue", cfg: baseCfg, setting: baseSetting, policyKnown: true, outgoingBaseMsat: 1000, peerRatePpm: 500, wantPeerPpm: 500, wantRequiredPpm: 500, wantFloorPpm: 567},
+		{name: "missing peer policy blocks cold inbound", cfg: baseCfg, setting: baseSetting, wantBlocked: "peer_policy_unavailable"},
+		{name: "fixed route budget cannot be repaired by advertised fee", cfg: func() RebalanceConfig { c := baseCfg; c.FeeLimitPpm = 400; return c }(), setting: baseSetting, policyKnown: true, peerRatePpm: 500, wantPeerPpm: 500, wantRequiredPpm: 500, wantBlocked: "fixed_fee_budget_below_cost"},
+		{name: "proportional cap below peer cost is blocked", cfg: func() RebalanceConfig { c := baseCfg; c.EconRatioMaxPpm = 600; return c }(), setting: baseSetting, policyKnown: true, peerRatePpm: 725, wantPeerPpm: 725, wantRequiredPpm: 725, wantBlocked: "econ_ratio_cap_below_cost"},
+		{name: "per channel ratio override", cfg: baseCfg, setting: channelSetting{AutoEnabled: true, UseDefaultEconRatio: false, EconRatioOverrideSet: true, EconRatioOverride: 0.5}, policyKnown: true, peerRatePpm: 500, wantPeerPpm: 500, wantRequiredPpm: 500, wantFloorPpm: 1000},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := deriveRebalanceEconomicEnvelope(
+				test.cfg, test.setting, test.initiator, true, false, test.policyKnown,
+				0, 10, 500, test.outgoingBaseMsat, test.peerRatePpm, test.peerBaseMsat, test.costPpm,
+			)
+			if got.PeerCostPpm != test.wantPeerPpm || got.RequiredCostPpm != test.wantRequiredPpm || got.FeeFloorPpm != test.wantFloorPpm || got.BlockedReason != test.wantBlocked {
+				t.Fatalf("unexpected envelope: got=%+v want peer=%d required=%d floor=%d blocked=%q", got, test.wantPeerPpm, test.wantRequiredPpm, test.wantFloorPpm, test.wantBlocked)
+			}
+		})
 	}
 }
 

--- a/lightningos-light/ui/src/components/rebalance/types.ts
+++ b/lightningos-light/ui/src/components/rebalance/types.ts
@@ -375,6 +375,15 @@ export type RebalanceChannel = {
   peer_fee_rate_ppm: number
   peer_base_msat: number
   spread_ppm: number
+  initiator: boolean
+  peer_policy_known: boolean
+  effective_econ_ratio: number
+  fee_budget_ppm: number
+  economic_fee_floor_ppm: number
+  economic_required_cost_ppm: number
+  economic_reference_amount_sat: number
+  economic_floor_reason?: string
+  economic_blocked_reason?: string
   target_outbound_pct: number
   target_amount_sat: number
   auto_enabled: boolean

--- a/lightningos-light/ui/src/i18n/en.json
+++ b/lightningos-light/ui/src/i18n/en.json
@@ -5448,7 +5448,7 @@
       "criticalMinSources": "Minimum eligible sources required to avoid critical mode.",
       "criticalMinAvailable": "Minimum total source liquidity required to avoid critical mode.",
       "criticalCycles": "Number of consecutive critical scans before releasing.",
-      "rebalanceCostFloorPpm": "Assumed cost ppm used when a target has no recent rebalance history. Channels are only eligible as targets when (spread × econ ratio) exceeds this floor.",
+      "rebalanceCostFloorPpm": "Assumed cost ppm used when a target has no recent rebalance history. Channels are only eligible as targets when the effective route budget covers this floor.",
       "sourceMinPaybackProgress": "Minimum lifetime payback (forwarding revenue / rebalance cost) for a channel to qualify as source. Default 0.95 — channels must be near or above break-even before being drained again. Set to 0 to disable. Set to 1.0 for strict break-even. Channels with insignificant historical cost (under 500 sat) bypass this filter so freshly opened channels remain eligible.",
       "missionControlReinforce": "After every successful rebalance attempt, push positive history entries for each pair on the route into LND's Mission Control. Helps LND learn good paths faster and recover from MC poisoning. Off by default; enable if your node has chronic 'no path' errors despite known-good routes.",
       "delegatedFastPath": "Before iterating source-by-source, tries a single SendPaymentV2 call with ALL eligible sources and MPP enabled, letting LND's native pathfinder and Mission Control choose paths and shard the payment. On success, finalizes the job and skips the legacy loop. On failure, falls back to the source-by-source loop normally. Recommended in environments where you see 'no path' errors despite viable sources existing.",
@@ -5478,6 +5478,8 @@
         "fees": "Fees (out / peer rate)",
       "feeOut": "Out {{value}} ppm",
       "feePeer": "Peer {{value}} ppm",
+      "economicFloor": "Econ floor {{value}} ppm · budget {{budget}} ppm",
+      "economicBlocked": "Economic budget blocked",
         "target": "Target outbound",
         "protected": "Protected",
         "actions": "Actions",
@@ -5535,7 +5537,7 @@
       "targetOutbound": "Desired outbound liquidity percentage after the rebalance.",
       "econRatio": "Channel-specific econ ratio in decimal format (0.01 to 0.99).",
       "useDefaultEconRatio": "Use the global econ ratio from Rebalance Settings.",
-      "autoBypassCostGate": "Let auto scan and manual auto-restart consider this channel as a target even when spread × econ ratio does not exceed recent rebalance cost. ROI, profit, budget, cooldown, and source guardrails still apply. Off by default; use only when the operator intentionally wants this channel refilled.",
+      "autoBypassCostGate": "Let auto scan and manual auto-restart consider this channel as a target even when the effective route budget does not cover recent rebalance cost. ROI, profit, budget, cooldown, and source guardrails still apply. Off by default; use only when the operator intentionally wants this channel refilled.",
       "autoBypassCostGateConviction": "Redundant here: Conviction mode is on, so this manual-restart channel already ignores the cost gate (and ROI). This toggle only matters for Auto channels or when Conviction mode is off.",
       "save": "Save target outbound, channel econ ratio, and cost-gate override.",
       "rebalanceIn": "Start a rebalance to increase local (outbound) liquidity.",
@@ -5932,13 +5934,13 @@
       "title": "What is happening with {{alias}}?",
       "kinds": {
         "refill_target": "AutoFee detected that this channel is drained and published a request for Rebalance to consider replenishing its outbound liquidity.",
-        "protect_fee_floor": "A recent successful rebalance created a temporary cost-protection floor so AutoFee does not immediately lower this channel's fee below the recovered cost basis. Upward fee moves remain allowed."
+        "protect_fee_floor": "Rebalance calculated a temporary economic floor from the peer policy, known actual cost, and effective econ ratio. AutoFee can raise a fee below the floor or prevent a reduction through it."
       },
       "refillInfluenced": "In the latest known evaluation, the Rebalance score changed from {{before}} to {{after}} sats. {{reason}}",
       "waitingRebalanceScan": "The signal is ready, but there is no Rebalance decision snapshot after the manager restart yet. The next scan will show whether it changes the ranking.",
       "refillNotChanged": "The signal was available but did not produce a measurable ranking change. {{reason}}",
-      "floorInfluenced": "AutoFee consumed the protection while evaluating a downward fee move: {{before}} → {{after}} ppm.",
-      "waitingAutofeeDecision": "The floor is active, but AutoFee has not yet recorded a downward decision that needed this protection.",
+      "floorInfluenced": "AutoFee consumed the economic protection while evaluating the fee: {{before}} → {{after}} ppm.",
+      "waitingAutofeeDecision": "The floor is active, but AutoFee has not yet recorded a decision that needed this protection.",
       "stillSubjectToGates": "The candidate still has to pass profit, ROI, budget, cooldown, source, and concurrency gates.",
       "noMeasurableDelta": "The confidence-adjusted multiplier may have rounded to the same score, or the candidate remained outside the applicable decision set.",
       "modes": {

--- a/lightningos-light/ui/src/i18n/pt-BR.json
+++ b/lightningos-light/ui/src/i18n/pt-BR.json
@@ -5448,7 +5448,7 @@
       "criticalMinSources": "Mínimo de fontes elegíveis para evitar modo crítico.",
       "criticalMinAvailable": "Mínimo de liquidez total para evitar modo crítico.",
       "criticalCycles": "Número de ciclos críticos antes de liberar.",
-      "rebalanceCostFloorPpm": "Custo ppm assumido quando o canal não tem histórico recente de rebal. Um canal só vira alvo se (spread × econ ratio) > este piso.",
+      "rebalanceCostFloorPpm": "Custo ppm assumido quando o canal não tem histórico recente de rebal. Um canal só vira alvo se o budget efetivo da rota cobrir este piso.",
       "sourceMinPaybackProgress": "Payback mínimo de vida (receita de forward / custo de rebal) para o canal ser elegível como source. Padrão 0.95 — canais precisam estar próximos ou acima do break-even antes de serem drenados de novo. Coloque 0 para desativar. Coloque 1.0 para exigir break-even estrito. Canais com custo histórico irrelevante (abaixo de 500 sat) ignoram este filtro, então canais novos continuam elegíveis.",
       "missionControlReinforce": "A cada rebalance bem-sucedido, envia entradas positivas para cada par da rota ao Mission Control do LND. Ajuda o LND a aprender caminhos bons mais rápido e recuperar de envenenamento do MC. Desativado por padrão; ative se seu nó tem erros 'no path' crônicos apesar de rotas conhecidas funcionarem.",
       "delegatedFastPath": "Antes de iterar source-por-source, tenta uma única chamada SendPaymentV2 com TODAS as sources elegíveis e MPP ligado, deixando o pathfinder e o Mission Control nativos do LND escolherem rota e fragmentação. Em sucesso, finaliza o job e pula o loop tradicional. Em falha, cai no loop legado normalmente. Recomendado em ambientes onde aparecem muitos 'no path' apesar de existirem sources viáveis.",
@@ -5478,6 +5478,8 @@
       "fees": "Fees (out / peer rate)",
       "feeOut": "Out {{value}} ppm",
       "feePeer": "Peer {{value}} ppm",
+      "economicFloor": "Piso econ {{value}} ppm · budget {{budget}} ppm",
+      "economicBlocked": "Budget econômico bloqueado",
       "target": "Alvo outbound",
       "protected": "Protegido",
       "actions": "Ações",
@@ -5535,7 +5537,7 @@
       "targetOutbound": "Percentual de outbound desejado após o rebalance.",
       "econRatio": "Ratio econômico por canal em formato decimal (0.01 a 0.99).",
       "useDefaultEconRatio": "Usa o ratio econômico global das configurações de Rebalance.",
-      "autoBypassCostGate": "Permite que o auto scan e o auto-restart manual considerem este canal como target mesmo quando spread × econ ratio não supera o custo recente de rebalance. ROI, lucro, orçamento, cooldown e guardrails de source continuam valendo. Desativado por padrão; use apenas quando o operador quer explicitamente repor liquidez neste canal.",
+      "autoBypassCostGate": "Permite que o auto scan e o auto-restart manual considerem este canal como target mesmo quando o budget efetivo da rota não cobre o custo recente de rebalance. ROI, lucro, orçamento, cooldown e guardrails de source continuam valendo. Desativado por padrão; use apenas quando o operador quer explicitamente repor liquidez neste canal.",
       "autoBypassCostGateConviction": "Redundante aqui: o Modo convicção está ligado, então este canal manual restart já ignora o cost gate (e o ROI). Este toggle só importa para canais Auto ou quando o Modo convicção está desligado.",
       "save": "Salvar target outbound, ratio econômico e override do gate de custo.",
       "rebalanceIn": "Iniciar rebalance manual para aumentar liquidez local (outbound).",
@@ -5932,13 +5934,13 @@
       "title": "O que está acontecendo com {{alias}}?",
       "kinds": {
         "refill_target": "O AutoFee detectou que este canal está drenado e publicou um pedido para o Rebalance considerar a reposição da liquidez outbound.",
-        "protect_fee_floor": "Um rebalance recente bem-sucedido criou um piso temporário de proteção de custo para o AutoFee não reduzir imediatamente a fee deste canal abaixo da base de custo recuperada. Aumentos de fee continuam permitidos."
+        "protect_fee_floor": "O Rebalance calculou um piso econômico temporário usando a policy do peer, o custo real conhecido e o econ ratio efetivo. O AutoFee pode elevar uma fee abaixo do piso ou impedir que ela seja reduzida através dele."
       },
       "refillInfluenced": "Na avaliação mais recente conhecida, o score do Rebalance mudou de {{before}} para {{after}} sats. {{reason}}",
       "waitingRebalanceScan": "O sinal está pronto, mas ainda não existe um snapshot de decisões do Rebalance após o restart do manager. O próximo scan mostrará se ele altera o ranking.",
       "refillNotChanged": "O sinal estava disponível, mas não produziu uma alteração mensurável no ranking. {{reason}}",
-      "floorInfluenced": "O AutoFee consumiu a proteção ao avaliar uma redução da fee: {{before}} → {{after}} ppm.",
-      "waitingAutofeeDecision": "O piso está ativo, mas o AutoFee ainda não registrou uma decisão de redução que precisasse dessa proteção.",
+      "floorInfluenced": "O AutoFee consumiu a proteção econômica ao avaliar a fee: {{before}} → {{after}} ppm.",
+      "waitingAutofeeDecision": "O piso está ativo, mas o AutoFee ainda não registrou uma decisão que precisasse dessa proteção.",
       "stillSubjectToGates": "O candidato ainda precisa passar pelos gates de lucro, ROI, orçamento, cooldown, fontes e concorrência.",
       "noMeasurableDelta": "O multiplicador ajustado pela confiança pode ter arredondado para o mesmo score, ou o candidato permaneceu fora do conjunto de decisões aplicável.",
       "modes": {

--- a/lightningos-light/ui/src/pages/RebalanceCenter.tsx
+++ b/lightningos-light/ui/src/pages/RebalanceCenter.tsx
@@ -4001,6 +4001,14 @@ export default function RebalanceCenter() {
                     <div>{t('rebalanceCenter.channels.feeOut', { value: ch.outgoing_fee_ppm })}</div>
                     <div>{t('rebalanceCenter.channels.feePeer', { value: ch.peer_fee_rate_ppm })}</div>
                     <div className="text-fog/50">{t('rebalanceCenter.channels.spread', { value: ch.spread_ppm })}</div>
+                    {ch.economic_fee_floor_ppm > 0 && (
+                      <div className={ch.outgoing_fee_ppm < ch.economic_fee_floor_ppm ? 'text-amber-300' : 'text-emerald-300/80'}>
+                        {t('rebalanceCenter.channels.economicFloor', { value: ch.economic_fee_floor_ppm, budget: ch.fee_budget_ppm })}
+                      </div>
+                    )}
+                    {ch.economic_blocked_reason && (
+                      <div className="text-rose-300" title={ch.economic_blocked_reason}>{t('rebalanceCenter.channels.economicBlocked')}</div>
+                    )}
                   </div>
                 </div>
 
@@ -4282,6 +4290,14 @@ export default function RebalanceCenter() {
                       {t('rebalanceCenter.channels.feePeer', { value: ch.peer_fee_rate_ppm })}
                     </div>
                     <div className="text-xs text-fog/50">{t('rebalanceCenter.channels.spread', { value: ch.spread_ppm })}</div>
+                    {ch.economic_fee_floor_ppm > 0 && (
+                      <div className={`text-xs ${ch.outgoing_fee_ppm < ch.economic_fee_floor_ppm ? 'text-amber-300' : 'text-emerald-300/80'}`}>
+                        {t('rebalanceCenter.channels.economicFloor', { value: ch.economic_fee_floor_ppm, budget: ch.fee_budget_ppm })}
+                      </div>
+                    )}
+                    {ch.economic_blocked_reason && (
+                      <div className="text-xs text-rose-300" title={ch.economic_blocked_reason}>{t('rebalanceCenter.channels.economicBlocked')}</div>
+                    )}
                   </td>
                   <td className="py-3 pl-4">
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
## Objetivo

Corrige o deadlock econômico entre AutoFee, Rebalance e Automation Interlock em canais inbound abertos pelo peer.

Quando o peer cobra `P` ppm e o canal usa `econ_ratio = R`, a fee outbound mínima passa a respeitar `ceil(P / R)`, incluindo base fee normalizada pelo menor shard executável. Custos reais recentes prevalecem quando forem maiores que a policy do peer.

## Mudanças

- cria um envelope econômico único por canal, com ratio efetivo, budget de rota, custo requerido, piso de fee, amount de referência e motivo de bloqueio;
- publica `protect_fee_floor` preventivamente para canais remote-opened abaixo do target, rompendo o ciclo fee baixa -> target inelegível -> nenhum sinal;
- transforma custo real de rebalance em piso via `cost_ppm / econ_ratio`;
- permite ao AutoFee elevar fees abaixo do piso e preservar o piso em reduções;
- faz correções econômicas ignorarem cooldown/churn/settling, mantendo o teto contratual Magma;
- quando a policy do peer está indisponível, mantém a fee atual em vez de assumir peer zero;
- alinha o cost gate ao limite realmente enviado ao LND: `route budget >= expected total cost`, eliminando o desconto duplo da fee do peer;
- expõe os diagnósticos na API e no Rebalance Center;
- atualiza documentação PT-BR/EN.

## Casos cobertos

- novo outbound continua seed-driven;
- novo inbound com peer 500 e ratio 0,75 gera piso 667 ppm;
- NOVA: peer 553 -> piso 738 ppm;
- ARCFLOWEX: peer 725 + base 1 sat no shard de 10k -> piso 1.100 ppm;
- custo real maior que peer;
- base fee local e remota;
- override de ratio por canal;
- policy ausente;
- fee limit fixo e econ ratio cap incompatíveis;
- modos enforce/shadow e teto externo/Magma.

## Validação

- `go test ./... -count=1`
- `npm.cmd run build`