### PR TITLE
0.5.22-Beta: Magma - não alarmar por channel point que a Amboss ainda não viu

### DIFF
--- a/lightningos-light/internal/server/magma_confirm_alert_test.go
+++ b/lightningos-light/internal/server/magma_confirm_alert_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"errors"
+	"testing"
+)
+
+// Order 7554c21d, 2026-09-02: the funding transaction was broadcast at 17:01:01,
+// we tried to report the outpoint at 17:01:03, and Amboss answered "Error
+// finding transaction in the mempool" - it had not seen the transaction yet,
+// two seconds in. That went to Telegram as a warning, and the retry confirmed
+// it 93 seconds later. The sale was never at risk; the alert was pure noise,
+// and noise like that trains an operator to ignore the real ones.
+func TestMagmaConfirmDoesNotAlertOnTheInlineAttempt(t *testing.T) {
+	realFailure := errors.New("outpoint belongs to a different channel")
+	if magmaConfirmShouldAlert(true, realFailure) {
+		t.Fatal("the attempt made seconds after the broadcast must never alert, whatever Amboss answers")
+	}
+	// The same error from a retry is worth surfacing: by then the transaction
+	// has had time to propagate, so a failure means something.
+	if !magmaConfirmShouldAlert(false, realFailure) {
+		t.Fatal("a retry failing for a real reason must reach the operator")
+	}
+}
+
+// The wording that caused the false alarm. Adding it to the propagation check
+// keeps retries quiet too - the inline rule above is what makes the alert
+// impossible to reintroduce by rewording, but a retry hitting the same race
+// should not shout either.
+func TestMagmaConfirmRecognisesTheMempoolWording(t *testing.T) {
+	for _, message := range []string{
+		"Error finding transaction in the mempool",
+		"transaction not found",
+		"output not found",
+		"not found in transaction",
+	} {
+		if !magmaErrorIsPropagationRace(errors.New(message)) {
+			t.Fatalf("%q describes a transaction Amboss cannot see yet", message)
+		}
+		if magmaConfirmShouldAlert(false, errors.New(message)) {
+			t.Fatalf("%q must not alert even on a retry", message)
+		}
+	}
+}
+
+// A wrong outpoint is the failure this alert exists for, and it has to survive
+// everything above.
+func TestMagmaConfirmStillAlertsOnARealProblem(t *testing.T) {
+	if !magmaConfirmShouldAlert(false, errors.New("order already has a channel")) {
+		t.Fatal("a genuine refusal from a retry must still reach the operator")
+	}
+	if magmaConfirmShouldAlert(false, nil) {
+		t.Fatal("there is nothing to alert about when the call succeeded")
+	}
+}

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -604,7 +604,7 @@ update magma_orders set local_state=$2, funding_txid=$3, updated_at=now() where 
 
 	// Best effort inline; the poller finishes the job if the outpoint is not
 	// visible yet, which is normal rather than an error.
-	if err := s.confirmChannelPoint(ctx, token, record.OrderID, fundingTxid); err != nil && s.logger != nil {
+	if err := s.confirmChannelPointInline(ctx, token, record.OrderID, fundingTxid); err != nil && s.logger != nil {
 		s.logger.Printf("magma: order %s awaiting channel point: %v", record.OrderID, err)
 	}
 	return s.orderByID(ctx, record.OrderID)
@@ -613,7 +613,35 @@ update magma_orders set local_state=$2, funding_txid=$3, updated_at=now() where 
 // confirmChannelPoint resolves the funding txid to a full outpoint and reports it
 // to Amboss. The vout is read from the node rather than assumed: real orders
 // carry both :0 and :1.
+// confirmChannelPointInline is the attempt made moments after the broadcast. It
+// never raises an alert, whatever Amboss answers: two seconds is not enough time
+// for a transaction to reach them, so a failure here carries no information
+// about the sale. The reconciliation retries it, and that one may alert.
+func (s *MagmaService) confirmChannelPointInline(ctx context.Context, token, orderID, fundingTxid string) error {
+	return s.confirmChannelPointMode(ctx, token, orderID, fundingTxid, false)
+}
+
 func (s *MagmaService) confirmChannelPoint(ctx context.Context, token, orderID, fundingTxid string) error {
+	return s.confirmChannelPointMode(ctx, token, orderID, fundingTxid, true)
+}
+
+// magmaConfirmShouldAlert decides whether a failed confirmation is worth the
+// operator's attention.
+//
+// Two rules, and the first one is what matters. An inline attempt runs seconds
+// after the broadcast and is expected to fail, so it never alerts - the alert
+// then cannot be reintroduced by Amboss rewording an error, which is exactly
+// how it appeared: "Error finding transaction in the mempool" is a wording the
+// propagation check had never seen, so a routine wait was reported as a
+// failure and then quietly fixed 93 seconds later by the retry.
+func magmaConfirmShouldAlert(inline bool, err error) bool {
+	if err == nil || inline {
+		return false
+	}
+	return !magmaErrorIsPropagationRace(err)
+}
+
+func (s *MagmaService) confirmChannelPointMode(ctx context.Context, token, orderID, fundingTxid string, mayAlert bool) error {
 	channelPoint, err := s.findChannelPoint(ctx, fundingTxid)
 	if err != nil {
 		return err
@@ -631,7 +659,7 @@ update magma_orders set local_state=$2, channel_point=$3, updated_at=now() where
 		// yet and answers that the output does not exist. That is propagation, not
 		// a wrong outpoint: the reconciliation retries and it lands within a cycle
 		// or two. Alerting on it trains the operator to ignore real alerts.
-		if magmaErrorIsPropagationRace(err) {
+		if !magmaConfirmShouldAlert(!mayAlert, err) {
 			s.appendEvent(ctx, orderID, "confirm_pending", "info", fmt.Sprintf(
 				"Amboss has not seen funding transaction %s yet; retrying", fundingTxid), nil)
 			return err
@@ -700,7 +728,10 @@ func magmaErrorIsPropagationRace(err error) bool {
 	lowered := strings.ToLower(err.Error())
 	return strings.Contains(lowered, "not found in transaction") ||
 		strings.Contains(lowered, "transaction not found") ||
-		strings.Contains(lowered, "output not found")
+		strings.Contains(lowered, "output not found") ||
+		// Amboss's fourth wording for the same thing, seen 2026-09-02:
+		// "Error finding transaction in the mempool".
+		strings.Contains(lowered, "finding transaction")
 }
 
 // magmaTxidFromPoint returns the transaction id from either a bare txid or a


### PR DESCRIPTION
## O que aconteceu

Venda `7554c21d` no Friendspool, 02/09:

```
17:01:01  open_broadcast   funding tx transmitida
17:01:03  error            "failed to confirm the channel point to Amboss:
                            Error finding transaction in the mempool"     ← ⚠️ Telegram
17:02:36  confirmed        "confirmed to Amboss on retry"
```

Tentamos reportar o outpoint **dois segundos** depois de transmitir. A Amboss ainda não tinha visto a transação. Isso virou aviso no Telegram do operador, e o retry consertou 93 segundos depois. A venda nunca esteve em risco.

## A causa imediata

`magmaErrorIsPropagationRace` reconhece três redações de "não achei a transação". A Amboss usou uma quarta — *"Error finding transaction in the mempool"* — e o erro caiu no caminho de falha.

## A causa estrutural

A chamada inline já carregava este comentário:

```go
// Best effort inline; the poller finishes the job if the outpoint is not
// visible yet, which is normal rather than an error.
```

Mas ela chamava o mesmo código que escala para `failOrder`. **A intenção declarada no chamador e o comportamento do chamado se contradiziam** — bastava a Amboss reescrever uma mensagem para o "melhor esforço" virar alarme.

Agora isso está no código, não só no comentário: a tentativa feita logo após o broadcast **nunca alarma**, qualquer que seja a resposta. Dois segundos não bastam para uma transação chegar até eles, então uma falha ali não carrega informação sobre a venda.

Essa é a parte que importa. Casar strings de erro de terceiros vai continuar perdendo essa corrida — foi assim que o alarme apareceu. Uma regra sobre **quando** a tentativa aconteceu não pode ser reescrita por eles.

## O que muda

- `confirmChannelPointInline` (pós-broadcast) nunca alarma
- `confirmChannelPoint` (reconcile) alarma quando o erro não for corrida de propagação
- a decisão saiu para `magmaConfirmShouldAlert`, função pura e testável
- a quarta redação entrou na lista, então um retry que bata na mesma corrida também fica quieto

## Testes

`internal/server/magma_confirm_alert_test.go`: a tentativa inline não alarma nem diante de um erro real; o mesmo erro vindo de um retry alarma; as quatro redações são reconhecidas; e uma recusa genuína num retry ainda chega ao operador — que é a razão de o alerta existir.

`go test ./...` e `go vet ./internal/server/` verdes.

## Nota

A venda `7554c21d` completou normalmente: `local_state = confirmed`, sem erro pendente. Isto corrige o ruído, não o desfecho.

Separada da #100 de propósito: aquela é a migração de endpoint, esta é um defeito de alerta e pode ser revisada e mesclada por conta própria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)