### PR TITLE
0.5.22-Beta: track App Store catalog versions

### DIFF
--- a/docs/03_API_SPEC.md
+++ b/docs/03_API_SPEC.md
@@ -587,6 +587,7 @@ POST /api/lnops/succession/simulate
 
 GET /api/apps
 - Returns app list with status.
+- Third-party catalog apps, except PeerSwap, may include `available_version`, `installed_version`, and `update_available`. The available release is synchronized to PostgreSQL when the manager starts. The installed release changes only after an existing install or start action succeeds; legacy installations remain with an omitted/unknown `installed_version` until that happens. Version persistence is informational and cannot fail or trigger an app lifecycle operation.
 - A historical App Store Bitcoin container is returned as installed with `legacy_migration_required=true`; ordinary lifecycle controls must be replaced by the explicit safe-migration flow.
 - While a lifecycle action is active, the affected app includes `operation` with `action`, UTC `started_at`, and an optional truthful `stage` for instrumented workflows.
 - Apps that currently receive privileged direct LND access include `security_notices=["elevated_lnd_access"]`. `lndg` additionally reports `lnd_data_directory_read`. These values are informational disclosures and do not alter lifecycle behavior.

--- a/lightningos-light/internal/server/apps_handlers.go
+++ b/lightningos-light/internal/server/apps_handlers.go
@@ -170,6 +170,11 @@ func writeAppOperationError(w http.ResponseWriter, status int, err error) {
 	writeError(w, status, err.Error())
 }
 
+func (s *Server) writeSuccessfulAppInstallOrStart(w http.ResponseWriter, r *http.Request, appID string) {
+	s.recordAppliedAppVersion(r.Context(), appID)
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
 func cloneAppInfos(apps []appInfo) []appInfo {
 	cloned := append([]appInfo(nil), apps...)
 	for index := range cloned {
@@ -220,6 +225,7 @@ func (s *Server) buildAppList(ctx context.Context) ([]appInfo, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	s.addAppVersions(ctx, resp)
 	return resp, nil
 }
 
@@ -318,7 +324,7 @@ func (s *Server) handleAppInstall(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.invalidateBitcoinStatusCaches()
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	if appID == elementsAppID {
@@ -333,7 +339,7 @@ func (s *Server) handleAppInstall(w http.ResponseWriter, r *http.Request) {
 			writeAppOperationError(w, http.StatusInternalServerError, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	if appID == peerswapAppID {
@@ -367,7 +373,7 @@ func (s *Server) handleAppInstall(w http.ResponseWriter, r *http.Request) {
 			writeAppOperationError(w, status, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	if appID == mempoolAppID {
@@ -382,7 +388,7 @@ func (s *Server) handleAppInstall(w http.ResponseWriter, r *http.Request) {
 			writeAppOperationError(w, http.StatusInternalServerError, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	if appID == fedimintGatewayAppID {
@@ -401,7 +407,7 @@ func (s *Server) handleAppInstall(w http.ResponseWriter, r *http.Request) {
 			writeAppOperationError(w, status, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	appContext := r.Context()
@@ -415,7 +421,7 @@ func (s *Server) handleAppInstall(w http.ResponseWriter, r *http.Request) {
 	if appID == "bitcoincore" {
 		s.invalidateBitcoinStatusCaches()
 	}
-	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	s.writeSuccessfulAppInstallOrStart(w, r, appID)
 }
 
 func (s *Server) handleAppUninstall(w http.ResponseWriter, r *http.Request) {
@@ -514,7 +520,7 @@ func (s *Server) handleAppStart(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.invalidateBitcoinStatusCaches()
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	if appID == electrsAppID {
@@ -533,7 +539,7 @@ func (s *Server) handleAppStart(w http.ResponseWriter, r *http.Request) {
 			writeAppOperationError(w, status, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	if appID == mempoolAppID {
@@ -548,7 +554,7 @@ func (s *Server) handleAppStart(w http.ResponseWriter, r *http.Request) {
 			writeAppOperationError(w, http.StatusInternalServerError, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	if appID == fedimintGatewayAppID {
@@ -567,7 +573,7 @@ func (s *Server) handleAppStart(w http.ResponseWriter, r *http.Request) {
 			writeAppOperationError(w, status, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		s.writeSuccessfulAppInstallOrStart(w, r, appID)
 		return
 	}
 	appContext := r.Context()
@@ -581,7 +587,7 @@ func (s *Server) handleAppStart(w http.ResponseWriter, r *http.Request) {
 	if appID == "bitcoincore" {
 		s.invalidateBitcoinStatusCaches()
 	}
-	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	s.writeSuccessfulAppInstallOrStart(w, r, appID)
 }
 
 func (s *Server) handleAppStop(w http.ResponseWriter, r *http.Request) {

--- a/lightningos-light/internal/server/apps_types.go
+++ b/lightningos-light/internal/server/apps_types.go
@@ -44,6 +44,9 @@ type appInfo struct {
 	SecurityNotices         []string          `json:"security_notices,omitempty"`
 	Operation               *appOperationInfo `json:"operation,omitempty"`
 	LegacyMigrationRequired bool              `json:"legacy_migration_required,omitempty"`
+	AvailableVersion        string            `json:"available_version,omitempty"`
+	InstalledVersion        string            `json:"installed_version,omitempty"`
+	UpdateAvailable         bool              `json:"update_available,omitempty"`
 }
 
 type appOperationInfo struct {

--- a/lightningos-light/internal/server/apps_versions.go
+++ b/lightningos-light/internal/server/apps_versions.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"lightningos-light/internal/appmanifest"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const appVersionsInitRetryCooldown = 10 * time.Second
+
+// thirdPartyAppCatalogVersions is intentionally separate from lifecycle
+// manifests. Updating a release here changes the version offered by the Store,
+// but never installs, starts, stops, or upgrades an app by itself.
+func thirdPartyAppCatalogVersions() map[string]string {
+	return map[string]string{
+		appmanifest.BitcoinCoreID:      appmanifest.BitcoinCoreRelease,
+		appmanifest.BarkWalletID:       catalogImageVersion(appmanifest.BarkWalletWebImage),
+		appmanifest.ElectrsID:          appmanifest.ElectrsRelease,
+		appmanifest.MempoolID:          appmanifest.MempoolRelease,
+		appmanifest.FedimintGuardianID: appmanifest.FedimintRelease,
+		appmanifest.FedimintGatewayID:  appmanifest.FedimintRelease,
+		appmanifest.LNDgID:             appmanifest.LNDgRelease,
+		appmanifest.LNbitsID:           appmanifest.LNbitsRelease,
+		appmanifest.BTCPayID:           appmanifest.BTCPayRelease,
+		appmanifest.ElementsID:         appmanifest.ElementsVersion,
+		appmanifest.RoboSatsID:         catalogImageVersion(appmanifest.RoboSatsImage),
+		appmanifest.PublicPoolID:       appmanifest.PublicPoolBackendVersionOutput,
+		appmanifest.TapdID:             appmanifest.TapdRelease,
+		appmanifest.LoopID:             appmanifest.LoopVersion,
+	}
+}
+
+func catalogImageVersion(image string) string {
+	withoutDigest, _, _ := strings.Cut(strings.TrimSpace(image), "@")
+	separator := strings.LastIndex(withoutDigest, ":")
+	if separator < strings.LastIndex(withoutDigest, "/") || separator == len(withoutDigest)-1 {
+		return ""
+	}
+	return withoutDigest[separator+1:]
+}
+
+func isVersionedThirdPartyApp(appID string) bool {
+	_, ok := thirdPartyAppCatalogVersions()[appID]
+	return ok
+}
+
+func (s *Server) initAppVersions() {
+	s.appVersionsMu.Lock()
+	defer s.appVersionsMu.Unlock()
+
+	if s.appVersions != nil && s.appVersionsErr == "" {
+		return
+	}
+	if !s.appVersionsInitAt.IsZero() && time.Since(s.appVersionsInitAt) < appVersionsInitRetryCooldown {
+		return
+	}
+	s.appVersionsInitAt = time.Now()
+
+	pool := s.db
+	if pool == nil {
+		dsn, err := ResolveNotificationsDSN(s.logger)
+		if err != nil {
+			s.setAppVersionsInitError(fmt.Errorf("resolve postgres configuration: %w", err))
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		pool, err = pgxpool.New(ctx, dsn)
+		if err != nil {
+			s.setAppVersionsInitError(fmt.Errorf("connect to postgres: %w", err))
+			return
+		}
+		s.db = pool
+	}
+
+	service := NewAppVersionsService(pool)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := service.EnsureSchema(ctx); err != nil {
+		s.setAppVersionsInitError(fmt.Errorf("initialize schema: %w", err))
+		return
+	}
+	if err := service.SyncCatalog(ctx, thirdPartyAppCatalogVersions()); err != nil {
+		s.setAppVersionsInitError(fmt.Errorf("synchronize catalog: %w", err))
+		return
+	}
+
+	s.appVersions = service
+	s.appVersionsErr = ""
+}
+
+func (s *Server) setAppVersionsInitError(err error) {
+	s.appVersionsErr = fmt.Sprintf("app version metadata unavailable: %v", err)
+	if s.logger != nil {
+		s.logger.Printf("%s", s.appVersionsErr)
+	}
+}
+
+func (s *Server) appVersionsService() (appVersionRepository, string) {
+	s.initAppVersions()
+	return s.appVersions, s.appVersionsErr
+}
+
+func decorateAppVersions(apps []appInfo, versions map[string]appVersionRecord) {
+	for index := range apps {
+		if !isVersionedThirdPartyApp(apps[index].ID) {
+			continue
+		}
+		record, ok := versions[apps[index].ID]
+		if !ok || record.CatalogVersion == "" {
+			continue
+		}
+		apps[index].AvailableVersion = record.CatalogVersion
+		if !apps[index].Installed {
+			continue
+		}
+		apps[index].InstalledVersion = record.AppliedVersion
+		apps[index].UpdateAvailable = record.AppliedVersion != "" && record.AppliedVersion != record.CatalogVersion
+	}
+}
+
+func (s *Server) addAppVersions(ctx context.Context, apps []appInfo) {
+	service, _ := s.appVersionsService()
+	if service == nil {
+		return
+	}
+	versions, err := service.List(ctx)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Printf("app version metadata unavailable: list versions: %v", err)
+		}
+		return
+	}
+	decorateAppVersions(apps, versions)
+}
+
+// recordAppliedAppVersion is best-effort bookkeeping after an already
+// successful lifecycle operation. Metadata persistence must never turn a
+// successful install or start into a user-visible failure.
+func (s *Server) recordAppliedAppVersion(ctx context.Context, appID string) {
+	if !isVersionedThirdPartyApp(appID) {
+		return
+	}
+	service, _ := s.appVersionsService()
+	if service == nil {
+		return
+	}
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
+	defer cancel()
+	if err := service.MarkApplied(writeCtx, appID); err != nil {
+		if s.logger != nil {
+			s.logger.Printf("app version metadata unavailable: record applied version for %s: %v", appID, err)
+		}
+		return
+	}
+	s.invalidateAppListCache()
+}

--- a/lightningos-light/internal/server/apps_versions_service.go
+++ b/lightningos-light/internal/server/apps_versions_service.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type appVersionRecord struct {
+	CatalogVersion string
+	AppliedVersion string
+}
+
+type appVersionRepository interface {
+	List(context.Context) (map[string]appVersionRecord, error)
+	MarkApplied(context.Context, string) error
+}
+
+type AppVersionsService struct {
+	db *pgxpool.Pool
+}
+
+func NewAppVersionsService(db *pgxpool.Pool) *AppVersionsService {
+	return &AppVersionsService{db: db}
+}
+
+func (s *AppVersionsService) EnsureSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("app versions database is unavailable")
+	}
+	_, err := s.db.Exec(ctx, `
+CREATE TABLE IF NOT EXISTS app_store_versions (
+    app_id TEXT PRIMARY KEY,
+    catalog_version TEXT NOT NULL CHECK (catalog_version <> ''),
+    applied_version TEXT NULL,
+    catalog_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    applied_updated_at TIMESTAMPTZ NULL
+)
+`)
+	return err
+}
+
+// SyncCatalog changes only the release offered by this LightningOS build. It
+// deliberately preserves applied_version, which describes the last release
+// successfully applied through the existing app lifecycle.
+func (s *AppVersionsService) SyncCatalog(ctx context.Context, catalog map[string]string) error {
+	if s == nil || s.db == nil {
+		return errors.New("app versions database is unavailable")
+	}
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	appIDs := make([]string, 0, len(catalog))
+	for appID := range catalog {
+		appIDs = append(appIDs, appID)
+	}
+	sort.Strings(appIDs)
+	for _, appID := range appIDs {
+		version := catalog[appID]
+		if appID == "" || version == "" {
+			return errors.New("app version catalog contains an empty id or version")
+		}
+		if _, err := tx.Exec(ctx, `
+INSERT INTO app_store_versions (app_id, catalog_version)
+VALUES ($1, $2)
+ON CONFLICT (app_id) DO UPDATE SET
+    catalog_version = EXCLUDED.catalog_version,
+    catalog_updated_at = CASE
+        WHEN app_store_versions.catalog_version IS DISTINCT FROM EXCLUDED.catalog_version THEN NOW()
+        ELSE app_store_versions.catalog_updated_at
+    END
+`, appID, version); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *AppVersionsService) List(ctx context.Context) (map[string]appVersionRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("app versions database is unavailable")
+	}
+	rows, err := s.db.Query(ctx, `
+SELECT app_id, catalog_version, COALESCE(applied_version, '')
+FROM app_store_versions
+`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	versions := make(map[string]appVersionRecord)
+	for rows.Next() {
+		var appID string
+		var record appVersionRecord
+		if err := rows.Scan(&appID, &record.CatalogVersion, &record.AppliedVersion); err != nil {
+			return nil, err
+		}
+		versions[appID] = record
+	}
+	return versions, rows.Err()
+}
+
+func (s *AppVersionsService) MarkApplied(ctx context.Context, appID string) error {
+	if s == nil || s.db == nil {
+		return errors.New("app versions database is unavailable")
+	}
+	result, err := s.db.Exec(ctx, `
+UPDATE app_store_versions
+SET applied_version = catalog_version,
+    applied_updated_at = NOW()
+WHERE app_id = $1
+`, appID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() != 1 {
+		return errors.New("app is not present in the version catalog")
+	}
+	return nil
+}

--- a/lightningos-light/internal/server/apps_versions_test.go
+++ b/lightningos-light/internal/server/apps_versions_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"lightningos-light/internal/appmanifest"
+)
+
+type fakeAppVersionRepository struct {
+	versions    map[string]appVersionRecord
+	marked      []string
+	markApplied error
+}
+
+func (f *fakeAppVersionRepository) List(context.Context) (map[string]appVersionRecord, error) {
+	return f.versions, nil
+}
+
+func (f *fakeAppVersionRepository) MarkApplied(_ context.Context, appID string) error {
+	f.marked = append(f.marked, appID)
+	return f.markApplied
+}
+
+func TestThirdPartyAppCatalogVersionsScope(t *testing.T) {
+	catalog := thirdPartyAppCatalogVersions()
+	for _, appID := range []string{
+		appmanifest.BitcoinCoreID,
+		appmanifest.BarkWalletID,
+		appmanifest.ElectrsID,
+		appmanifest.MempoolID,
+		appmanifest.FedimintGuardianID,
+		appmanifest.FedimintGatewayID,
+		appmanifest.LNDgID,
+		appmanifest.LNbitsID,
+		appmanifest.BTCPayID,
+		appmanifest.ElementsID,
+		appmanifest.RoboSatsID,
+		appmanifest.PublicPoolID,
+		appmanifest.TapdID,
+		appmanifest.LoopID,
+	} {
+		if catalog[appID] == "" {
+			t.Fatalf("versioned third-party app %q has no catalog version", appID)
+		}
+	}
+	for _, appID := range []string{
+		appmanifest.PeerSwapID,
+		appmanifest.CPUMinerID,
+		"depix-buy",
+		"fswap",
+		"loopout-brln",
+		"magma",
+	} {
+		if _, ok := catalog[appID]; ok {
+			t.Fatalf("excluded app %q is present in the version catalog", appID)
+		}
+	}
+}
+
+func TestCatalogImageVersionTracksPinnedProductTag(t *testing.T) {
+	if got := catalogImageVersion(appmanifest.BarkWalletWebImage); got != "0.7.2" {
+		t.Fatalf("unexpected Bark Wallet catalog version: %q", got)
+	}
+	if got := catalogImageVersion(appmanifest.RoboSatsImage); got != "v0.8.4-alpha" {
+		t.Fatalf("unexpected RoboSats catalog version: %q", got)
+	}
+	if got := catalogImageVersion("registry.example:5000/app"); got != "" {
+		t.Fatalf("image without a tag produced version %q", got)
+	}
+}
+
+func TestDecorateAppVersionsDistinguishesAvailableAppliedAndUnknown(t *testing.T) {
+	apps := []appInfo{
+		{ID: appmanifest.MempoolID, Installed: true},
+		{ID: appmanifest.ElectrsID, Installed: true},
+		{ID: appmanifest.BTCPayID, Installed: false},
+		{ID: appmanifest.PeerSwapID, Installed: true},
+	}
+	versions := map[string]appVersionRecord{
+		appmanifest.MempoolID:  {CatalogVersion: "3.4.0", AppliedVersion: "3.3.1"},
+		appmanifest.ElectrsID:  {CatalogVersion: "0.11.1"},
+		appmanifest.BTCPayID:   {CatalogVersion: "2.4.2", AppliedVersion: "2.3.0"},
+		appmanifest.PeerSwapID: {CatalogVersion: "should-not-appear", AppliedVersion: "should-not-appear"},
+	}
+
+	decorateAppVersions(apps, versions)
+
+	if apps[0].AvailableVersion != "3.4.0" || apps[0].InstalledVersion != "3.3.1" || !apps[0].UpdateAvailable {
+		t.Fatalf("unexpected Mempool version metadata: %+v", apps[0])
+	}
+	if apps[1].AvailableVersion != "0.11.1" || apps[1].InstalledVersion != "" || apps[1].UpdateAvailable {
+		t.Fatalf("legacy Electrs install must remain unknown: %+v", apps[1])
+	}
+	if apps[2].AvailableVersion != "2.4.2" || apps[2].InstalledVersion != "" || apps[2].UpdateAvailable {
+		t.Fatalf("not-installed BTCPay must expose only the catalog version: %+v", apps[2])
+	}
+	if apps[3].AvailableVersion != "" || apps[3].InstalledVersion != "" || apps[3].UpdateAvailable {
+		t.Fatalf("PeerSwap must not expose version metadata: %+v", apps[3])
+	}
+}
+
+func TestRecordAppliedAppVersionOnlyTouchesVersionedThirdPartyApps(t *testing.T) {
+	repository := &fakeAppVersionRepository{}
+	server := &Server{appVersions: repository}
+
+	server.recordAppliedAppVersion(context.Background(), appmanifest.PeerSwapID)
+	server.recordAppliedAppVersion(context.Background(), appmanifest.MempoolID)
+
+	if len(repository.marked) != 1 || repository.marked[0] != appmanifest.MempoolID {
+		t.Fatalf("unexpected applied-version writes: %v", repository.marked)
+	}
+}
+
+func TestRecordAppliedAppVersionDoesNotPropagateMetadataFailure(t *testing.T) {
+	repository := &fakeAppVersionRepository{markApplied: errors.New("postgres unavailable")}
+	server := &Server{appVersions: repository}
+
+	server.recordAppliedAppVersion(context.Background(), appmanifest.MempoolID)
+
+	if len(repository.marked) != 1 {
+		t.Fatalf("expected one best-effort metadata write, got %v", repository.marked)
+	}
+}

--- a/lightningos-light/internal/server/server.go
+++ b/lightningos-light/internal/server/server.go
@@ -102,6 +102,10 @@ type Server struct {
 	uiPreferencesMu             sync.Mutex
 	uiPreferences               *UIPreferencesService
 	uiPreferencesErr            string
+	appVersionsInitAt           time.Time
+	appVersionsMu               sync.Mutex
+	appVersions                 appVersionRepository
+	appVersionsErr              string
 	channelRankingInitAt        time.Time
 	channelRankingMu            sync.Mutex
 	channelRanking              *ChannelRankingService
@@ -207,6 +211,7 @@ func (s *Server) Run() error {
 	s.startLegacyPrivilegeTransitionReconciler()
 	s.startAppUpgradeChecker()
 	s.initNotifications()
+	s.initAppVersions()
 	s.initAuditLog()
 	s.initSpendingGuard()
 	s.startSpendingGuardReconciler()

--- a/lightningos-light/ui/src/api.ts
+++ b/lightningos-light/ui/src/api.ts
@@ -1198,6 +1198,9 @@ export type AppStoreInfo = {
   security_notices?: string[]
   operation?: AppOperationInfo
   legacy_migration_required?: boolean
+  available_version?: string
+  installed_version?: string
+  update_available?: boolean
 }
 
 export const getApps = (): Promise<AppStoreInfo[]> => request('/api/apps')

--- a/lightningos-light/ui/src/i18n/en.json
+++ b/lightningos-light/ui/src/i18n/en.json
@@ -1223,6 +1223,11 @@
     "copyLndgPassword": "Copy LNDg admin password",
     "defaultAccess": "Default access: {{access}}",
     "defaultPort": "Default port: {{port}}",
+    "installedVersion": "Installed version",
+    "availableVersion": "Available version",
+    "unknownVersion": "Unknown",
+    "updateAvailable": "Update available",
+    "upToDate": "Up to date",
     "filters": {
       "all": "All",
       "installed": "Installed",

--- a/lightningos-light/ui/src/i18n/pt-BR.json
+++ b/lightningos-light/ui/src/i18n/pt-BR.json
@@ -1223,6 +1223,11 @@
     "copyLndgPassword": "Copiar senha admin do LNDg",
     "defaultAccess": "Acesso padrão: {{access}}",
     "defaultPort": "Porta padrão: {{port}}",
+    "installedVersion": "Versão instalada",
+    "availableVersion": "Versão disponível",
+    "unknownVersion": "Desconhecida",
+    "updateAvailable": "Atualização disponível",
+    "upToDate": "Atualizado",
     "filters": {
       "all": "Todos",
       "installed": "Instalados",

--- a/lightningos-light/ui/src/pages/AppStore.tsx
+++ b/lightningos-light/ui/src/pages/AppStore.tsx
@@ -976,6 +976,29 @@ export default function AppStore() {
                 </div>
               </div>
 
+              {app.available_version && (
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 text-xs text-fog/65">
+                  {app.installed && (
+                    <span>
+                      {t('appStore.installedVersion')}: <strong className="font-mono font-medium text-fog/90">{app.installed_version || t('appStore.unknownVersion')}</strong>
+                    </span>
+                  )}
+                  <span>
+                    {t('appStore.availableVersion')}: <strong className="font-mono font-medium text-fog/90">{app.available_version}</strong>
+                  </span>
+                  {app.installed && app.update_available && (
+                    <span className="rounded-full border border-amber-400/35 bg-amber-500/15 px-2 py-0.5 font-semibold uppercase tracking-wide text-amber-200">
+                      {t('appStore.updateAvailable')}
+                    </span>
+                  )}
+                  {app.installed && app.installed_version && !app.update_available && (
+                    <span className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 font-semibold uppercase tracking-wide text-emerald-200">
+                      {t('appStore.upToDate')}
+                    </span>
+                  )}
+                </div>
+              )}
+
               {operationAction && !isResetting && (
                 <div className="rounded-lg border border-cyan-400/25 bg-cyan-500/10 px-4 py-3" role="status" aria-live="polite">
                   <div className="flex items-center justify-between gap-3 text-sm">


### PR DESCRIPTION
## Resumo

- cria a tabela PostgreSQL app_store_versions para separar a versão disponível no catálogo da última versão aplicada com sucesso;
- sincroniza as versões selecionadas pelo LightningOS durante a inicialização do Manager;
- expõe available_version, installed_version e update_available em GET /api/apps;
- mostra as versões e os estados Atualizado, Atualização disponível ou Desconhecida nos cards da Loja;
- registra a versão aplicada somente depois que o fluxo existente de Install ou Start termina com sucesso.

## Escopo e segurança

- inclui apenas apps de terceiros gerenciados pela Loja;
- exclui PeerSwap, CPU Miner, Loop Out BRLN, Magma, FSwap e o app oculto DePix Buy;
- não adiciona atualização automática nem consulta versões upstream;
- não altera o broker privilegiado, seus manifests ou o protocolo de lifecycle;
- falhas na persistência do metadado não transformam uma instalação ou inicialização bem-sucedida em erro;
- instalações legadas permanecem com versão desconhecida até o próximo Install ou Start bem-sucedido.

Para uma nova versão da Mempool, o novo catálogo aparece imediatamente após a atualização do LightningOS. A versão instalada só avança depois do Stop/Start já existente concluir com sucesso.

## Validação

- go test ./...
- npm.cmd run build
- git diff --check

Closes #77