### PR TITLE
0.5.22-Beta: expire stale inbound fee discounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ Movement settings (drawer in the Autofee card):
 - `Step cap override (%)`: maximum fee change allowed per run. Higher = more movement per round; lower = smoother behavior.
 - `Discovery down cap override (%)`: extra down-step cap used in discovery-like scenarios. Higher = faster unlock/down moves.
 - `Stall relax gap trigger (%)`: minimum gap between current fee and target before stall-relax softens the floor. Lower = relaxes earlier; higher = protects floors longer.
-- `Inbound discount max ratio (%)`: maximum inbound discount as a share of the applied outbound fee. Higher = more aggressive inbound pricing for sink-like channels.
+- `Inbound discount max ratio (%)`: maximum inbound discount as a share of the applied outbound fee (5-100%; blank uses the profile). Higher = more aggressive inbound pricing for sink-like channels.
 - `Inbound discount reach out ratio (%)`: maximum effective out-ratio still eligible for passive inbound discount. Higher = broader reach.
 - `Inbound discount min retained spread (%)`: minimum retained spread above the cost anchor when applying inbound discount. Higher = stronger profit protection.
 - `Low-flow floor factor override (%)`: multiplier applied to the floor when outbound flow is low. Higher = keeps fees higher; lower = allows lower floors.

--- a/docs/AUTOFEE_TAG_GLOSSARIO_PT_BR.md
+++ b/docs/AUTOFEE_TAG_GLOSSARIO_PT_BR.md
@@ -112,6 +112,9 @@ Notas:
 - `new-inbound`: canal identificado como inbound novo.
 - `bootstrap`: fase de bootstrap de fee para canal novo.
 - `inb-<n>`: desconto inbound aplicado (`n` ppm).
+- `inbound-grace`: um desconto existente foi mantido temporariamente depois que o canal deixou de ser elegivel.
+- `inbound-decay`: o desconto inelegivel esta sendo reduzido ate zero depois do periodo de carencia.
+- `inbound-normalize`: o desconto foi limitado imediatamente pela proporcao de seguranca da fee outbound atual.
 
 ## Market refill
 - `market-refill`: canal sendo precificado no modo global `Market refill`.

--- a/docs/AUTOFEE_TAG_GLOSSARY_EN.md
+++ b/docs/AUTOFEE_TAG_GLOSSARY_EN.md
@@ -112,6 +112,9 @@ Notes:
 - `new-inbound`: recently opened inbound channel detected.
 - `bootstrap`: bootstrap phase for new channel pricing.
 - `inb-<n>`: inbound discount applied (`n` ppm).
+- `inbound-grace`: an existing discount was retained temporarily after the channel stopped qualifying.
+- `inbound-decay`: an ineligible discount is being reduced toward zero after its grace period.
+- `inbound-normalize`: the discount was capped immediately to the current outbound-fee safety ratio.
 
 ## Market refill
 - `market-refill`: channel is being priced under the global `Market refill` mode.

--- a/docs/README-PT-BR.md
+++ b/docs/README-PT-BR.md
@@ -566,7 +566,7 @@ Configuracoes de movimento (gaveta no card do Autofee):
 - `Step cap override (%)`: mudanca maxima permitida por rodada. Maior = mais movimento por execucao; menor = comportamento mais suave.
 - `Discovery down cap override (%)`: cap extra de queda em cenarios de discovery. Maior = destrava e abaixa mais rapido.
 - `Stall relax gap trigger (%)`: gap minimo entre fee atual e alvo antes do stall-relax suavizar o piso. Menor = relaxa antes; maior = preserva o piso por mais tempo.
-- `Inbound discount max ratio (%)`: desconto inbound maximo como fracao da fee outbound aplicada. Maior = pricing inbound mais agressivo em canais tipo sink.
+- `Inbound discount max ratio (%)`: desconto inbound maximo como fracao da fee outbound aplicada (5-100%; vazio usa o perfil). Maior = pricing inbound mais agressivo em canais tipo sink.
 - `Inbound discount reach out ratio (%)`: out ratio efetivo maximo ainda elegivel para discount inbound passivo. Maior = alcance maior.
 - `Inbound discount min retained spread (%)`: spread minimo que precisa sobrar acima da ancora de custo. Maior = mais protecao de lucro.
 - `Low-flow floor factor override (%)`: multiplicador aplicado ao piso quando o fluxo de saida esta baixo. Maior = mantem fees mais altas; menor = permite pisos mais baixos.

--- a/lightningos-light/internal/server/autofee_evaluate_golden_test.go
+++ b/lightningos-light/internal/server/autofee_evaluate_golden_test.go
@@ -292,6 +292,12 @@ func TestEvaluateChannelNormalizesExtremeCurrentInboundPolicy(t *testing.T) {
 	if st.LastInboundDiscount != 450 {
 		t.Fatalf("expected state inbound discount to be normalized, got %d", st.LastInboundDiscount)
 	}
+	if st.InboundStaleRounds != 1 {
+		t.Fatalf("expected first ineligible grace round to be persisted, got %d", st.InboundStaleRounds)
+	}
+	if !goldenHasAnyTag(decision.Tags, "inbound-normalize") || !goldenHasAnyTag(decision.Tags, "inbound-grace") {
+		t.Fatalf("expected inbound lifecycle tags, got %v", decision.Tags)
+	}
 }
 
 func TestEvaluateChannelGolden_OrganicRefillCapsRevfloor(t *testing.T) {

--- a/lightningos-light/internal/server/autofee_service.go
+++ b/lightningos-light/internal/server/autofee_service.go
@@ -229,6 +229,9 @@ const (
 	classificationRouterBiasAbsMax      = 0.25
 	classificationLabelSwitchMinDelta   = 0.07
 	defaultInboundDiscountMaxRatio      = 0.90
+	inboundDiscountGraceRounds          = 2
+	inboundDiscountDecayFraction        = 0.25
+	inboundDiscountDecayMinPpm          = 25
 )
 
 func normalizeRebalCostMode(value string) string {
@@ -1324,6 +1327,7 @@ create table if not exists autofee_state (
   channel_id bigint primary key,
   last_ppm integer,
   last_inbound_discount_ppm integer,
+  inbound_ineligible_rounds integer not null default 0,
   last_seed_ppm integer,
   seed_shock_pending_ppm integer,
   seed_shock_rounds integer not null default 0,
@@ -1449,6 +1453,7 @@ alter table autofee_state add column if not exists last_idle_refresh_source text
 alter table autofee_state add column if not exists seed_shock_pending_ppm integer;
 alter table autofee_state add column if not exists seed_shock_rounds integer not null default 0;
 alter table autofee_state add column if not exists seed_shock_dir text;
+alter table autofee_state add column if not exists inbound_ineligible_rounds integer not null default 0;
 alter table autofee_logs add column if not exists payload jsonb;
 alter table autofee_outcomes add column if not exists liquidity_state text;
 `)
@@ -1771,11 +1776,7 @@ func (s *AutofeeService) UpdateConfig(ctx context.Context, req AutofeeConfigUpda
 	} else if current.StallFloorRelaxGapFracOverride > 0 {
 		current.StallFloorRelaxGapFracOverride = clampFloat(current.StallFloorRelaxGapFracOverride, 0.01, 0.80)
 	}
-	if current.InboundDiscountMaxRatioOverride < 0 {
-		current.InboundDiscountMaxRatioOverride = 0
-	} else if current.InboundDiscountMaxRatioOverride > 0 {
-		current.InboundDiscountMaxRatioOverride = clampFloat(current.InboundDiscountMaxRatioOverride, 0.50, 1.00)
-	}
+	current.InboundDiscountMaxRatioOverride = normalizeInboundDiscountMaxRatioOverride(current.InboundDiscountMaxRatioOverride)
 	if current.InboundDiscountReachOutRatioOverride < 0 {
 		current.InboundDiscountReachOutRatioOverride = 0
 	} else if current.InboundDiscountReachOutRatioOverride > 0 {
@@ -3085,6 +3086,7 @@ type autofeeChannelState struct {
 	ChannelID           uint64
 	LastPpm             int
 	LastInboundDiscount int
+	InboundStaleRounds  int
 	LastSeed            int
 	SeedShockPendingPpm int
 	SeedShockRounds     int
@@ -3276,6 +3278,13 @@ func (s *AutofeeService) refreshReferenceFees(ctx context.Context, opts autofeeR
 	if err != nil {
 		return result, err
 	}
+	states := map[uint64]*autofeeChannelState{}
+	if includeInbound {
+		states, err = engine.loadState(ctx)
+		if err != nil {
+			return result, err
+		}
+	}
 
 	forwardStats7d, err := engine.fetchForwardStats(ctx, 7)
 	if err != nil {
@@ -3424,9 +3433,14 @@ func (s *AutofeeService) refreshReferenceFees(ctx context.Context, opts autofeeR
 		item.CurrentInboundDiscount = currentInboundDiscountFromPolicy(policy)
 		item.TargetInboundDiscount = item.CurrentInboundDiscount
 		if includeInbound {
+			classLabel := ""
+			if state := states[ch.ChannelID]; state != nil {
+				classLabel = state.ClassLabel
+			}
 			if targetInboundDiscount, inboundSource, applyInbound := selectAutofeeRefreshInboundDiscount(
 				cfg,
 				engine.profile,
+				classLabel,
 				rawOutRatio,
 				effectiveOutRatio,
 				forwardStats1d[ch.ChannelID],
@@ -5193,6 +5207,13 @@ func inboundDiscountMaxRatioFromConfig(cfg AutofeeConfig) float64 {
 	return defaultInboundDiscountMaxRatio
 }
 
+func normalizeInboundDiscountMaxRatioOverride(value float64) float64 {
+	if value <= 0 {
+		return 0
+	}
+	return clampFloat(value, 0.05, 1.00)
+}
+
 func maxInboundDiscountForAppliedPpm(appliedPpm int, maxRatio float64) int {
 	if appliedPpm <= 0 {
 		return 0
@@ -5216,6 +5237,35 @@ func normalizeStaleInboundDiscount(currentDiscount int, appliedPpm int, maxRatio
 		return capDiscount, true
 	}
 	return currentDiscount, false
+}
+
+func advanceBalancedInboundDiscountLifecycle(candidateDiscount int, previousDiscount int, appliedPpm int, maxRatio float64, previousIneligibleRounds int) (int, int, []string) {
+	if candidateDiscount > 0 {
+		return candidateDiscount, 0, nil
+	}
+
+	previousDiscount = absInt(previousDiscount)
+	if previousDiscount <= 0 {
+		return 0, 0, nil
+	}
+
+	ineligibleRounds := maxInt(0, previousIneligibleRounds) + 1
+	targetDiscount := previousDiscount
+	tags := make([]string, 0, 2)
+	if normalizedDiscount, normalized := normalizeStaleInboundDiscount(targetDiscount, appliedPpm, maxRatio); normalized {
+		targetDiscount = normalizedDiscount
+		tags = append(tags, "inbound-normalize")
+	}
+	if targetDiscount <= 0 {
+		return 0, ineligibleRounds, tags
+	}
+	if ineligibleRounds <= inboundDiscountGraceRounds {
+		return targetDiscount, ineligibleRounds, append(tags, "inbound-grace")
+	}
+
+	decayPpm := maxInt(inboundDiscountDecayMinPpm, int(math.Ceil(float64(targetDiscount)*inboundDiscountDecayFraction)))
+	targetDiscount = maxInt(0, targetDiscount-decayPpm)
+	return targetDiscount, ineligibleRounds, append(tags, "inbound-decay")
 }
 
 func selectAutofeeRefreshReference(capacitySat int64, forward7d forwardStat, forward21d forwardStat, rebal7d rebalStat, rebal21d rebalStat, rebalMarkupFrac float64) (int, int, string, bool) {
@@ -5569,7 +5619,7 @@ func (e *autofeeEngine) maybeApplyIdleRefresh(ctx context.Context, ch lndclient.
 	return d
 }
 
-func selectAutofeeRefreshInboundDiscount(cfg AutofeeConfig, profile autofeeProfile, rawOutRatio float64, effectiveOutRatio float64, forward1d forwardStat, forward7d forwardStat, capacitySat int64, baseCostPpm int, appliedPpm int) (int, string, bool) {
+func selectAutofeeRefreshInboundDiscount(cfg AutofeeConfig, profile autofeeProfile, classLabel string, rawOutRatio float64, effectiveOutRatio float64, forward1d forwardStat, forward7d forwardStat, capacitySat int64, baseCostPpm int, appliedPpm int) (int, string, bool) {
 	if appliedPpm <= 0 || baseCostPpm <= 0 {
 		return 0, "", false
 	}
@@ -5621,7 +5671,7 @@ func selectAutofeeRefreshInboundDiscount(cfg AutofeeConfig, profile autofeeProfi
 		marginPpm7d := outPpm7d - int(math.Ceil(float64(baseCostPpm)*1.10))
 		discount, source := computeBalancedInboundDiscount(
 			true,
-			"sink",
+			classLabel,
 			rawOutRatio,
 			fwdCount,
 			marginPpm7d,
@@ -8135,7 +8185,7 @@ select channel_id, last_ppm, last_inbound_discount_ppm, last_seed_ppm, last_outr
   last_ts, last_dir, low_streak, stalled_rounds, baseline_fwd7d, class_label, class_conf, bias_ema,
   first_seen_ts, ss_active, ss_ok_since, ss_bad_since, explorer_state,
   apply_error_streak, last_apply_error, apply_error_alerted,
-  seed_shock_pending_ppm, seed_shock_rounds, seed_shock_dir
+  seed_shock_pending_ppm, seed_shock_rounds, seed_shock_dir, inbound_ineligible_rounds
 from autofee_state
 `)
 	if err != nil {
@@ -8175,11 +8225,12 @@ from autofee_state
 		var applyErrorStreak int
 		var lastApplyError pgtype.Text
 		var applyErrorAlerted bool
+		var inboundIneligibleRounds int
 		if err := rows.Scan(&channelID, &lastPpm, &lastInb, &lastSeed, &lastOut, &lastOutTs, &lastRebal, &lastRebalTs,
 			&lastIdleRefreshTs, &lastIdleRefreshPpm, &lastIdleRefreshSource, &lastTs, &lastDir,
 			&lowStreak, &stalledRounds, &baseline, &classLabel, &classConf, &biasEma, &firstSeen, &ssActive, &ssOkSince, &ssBadSince, &explorerRaw,
 			&applyErrorStreak, &lastApplyError, &applyErrorAlerted,
-			&seedShockPending, &seedShockRounds, &seedShockDir); err != nil {
+			&seedShockPending, &seedShockRounds, &seedShockDir, &inboundIneligibleRounds); err != nil {
 			return items, err
 		}
 		st.ApplyErrorStreak = applyErrorStreak
@@ -8187,6 +8238,7 @@ from autofee_state
 			st.LastApplyError = lastApplyError.String
 		}
 		st.ApplyErrorAlerted = applyErrorAlerted
+		st.InboundStaleRounds = inboundIneligibleRounds
 		st.ChannelID = uint64(channelID)
 		if lastPpm.Valid {
 			st.LastPpm = int(lastPpm.Int32)
@@ -8332,8 +8384,8 @@ insert into autofee_state (
   last_ts, last_dir, low_streak, stalled_rounds, baseline_fwd7d, class_label, class_conf, bias_ema,
   first_seen_ts, ss_active, ss_ok_since, ss_bad_since, explorer_state,
   apply_error_streak, last_apply_error, apply_error_alerted,
-  seed_shock_pending_ppm, seed_shock_rounds, seed_shock_dir
-) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30)
+  seed_shock_pending_ppm, seed_shock_rounds, seed_shock_dir, inbound_ineligible_rounds
+) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31)
 `+
 		`on conflict (channel_id) do update set
   last_ppm=excluded.last_ppm,
@@ -8364,7 +8416,8 @@ insert into autofee_state (
   explorer_state=excluded.explorer_state,
   apply_error_streak=excluded.apply_error_streak,
   last_apply_error=excluded.last_apply_error,
-  apply_error_alerted=excluded.apply_error_alerted
+  apply_error_alerted=excluded.apply_error_alerted,
+  inbound_ineligible_rounds=excluded.inbound_ineligible_rounds
 `, int64(st.ChannelID), nullableInt(int64(st.LastPpm)), nullableInt(int64(st.LastInboundDiscount)),
 		nullableInt(int64(st.LastSeed)), nullableInt(int64(st.LastOutrate)), nullableTime(st.LastOutrateTs),
 		nullableInt(int64(st.LastRebalCost)), nullableTime(st.LastRebalCostTs), nullableTime(st.LastIdleRefreshTs),
@@ -8374,6 +8427,7 @@ insert into autofee_state (
 		nullableTime(st.SuperSourceOkSince), nullableTime(st.SuperSourceBadSince), rawExplorer,
 		st.ApplyErrorStreak, nullableString(st.LastApplyError), st.ApplyErrorAlerted,
 		nullableInt(int64(st.SeedShockPendingPpm)), st.SeedShockRounds, nullableString(st.SeedShockDir),
+		st.InboundStaleRounds,
 	)
 }
 
@@ -11592,12 +11646,21 @@ func (e *autofeeEngine) evaluateChannel(ch lndclient.ChannelInfo, st *autofeeCha
 			tags = appendAutofeeTagOnce(tags, "inbound-balanced")
 		}
 	}
-	if normalizeAutofeeOperationMode(e.cfg.OperationMode) != autofeeOperationModeMarketRefill && e.cfg.InboundPassiveEnabled && inboundDiscount <= 0 {
-		if normalizedInboundDiscount, normalized := normalizeStaleInboundDiscount(prevInboundDiscount, appliedPpm, inboundDiscountMaxRatio); normalized {
-			inboundDiscount = normalizedInboundDiscount
-			tags = appendAutofeeTagOnce(tags, "inbound-normalize")
-		} else {
-			inboundDiscount = prevInboundDiscount
+	if normalizeAutofeeOperationMode(e.cfg.OperationMode) == autofeeOperationModeMarketRefill {
+		st.InboundStaleRounds = 0
+	} else if !e.cfg.InboundPassiveEnabled {
+		st.InboundStaleRounds = 0
+	} else {
+		var lifecycleTags []string
+		inboundDiscount, st.InboundStaleRounds, lifecycleTags = advanceBalancedInboundDiscountLifecycle(
+			inboundDiscount,
+			prevInboundDiscount,
+			appliedPpm,
+			inboundDiscountMaxRatio,
+			st.InboundStaleRounds,
+		)
+		for _, lifecycleTag := range lifecycleTags {
+			tags = appendAutofeeTagOnce(tags, lifecycleTag)
 		}
 	}
 	inboundChanged := inboundDiscount != prevInboundDiscount

--- a/lightningos-light/internal/server/autofee_service_test.go
+++ b/lightningos-light/internal/server/autofee_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -901,6 +902,7 @@ func TestSelectAutofeeRefreshInboundDiscountBalancedEligible(t *testing.T) {
 	discount, source, apply := selectAutofeeRefreshInboundDiscount(
 		cfg,
 		profile,
+		"sink",
 		0.08,
 		0.08,
 		forwardStat{},
@@ -923,6 +925,7 @@ func TestSelectAutofeeRefreshInboundDiscountBalancedPreservesIneligible(t *testi
 	discount, source, apply := selectAutofeeRefreshInboundDiscount(
 		cfg,
 		profile,
+		"sink",
 		0.30,
 		0.30,
 		forwardStat{},
@@ -942,6 +945,7 @@ func TestSelectAutofeeRefreshInboundDiscountBalancedLowSampleRecreatesTarget(t *
 	discount, source, apply := selectAutofeeRefreshInboundDiscount(
 		cfg,
 		profile,
+		"sink",
 		0.08,
 		0.08,
 		forwardStat{},
@@ -975,6 +979,74 @@ func TestNormalizeStaleInboundDiscountCapsExtremeDiscount(t *testing.T) {
 	}
 }
 
+func TestNormalizeInboundDiscountMaxRatioOverride(t *testing.T) {
+	tests := []struct {
+		value float64
+		want  float64
+	}{
+		{value: -0.20, want: 0},
+		{value: 0, want: 0},
+		{value: 0.01, want: 0.05},
+		{value: 0.25, want: 0.25},
+		{value: 1.50, want: 1.00},
+	}
+	for _, tt := range tests {
+		if got := normalizeInboundDiscountMaxRatioOverride(tt.value); got != tt.want {
+			t.Fatalf("normalizeInboundDiscountMaxRatioOverride(%v)=%v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestAdvanceBalancedInboundDiscountLifecycle(t *testing.T) {
+	tests := []struct {
+		name           string
+		candidate      int
+		previous       int
+		applied        int
+		maxRatio       float64
+		previousRounds int
+		wantDiscount   int
+		wantRounds     int
+		wantTags       []string
+	}{
+		{name: "eligible resets lifecycle", candidate: 400, previous: 600, applied: 1000, maxRatio: 0.90, previousRounds: 8, wantDiscount: 400, wantRounds: 0},
+		{name: "first grace round preserves", previous: 600, applied: 1000, maxRatio: 0.90, wantDiscount: 600, wantRounds: 1, wantTags: []string{"inbound-grace"}},
+		{name: "grace still enforces current cap", previous: 1000, applied: 500, maxRatio: 0.90, previousRounds: 1, wantDiscount: 450, wantRounds: 2, wantTags: []string{"inbound-normalize", "inbound-grace"}},
+		{name: "decays after grace", previous: 600, applied: 1000, maxRatio: 0.90, previousRounds: 2, wantDiscount: 450, wantRounds: 3, wantTags: []string{"inbound-decay"}},
+		{name: "minimum decrement reaches zero", previous: 20, applied: 1000, maxRatio: 0.90, previousRounds: 5, wantDiscount: 0, wantRounds: 6, wantTags: []string{"inbound-decay"}},
+		{name: "no prior discount resets lifecycle", previous: 0, applied: 1000, maxRatio: 0.90, previousRounds: 5, wantDiscount: 0, wantRounds: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discount, rounds, tags := advanceBalancedInboundDiscountLifecycle(tt.candidate, tt.previous, tt.applied, tt.maxRatio, tt.previousRounds)
+			if discount != tt.wantDiscount || rounds != tt.wantRounds || !reflect.DeepEqual(tags, tt.wantTags) {
+				t.Fatalf("got discount=%d rounds=%d tags=%v, want discount=%d rounds=%d tags=%v", discount, rounds, tags, tt.wantDiscount, tt.wantRounds, tt.wantTags)
+			}
+		})
+	}
+}
+
+func TestSelectAutofeeRefreshInboundDiscountRejectsNonSink(t *testing.T) {
+	cfg := AutofeeConfig{InboundPassiveEnabled: true}
+	profile := autofeeProfiles["moderate"]
+	discount, source, apply := selectAutofeeRefreshInboundDiscount(
+		cfg,
+		profile,
+		"router",
+		0.08,
+		0.08,
+		forwardStat{},
+		forwardStat{FeeMsat: 1_000_000, AmtMsat: 1_000_000_000, Count: 6},
+		5_000_000,
+		500,
+		1000,
+	)
+	if apply || source != "" || discount != 0 {
+		t.Fatalf("expected non-sink refresh to preserve inbound policy, apply=%v source=%q discount=%d", apply, source, discount)
+	}
+}
+
 func TestInboundFeeUpdateForDiscountClearsStaleDiscount(t *testing.T) {
 	enabled, rate := inboundFeeUpdateForDiscount(10_000, 0)
 	if !enabled || rate != 0 {
@@ -998,6 +1070,7 @@ func TestSelectAutofeeRefreshInboundDiscountMarketRefillApplies(t *testing.T) {
 	discount, source, apply := selectAutofeeRefreshInboundDiscount(
 		cfg,
 		profile,
+		"sink",
 		0.08,
 		0.08,
 		forwardStat{Count: 1},

--- a/lightningos-light/ui/src/i18n/en.json
+++ b/lightningos-light/ui/src/i18n/en.json
@@ -3764,7 +3764,7 @@
     "autofeeMovementHintStepCap": "Maximum fee change per round. Higher = more movement per run; lower = smoother adjustments.",
     "autofeeMovementHintDiscoveryDownCap": "Extra down-step cap used in discovery-like situations. Higher = faster unlock/down moves.",
     "autofeeMovementHintStallRelaxGap": "Minimum gap between current fee and target before stall-relax softens the floor. Lower = relaxes earlier; higher = protects floors longer.",
-    "autofeeMovementHintInboundDiscountMaxRatio": "Maximum inbound discount as a share of the applied outbound fee. Higher = more aggressive inbound pricing.",
+    "autofeeMovementHintInboundDiscountMaxRatio": "Maximum inbound discount as a share of the applied outbound fee (5% to 100% override; blank uses the profile). Higher = more aggressive inbound pricing.",
     "autofeeMovementHintInboundDiscountReachOutRatio": "Highest out ratio still eligible for inbound discount. Higher = more sinks can receive discounts.",
     "autofeeMovementHintInboundDiscountMinRetainedSpread": "Minimum share of outbound fee kept above the cost anchor after discount. Higher = safer margins, lower = stronger inbound discounts.",
     "autofeeMovementHintLowFlowFloor": "Floor multiplier when outbound flow is low. Higher = keeps fees higher; lower = allows lower floors.",

--- a/lightningos-light/ui/src/i18n/pt-BR.json
+++ b/lightningos-light/ui/src/i18n/pt-BR.json
@@ -3764,7 +3764,7 @@
     "autofeeMovementHintStepCap": "Mudança máxima de fee por rodada. Maior = mais movimento por execução; menor = ajuste mais suave.",
     "autofeeMovementHintDiscoveryDownCap": "Cap extra de queda em cenários de discovery. Maior = destrava/abaixa mais rápido.",
     "autofeeMovementHintStallRelaxGap": "Gap mínimo entre a fee atual e o alvo para o stall-relax suavizar o piso. Menor = relaxa antes; maior = preserva o piso por mais tempo.",
-    "autofeeMovementHintInboundDiscountMaxRatio": "Desconto inbound máximo como fração da fee outbound aplicada. Maior = pricing inbound mais agressivo.",
+    "autofeeMovementHintInboundDiscountMaxRatio": "Desconto inbound máximo como fração da fee outbound aplicada (override de 5% a 100%; vazio usa o perfil). Maior = pricing inbound mais agressivo.",
     "autofeeMovementHintInboundDiscountReachOutRatio": "Maior out ratio ainda elegível para desconto inbound. Maior = mais canais sink podem receber desconto.",
     "autofeeMovementHintInboundDiscountMinRetainedSpread": "Fração mínima da fee outbound mantida acima da âncora de custo após o desconto. Maior = margem mais protegida; menor = desconto inbound mais forte.",
     "autofeeMovementHintLowFlowFloor": "Multiplicador do piso quando o fluxo de saída está baixo. Maior = mantém taxas mais altas; menor = permite pisos mais baixos.",

--- a/lightningos-light/ui/src/pages/FeeCenter.tsx
+++ b/lightningos-light/ui/src/pages/FeeCenter.tsx
@@ -820,7 +820,7 @@ export default function FeeCenter() {
         step_cap_override: parsePercentOverride(stepCapOverride, 1, 30),
         discovery_step_cap_down_override: parsePercentOverride(discoveryStepCapDownOverride, 1, 40),
         stall_floor_relax_gap_frac_override: parsePercentOverride(stallFloorRelaxGapFracOverride, 1, 80),
-        inbound_discount_max_ratio_override: parsePercentOverride(inboundDiscountMaxRatioOverride, 50, 100),
+        inbound_discount_max_ratio_override: parsePercentOverride(inboundDiscountMaxRatioOverride, 5, 100),
         inbound_discount_reach_out_ratio_override: parsePercentOverride(inboundDiscountReachOutRatioOverride, 5, 50),
         inbound_discount_min_retained_spread_frac_override: parsePercentOverride(inboundDiscountMinRetainedSpreadFracOverride, 1, 50),
         outrate_floor_factor_low_override: parsePercentOverride(outrateFloorFactorLowOverride, 50, 100),

--- a/lightningos-light/ui/src/pages/LightningOps.tsx
+++ b/lightningos-light/ui/src/pages/LightningOps.tsx
@@ -4851,7 +4851,7 @@ export default function LightningOps() {
       const stepCapOverride = parsePercentOverride(autofeeStepCapOverride, 1, 30)
       const discoveryStepCapDownOverride = parsePercentOverride(autofeeDiscoveryStepCapDownOverride, 1, 40)
       const stallFloorRelaxGapFracOverride = parsePercentOverride(autofeeStallFloorRelaxGapFracOverride, 1, 80)
-      const inboundDiscountMaxRatioOverride = parsePercentOverride(autofeeInboundDiscountMaxRatioOverride, 50, 100)
+      const inboundDiscountMaxRatioOverride = parsePercentOverride(autofeeInboundDiscountMaxRatioOverride, 5, 100)
       const inboundDiscountReachOutRatioOverride = parsePercentOverride(autofeeInboundDiscountReachOutRatioOverride, 5, 50)
       const inboundDiscountMinRetainedSpreadFracOverride = parsePercentOverride(autofeeInboundDiscountMinRetainedSpreadFracOverride, 1, 50)
       const outrateFloorFactorLowOverride = parsePercentOverride(autofeeOutrateFloorFactorLowOverride, 50, 100)


### PR DESCRIPTION
## Context

The production audit of Friendspool found that balanced-mode inbound fee discounts could be preserved indefinitely after a channel stopped qualifying as a sink. In the audited cohort, most recent discounted forwarding volume was effectively zero-fee, while roughly 90% of recent inbound decisions merely preserved an existing discount without a current eligibility signal.

## Changes

- persist an inbound-discount ineligibility counter per channel, with an idempotent schema migration
- keep a two-run grace period when a previously eligible channel loses its signal
- enforce the current outbound-ratio cap immediately during grace
- decay stale discounts by 25% per run, with a 25 ppm minimum decrement, until zero
- reset the lifecycle as soon as the channel qualifies again, inbound automation is disabled, or market-refill mode owns the policy
- make reference refresh use the persisted channel classification instead of assuming every channel is a sink
- align UI and backend override validation to 5%-100% (blank/zero continues to use the profile default)
- document the new lifecycle tags in English and Portuguese

## Safety

- AutoFee-disabled channels remain untouched
- market-refill behavior is unchanged
- refresh does not advance the lifecycle counter; scheduled evaluation remains its single owner
- no production node settings or policies were changed by this PR

## Validation

- `go test ./...`
- `npm.cmd run build`
- focused lifecycle, normalization, refresh-classification, and golden evaluation tests