### PR TITLE
0.5.23-Beta: relax stale AutoFee outrate memory floors

### DIFF
--- a/lightningos-light/internal/server/autofee_service.go
+++ b/lightningos-light/internal/server/autofee_service.go
@@ -7450,10 +7450,12 @@ func shouldHoldSeedDrivenUpOnFullChannel(marketRefillMode bool, rawOutRatio floa
 	return strings.TrimSpace(baseCostSrc) == "seed"
 }
 
-func isStaleNoFlowAdvisoryFloorSource(src string) bool {
+func isStaleNoFlowAdvisoryFloorSource(src string, baseSrc string) bool {
 	switch strings.TrimSpace(src) {
 	case "seed", "seed-sink", "seed-soft", "seed-synthetic", "seed-goodliq-hold", "seed-hold", "no-signal":
 		return true
+	case "outrate":
+		return strings.TrimSpace(baseSrc) == "outrate-mem"
 	default:
 		return false
 	}
@@ -7465,6 +7467,7 @@ func relaxStaleNoFlowAdvisoryFloor(
 	targetPpm int,
 	floorPpm int,
 	floorSrc string,
+	floorBaseSrc string,
 	meta outRatioNormalizationMeta,
 	goodOutRatio float64,
 	noFlow1d bool,
@@ -7496,7 +7499,7 @@ func relaxStaleNoFlowAdvisoryFloor(
 		newInboundBootstrap {
 		return floorPpm, floorSrc, nil
 	}
-	if !isStaleNoFlowAdvisoryFloorSource(floorSrc) {
+	if !isStaleNoFlowAdvisoryFloorSource(floorSrc, floorBaseSrc) {
 		return floorPpm, floorSrc, nil
 	}
 	if bootstrapHours <= 0 {
@@ -11034,6 +11037,7 @@ func (e *autofeeEngine) evaluateChannel(ch lndclient.ChannelInfo, st *autofeeCha
 		target,
 		floor,
 		floorSrc,
+		floorBaseSrc,
 		outNormMeta,
 		goodOutRatio,
 		noFlow1d,

--- a/lightningos-light/internal/server/autofee_service_test.go
+++ b/lightningos-light/internal/server/autofee_service_test.go
@@ -1819,6 +1819,7 @@ func TestRelaxStaleNoFlowAdvisoryFloorUsesEffectiveLiquidity(t *testing.T) {
 		583,
 		607,
 		"seed-synthetic",
+		"seed",
 		meta,
 		0.20,
 		true,
@@ -1845,6 +1846,7 @@ func TestRelaxStaleNoFlowAdvisoryFloorUsesEffectiveLiquidity(t *testing.T) {
 		583,
 		607,
 		"seed-synthetic",
+		"seed",
 		meta,
 		0.20,
 		true,
@@ -1879,6 +1881,7 @@ func TestRelaxStaleNoFlowAdvisoryFloorSmallOutnormIsSlower(t *testing.T) {
 		620,
 		645,
 		"seed-synthetic",
+		"seed",
 		meta,
 		0.20,
 		true,
@@ -1905,6 +1908,7 @@ func TestRelaxStaleNoFlowAdvisoryFloorSmallOutnormIsSlower(t *testing.T) {
 		620,
 		645,
 		"seed-synthetic",
+		"seed",
 		meta,
 		0.20,
 		true,
@@ -1934,6 +1938,7 @@ func TestRelaxStaleNoFlowAdvisoryFloorKeepsHardCostFloor(t *testing.T) {
 		820,
 		1000,
 		"rebal-recent",
+		"rebal-recent",
 		meta,
 		0.20,
 		true,
@@ -1952,6 +1957,68 @@ func TestRelaxStaleNoFlowAdvisoryFloorKeepsHardCostFloor(t *testing.T) {
 	)
 	if len(tags) > 0 || floor != 1000 || src != "rebal-recent" {
 		t.Fatalf("hard recent rebalance floor must not relax: floor=%d src=%s tags=%v", floor, src, tags)
+	}
+}
+
+func TestRelaxStaleNoFlowAdvisoryFloorAllowsOutrateMemory(t *testing.T) {
+	meta := outRatioNormalizationMeta{
+		Raw:          0.99,
+		Effective:    0.39,
+		CapRel:       0.28,
+		OutlierSmall: true,
+	}
+	floor, src, tags := relaxStaleNoFlowAdvisoryFloor(
+		false,
+		804,
+		237,
+		885,
+		"outrate",
+		"outrate-mem",
+		meta,
+		0.20,
+		true,
+		0,
+		0,
+		0,
+		0,
+		0,
+		false,
+		false,
+		false,
+		30*24,
+		defaultBootstrapHours,
+		135,
+		10,
+	)
+	if floor != 772 || src != "stale-noflow" || !containsTag(tags, "stale-noflow-down") || !containsTag(tags, "advisory-floor-relax") {
+		t.Fatalf("expected stale outrate memory to relax conservatively: floor=%d src=%s tags=%v", floor, src, tags)
+	}
+
+	floor, src, tags = relaxStaleNoFlowAdvisoryFloor(
+		false,
+		804,
+		237,
+		885,
+		"outrate",
+		"outrate",
+		meta,
+		0.20,
+		true,
+		0,
+		0,
+		0,
+		0,
+		0,
+		false,
+		false,
+		false,
+		30*24,
+		defaultBootstrapHours,
+		135,
+		10,
+	)
+	if floor != 885 || src != "outrate" || len(tags) != 0 {
+		t.Fatalf("current outrate floor must remain protected: floor=%d src=%s tags=%v", floor, src, tags)
 	}
 }
 


### PR DESCRIPTION
## Summary

- allow the existing stale/no-flow AutoFee relaxation to handle floors backed specifically by `outrate-mem`
- keep current outrate, 21-day outrate, and rebalance-derived floors protected
- add regression coverage for both the memory relaxation and the current-outrate guard

## Behavior

A stale `outrate-mem` floor now reuses the existing liquidity, no-flow, age, HTLC-pressure, rebalance, bootstrap, and step-size guards. The representative 804 ppm case takes one conservative 4% step to 772 ppm instead of remaining locked by the historical floor.

## Tests

- `go test ./internal/server -run TestRelaxStaleNoFlowAdvisoryFloor -count=1`
- `go test ./internal/server/... -count=1`
- `go test ./... -count=1`
- `go build -o bin/lightningos-manager.exe ./cmd/lightningos-manager`
