### PR TITLE
0.5.23-Beta: preserve AutoFee calibration after refreshes

### DIFF
--- a/docs/03_API_SPEC.md
+++ b/docs/03_API_SPEC.md
@@ -451,6 +451,16 @@ Body:
 - Parking a channel disables Autofee for that channel, disables rebalance auto and manual restart, and excludes the channel as a rebalance source.
 - Unparking with `restore_previous=false` keeps Autofee and rebalance automations disabled until the operator explicitly enables them again.
 
+### AutoFee results and refresh auditing
+
+GET /api/lnops/autofee/results?runs=4
+- Returns the selected structured run `items` and rendered `lines`.
+- Also returns `latest_calibration`, containing the most recent structured node calibration from the complete AutoFee history, or `null` when no calibration has been recorded. This field is independent of the selected run window so channel reference refreshes do not hide the last valid node calibration.
+
+POST /api/lnops/autofee/refresh
+- Refreshes reference fees globally or for the channel identified by `channel_point`, `channel_id`, or `channel_id_str`.
+- Records completed refreshes in an `autofee.refresh` audit event with the authenticated session, client IP, scope, target, dry-run/inbound parameters, outcome, and aggregate counts. Channel-not-found and service execution failures record a bounded error code without persisting the underlying error text.
+
 ### AutoFee/Rebalance automation intents
 
 GET /api/lnops/automation-intents/config

--- a/lightningos-light/internal/server/autofee_handlers.go
+++ b/lightningos-light/internal/server/autofee_handlers.go
@@ -288,6 +288,14 @@ func (s *Server) handleAutofeeRefresh(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
 	defer cancel()
+	auditTarget, auditScope := autofeeRefreshAuditTarget(req.ChannelPoint, channelID)
+	auditMetadata := map[string]any{
+		"scope":           auditScope,
+		"dry_run":         req.DryRun,
+		"include_inbound": req.IncludeInbound,
+		"channel_point":   strings.TrimSpace(req.ChannelPoint),
+		"channel_id_str":  autofeeRefreshAuditChannelID(channelID),
+	}
 
 	var result AutofeeRefreshResult
 	var err error
@@ -297,14 +305,44 @@ func (s *Server) handleAutofeeRefresh(w http.ResponseWriter, r *http.Request) {
 		result, err = svc.RefreshReferenceFees(ctx, req.DryRun, req.IncludeInbound)
 	}
 	if err != nil {
+		auditMetadata["status"] = "error"
 		if errors.Is(err, errAutofeeRefreshChannelNotFound) {
+			auditMetadata["error_code"] = "channel_not_found"
+			s.recordAuditEvent(r, "autofee.refresh", auditTarget, auditMetadata)
 			writeError(w, http.StatusNotFound, "channel not found")
 			return
 		}
+		auditMetadata["error_code"] = "refresh_failed"
+		s.recordAuditEvent(r, "autofee.refresh", auditTarget, auditMetadata)
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	auditMetadata["status"] = auditStatusFromResult(result.Total, result.Errors)
+	auditMetadata["total"] = result.Total
+	auditMetadata["updated"] = result.Updated
+	auditMetadata["inbound_updated"] = result.InboundUpdated
+	auditMetadata["same"] = result.Same
+	auditMetadata["skipped"] = result.Skipped
+	auditMetadata["errors"] = result.Errors
+	s.recordAuditEvent(r, "autofee.refresh", auditTarget, auditMetadata)
 	writeJSON(w, http.StatusOK, result)
+}
+
+func autofeeRefreshAuditTarget(channelPoint string, channelID uint64) (string, string) {
+	if channelPoint = strings.TrimSpace(channelPoint); channelPoint != "" {
+		return channelPoint, "channel"
+	}
+	if channelID != 0 {
+		return strconv.FormatUint(channelID, 10), "channel"
+	}
+	return "all", "all"
+}
+
+func autofeeRefreshAuditChannelID(channelID uint64) string {
+	if channelID == 0 {
+		return ""
+	}
+	return strconv.FormatUint(channelID, 10)
 }
 
 func (s *Server) handleAutofeeStatus(w http.ResponseWriter, r *http.Request) {
@@ -451,7 +489,45 @@ limit $1
 		}
 		items = append(items, item)
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"lines": out, "items": items})
+	if err := rows.Err(); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	rows.Close()
+
+	latestCalibration, err := s.readLatestAutofeeCalibration(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"lines":              out,
+		"items":              items,
+		"latest_calibration": latestCalibration,
+	})
+}
+
+func (s *Server) readLatestAutofeeCalibration(ctx context.Context) (map[string]any, error) {
+	var raw []byte
+	err := s.db.QueryRow(ctx, `
+select payload
+from autofee_logs
+where payload->>'kind' = 'calib'
+order by occurred_at desc, id desc
+limit 1
+`).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var item map[string]any
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil, err
+	}
+	return item, nil
 }
 
 func parseAutofeeLimit(raw string) int {

--- a/lightningos-light/internal/server/autofee_handlers_test.go
+++ b/lightningos-light/internal/server/autofee_handlers_test.go
@@ -1,0 +1,36 @@
+package server
+
+import "testing"
+
+func TestAutofeeRefreshAuditTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		channelPoint string
+		channelID    uint64
+		wantTarget   string
+		wantScope    string
+	}{
+		{name: "all channels", wantTarget: "all", wantScope: "all"},
+		{name: "channel point", channelPoint: "  abc:1  ", channelID: 42, wantTarget: "abc:1", wantScope: "channel"},
+		{name: "channel id", channelID: 42, wantTarget: "42", wantScope: "channel"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			target, scope := autofeeRefreshAuditTarget(tc.channelPoint, tc.channelID)
+			if target != tc.wantTarget || scope != tc.wantScope {
+				t.Fatalf("autofeeRefreshAuditTarget() = (%q, %q), want (%q, %q)", target, scope, tc.wantTarget, tc.wantScope)
+			}
+		})
+	}
+}
+
+func TestAutofeeRefreshAuditChannelIDPreservesUint64(t *testing.T) {
+	const channelID = uint64(18_446_744_073_709_551_615)
+	if got := autofeeRefreshAuditChannelID(channelID); got != "18446744073709551615" {
+		t.Fatalf("autofeeRefreshAuditChannelID() = %q", got)
+	}
+	if got := autofeeRefreshAuditChannelID(0); got != "" {
+		t.Fatalf("zero channel id = %q, want empty", got)
+	}
+}

--- a/lightningos-light/ui/src/pages/FeeCenter.tsx
+++ b/lightningos-light/ui/src/pages/FeeCenter.tsx
@@ -360,6 +360,7 @@ export default function FeeCenter() {
   const [channelSettings, setChannelSettings] = useState<Record<string, boolean>>({})
   const [resultItems, setResultItems] = useState<AutofeeResultItem[]>([])
   const [resultLines, setResultLines] = useState<string[]>([])
+  const [latestCalibration, setLatestCalibration] = useState<AutofeeResultItem | null>(null)
   const [pageStatus, setPageStatus] = useState('')
   const [busy, setBusy] = useState(false)
   const [profileSaving, setProfileSaving] = useState(false)
@@ -472,6 +473,7 @@ export default function FeeCenter() {
       const payload = resultsRes.value as any
       setResultItems(Array.isArray(payload?.items) ? payload.items : [])
       setResultLines(Array.isArray(payload?.lines) ? payload.lines : [])
+      setLatestCalibration(payload?.latest_calibration?.kind === 'calib' ? payload.latest_calibration : null)
     }
     if (channelsRes.status === 'fulfilled') {
       const payload = channelsRes.value as any
@@ -512,7 +514,7 @@ export default function FeeCenter() {
   const latestRun = runs[0]
   const latestSummary = latestRun?.summary
   const latestSeed = latestRun?.seed
-  const latestCalib = latestRun?.calib
+  const latestCalib = latestCalibration || runs.find((run) => run.calib)?.calib
   const latestChanged = useMemo(
     () => (latestRun?.channels || []).filter((item) => item.category === 'changed'),
     [latestRun]
@@ -871,6 +873,7 @@ export default function FeeCenter() {
     const payload = await getAutofeeResults(params) as any
     setResultLines(Array.isArray(payload?.lines) ? payload.lines : [])
     setResultItems(Array.isArray(payload?.items) ? payload.items : [])
+    setLatestCalibration(payload?.latest_calibration?.kind === 'calib' ? payload.latest_calibration : null)
   }
 
   const handleRun = async (dryRun: boolean) => {


### PR DESCRIPTION
## Resumo

- mantém no Fee Center a última calibração válida do node mesmo após refreshes globais ou individuais de canais;
- adiciona `latest_calibration` à resposta de resultados do AutoFee, consultando o histórico completo sem depender da janela de runs exibida;
- mantém fallback no frontend para compatibilidade com Managers anteriores;
- registra `autofee.refresh` no audit log com sessão, IP, escopo, alvo, parâmetros e resultado agregado;
- preserva `channel_id_str` como string para não perder precisão em IDs Lightning.

## Cenário corrigido

No Friendspool, um refresh individual do canal Garlic passou a ser o run mais recente. Como runs de refresh não contêm `calib`, o Fee Center mostrava `Node calibration is not available yet`, embora a calibração válida anterior continuasse gravada.

Agora a calibração do card é obtida separadamente do histórico completo. Refreshes posteriores não escondem mais o estado calibrado do node.

## Auditoria

Refreshes concluídos, falhas de execução e canal não encontrado geram o evento `autofee.refresh`. O evento diferencia escopo `all`/`channel`, identifica o alvo e grava somente códigos de erro limitados, sem persistir mensagens internas.

## Release

Mudança destinada à `0.5.23-Beta`. O bump de `ui/public/version.txt` já está na PR #107 e não foi duplicado aqui para evitar conflito durante a integração da release.

## Validação

- `go test ./internal/server -run 'TestAutofeeRefreshAudit(Target|ChannelID)' -count=1`
- `go test ./... -count=1`
- `go build -o bin/lightningos-manager.exe ./cmd/lightningos-manager`
- `npm.cmd run build`
- `git diff --check`