### PR TITLE
0.5.24-Beta: Magma - não alarmar por channel point ainda não propagado

### DIFF
--- a/lightningos-light/internal/server/magma_confirm_alert_test.go
+++ b/lightningos-light/internal/server/magma_confirm_alert_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"errors"
+	"testing"
+)
+
+// Order 7554c21d, 2026-09-02: the funding transaction was broadcast at 17:01:01,
+// we tried to report the outpoint at 17:01:03, and Amboss answered "Error
+// finding transaction in the mempool" - it had not seen the transaction yet,
+// two seconds in. That went to Telegram as a warning, and the retry confirmed
+// it 93 seconds later. The sale was never at risk; the alert was pure noise,
+// and noise like that trains an operator to ignore the real ones.
+func TestMagmaConfirmDoesNotAlertOnTheInlineAttempt(t *testing.T) {
+	realFailure := errors.New("outpoint belongs to a different channel")
+	if magmaConfirmShouldAlert(true, realFailure) {
+		t.Fatal("the attempt made seconds after the broadcast must never alert, whatever Amboss answers")
+	}
+	// The same error from a retry is worth surfacing: by then the transaction
+	// has had time to propagate, so a failure means something.
+	if !magmaConfirmShouldAlert(false, realFailure) {
+		t.Fatal("a retry failing for a real reason must reach the operator")
+	}
+}
+
+// The wording that caused the false alarm. Adding it to the propagation check
+// keeps retries quiet too - the inline rule above is what makes the alert
+// impossible to reintroduce by rewording, but a retry hitting the same race
+// should not shout either.
+func TestMagmaConfirmRecognisesTheMempoolWording(t *testing.T) {
+	for _, message := range []string{
+		"Error finding transaction in the mempool",
+		"transaction not found",
+		"output not found",
+		"not found in transaction",
+	} {
+		if !magmaErrorIsPropagationRace(errors.New(message)) {
+			t.Fatalf("%q describes a transaction Amboss cannot see yet", message)
+		}
+		if magmaConfirmShouldAlert(false, errors.New(message)) {
+			t.Fatalf("%q must not alert even on a retry", message)
+		}
+	}
+}
+
+// A wrong outpoint is the failure this alert exists for, and it has to survive
+// everything above.
+func TestMagmaConfirmStillAlertsOnARealProblem(t *testing.T) {
+	if !magmaConfirmShouldAlert(false, errors.New("order already has a channel")) {
+		t.Fatal("a genuine refusal from a retry must still reach the operator")
+	}
+	if magmaConfirmShouldAlert(false, nil) {
+		t.Fatal("there is nothing to alert about when the call succeeded")
+	}
+}

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -604,7 +604,7 @@ update magma_orders set local_state=$2, funding_txid=$3, updated_at=now() where 
 
 	// Best effort inline; the poller finishes the job if the outpoint is not
 	// visible yet, which is normal rather than an error.
-	if err := s.confirmChannelPoint(ctx, token, record.OrderID, fundingTxid); err != nil && s.logger != nil {
+	if err := s.confirmChannelPointInline(ctx, token, record.OrderID, fundingTxid); err != nil && s.logger != nil {
 		s.logger.Printf("magma: order %s awaiting channel point: %v", record.OrderID, err)
 	}
 	return s.orderByID(ctx, record.OrderID)
@@ -613,7 +613,35 @@ update magma_orders set local_state=$2, funding_txid=$3, updated_at=now() where 
 // confirmChannelPoint resolves the funding txid to a full outpoint and reports it
 // to Amboss. The vout is read from the node rather than assumed: real orders
 // carry both :0 and :1.
+// confirmChannelPointInline is the attempt made moments after the broadcast. It
+// never raises an alert, whatever Amboss answers: two seconds is not enough time
+// for a transaction to reach them, so a failure here carries no information
+// about the sale. The reconciliation retries it, and that one may alert.
+func (s *MagmaService) confirmChannelPointInline(ctx context.Context, token, orderID, fundingTxid string) error {
+	return s.confirmChannelPointMode(ctx, token, orderID, fundingTxid, false)
+}
+
 func (s *MagmaService) confirmChannelPoint(ctx context.Context, token, orderID, fundingTxid string) error {
+	return s.confirmChannelPointMode(ctx, token, orderID, fundingTxid, true)
+}
+
+// magmaConfirmShouldAlert decides whether a failed confirmation is worth the
+// operator's attention.
+//
+// Two rules, and the first one is what matters. An inline attempt runs seconds
+// after the broadcast and is expected to fail, so it never alerts - the alert
+// then cannot be reintroduced by Amboss rewording an error, which is exactly
+// how it appeared: "Error finding transaction in the mempool" is a wording the
+// propagation check had never seen, so a routine wait was reported as a
+// failure and then quietly fixed 93 seconds later by the retry.
+func magmaConfirmShouldAlert(inline bool, err error) bool {
+	if err == nil || inline {
+		return false
+	}
+	return !magmaErrorIsPropagationRace(err)
+}
+
+func (s *MagmaService) confirmChannelPointMode(ctx context.Context, token, orderID, fundingTxid string, mayAlert bool) error {
 	channelPoint, err := s.findChannelPoint(ctx, fundingTxid)
 	if err != nil {
 		return err
@@ -631,7 +659,7 @@ update magma_orders set local_state=$2, channel_point=$3, updated_at=now() where
 		// yet and answers that the output does not exist. That is propagation, not
 		// a wrong outpoint: the reconciliation retries and it lands within a cycle
 		// or two. Alerting on it trains the operator to ignore real alerts.
-		if magmaErrorIsPropagationRace(err) {
+		if !magmaConfirmShouldAlert(!mayAlert, err) {
 			s.appendEvent(ctx, orderID, "confirm_pending", "info", fmt.Sprintf(
 				"Amboss has not seen funding transaction %s yet; retrying", fundingTxid), nil)
 			return err
@@ -700,7 +728,10 @@ func magmaErrorIsPropagationRace(err error) bool {
 	lowered := strings.ToLower(err.Error())
 	return strings.Contains(lowered, "not found in transaction") ||
 		strings.Contains(lowered, "transaction not found") ||
-		strings.Contains(lowered, "output not found")
+		strings.Contains(lowered, "output not found") ||
+		// Amboss's fourth wording for the same thing, seen 2026-09-02:
+		// "Error finding transaction in the mempool".
+		strings.Contains(lowered, "finding transaction")
 }
 
 // magmaTxidFromPoint returns the transaction id from either a bare txid or a


### PR DESCRIPTION
## Organização da release

Esta PR substitui a #128, que foi criada por engano a partir de main com nome e commit 0.5.22. Esta versão deriva diretamente de agent/0.5.24-release e mantém version.txt em 0.5.24-Beta.

## Problema

A confirmação inline do channel point, executada poucos segundos após o broadcast, podia gerar alerta no Telegram quando a Amboss ainda não tinha visto a transação. O retry confirmava normalmente depois, portanto o primeiro aviso era ruído e não indicava risco para a venda.

## Correção

- a confirmação inline pós-broadcast passa a ser sempre best effort e não alarma
- o reconcile continua alarmando falhas reais que não sejam corrida de propagação
- a decisão fica centralizada em magmaConfirmShouldAlert
- reconhece também a mensagem Error finding transaction in the mempool
- inclui testes para tentativa inline, retry, corrida de propagação e falha real

## Validação

- go test ./...
- branch baseada em agent/0.5.24-release
- version.txt = 0.5.24-Beta

Nenhuma alteração foi aplicada em produção.