### PR TITLE
0.5.25-Beta: align autopilot with liquidity intent and source roles

### DIFF
--- a/docs/03_API_SPEC.md
+++ b/docs/03_API_SPEC.md
@@ -465,9 +465,12 @@ POST /api/lnops/autofee/refresh
 
 GET /api/lnops/channel-ranking
 - Returns the persisted economic ranking. The existing score, state, reasons, recommendations, 7d/30d economics, liquidity, HTLC and automation fields remain the source of truth.
+- Assisted revenue still contributes to the score, but a mature channel holding at least 70% local liquidity receives a bounded capital-turnover penalty when its useful source role moves too little volume for the capital retained. The reason is exposed as `source_liquidity_underused`; this is advisory and never triggers an automatic close.
 
 GET /api/lnops/channel-ranking/plan
 - Returns a read-only operational view over the current ranking. Each entry keeps the original ranking item under `channel` and adds `action`, `priority`, `eligible`, observation progress, blockers, recoverable local balance and an optional primary action link.
+- Refill entries also expose the live Rebalance deficit (`target_outbound_pct`, `target_amount_sat`), `automation_ready`, `automation_blockers`, and `active_refill_intent`. Strategic recommendation and current automatic executability are intentionally separate.
+- `recycle_source` identifies a high-local-liquidity source reservoir with meaningful assisted flow but little direct outbound flow. It recommends using the liquidity as a Rebalance source before considering rotation; it never closes a channel automatically.
 - `parked` is treated as an operator policy, not an economic classification. Parked channels continue to carry their ranking evidence but are not eligible for plan execution.
 - Active Magma commitments produce `protected` entries and never enter early-close rotation. If Magma state cannot be verified, close candidates fail closed with `magma_state_unavailable`.
 - `recoverable_local_sat` uses local balance, not total channel capacity, and is only operationally available after a cooperative close confirms.
@@ -497,6 +500,8 @@ GET /api/lnops/automation-intents?active=true&consumer=rebalance&kind=refill_tar
 - Lists current intents and their producer profile/node calibration provenance.
 - Includes `channel_id_str` so clients can preserve the full unsigned Lightning channel ID without JavaScript number rounding.
 - Supported kinds in the MVP are `refill_target` and `protect_fee_floor`.
+- `refill_target` requires a live, eligible Rebalance deficit in automation scope. AutoFee may publish it for `low`, `drained`, or `extreme-drained` liquidity and for productive channels below their configured outbound target.
+- In `enforce` mode, an admitted refill intent receives an operational priority lane among candidates with the same outbound urgency. It never bypasses ROI, profit, budget, cooldown, busy-channel, or source safety gates. AutoFee settling may neutralize the score boost but cannot invert it below the pre-settling score.
 - `protect_fee_floor` evidence exposes the peer fee rate, amount-normalized peer and local base fees,
   effective peer/required costs, econ ratio, reference amount, and calculated floor.
 - AutoFee result channel items influenced by that intent include an `economic_floor` object with the
@@ -805,6 +810,7 @@ POST /api/rebalance/channel/guaranteed
 GET /api/rebalance/history
 - Returns completed jobs and attempts from the last 24 hours.
 - Sovereign jobs include their planned economics and realized forwarding attribution. Jobs selected through the adaptive exploration path expose `exploration_slot: true`; the field is omitted for regular jobs.
+- Source routeability is also learned across targets: a source with at least 12 consecutive failed attempts spanning at least four different targets in six hours is quarantined for six hours. It becomes eligible for a recovery probe after the quarantine expires, and any success resets the failure pressure.
 
 GET /api/rebalance/overview
 - Includes separate 7-day exploration counters and realized economics under the `sovereign_exploration_*_7d` fields. `sovereign_jobs_7d` and `sovereign_exploration_share_7d` expose the actual completed-job mix so operators can compare the effective exploration share with the configured per-cycle slot percentage.

--- a/lightningos-light/internal/server/autofee_service.go
+++ b/lightningos-light/internal/server/autofee_service.go
@@ -2778,6 +2778,9 @@ type autofeeRebalanceRuntimeSnapshot struct {
 	AutoEnabled          bool
 	ManualRestartEnabled bool
 	EligibleAsTarget     bool
+	TargetOutboundPct    float64
+	TargetAmountSat      int64
+	LocalBalancePct      float64
 	PaybackProgress      float64
 	ROIEstimate          float64
 	ROIEstimateValid     bool
@@ -3766,6 +3769,9 @@ func (e *autofeeEngine) Execute(ctx context.Context, dryRun bool, reason string)
 					AutoEnabled:          item.AutoEnabled,
 					ManualRestartEnabled: item.ManualRestartEnabled,
 					EligibleAsTarget:     item.EligibleAsTarget,
+					TargetOutboundPct:    item.TargetOutboundPct,
+					TargetAmountSat:      item.TargetAmountSat,
+					LocalBalancePct:      item.LocalPct,
 					PaybackProgress:      item.PaybackProgress,
 					ROIEstimate:          item.ROIEstimate,
 					ROIEstimateValid:     item.ROIEstimateValid,
@@ -4383,20 +4389,36 @@ func (e *autofeeEngine) deriveRefillTargetIntent(ch lndclient.ChannelInfo, d *de
 	if d == nil || ch.ChannelID == 0 || e.automationIntentConfig.Mode == automationIntentModeOff {
 		return AutomationIntent{}, false
 	}
-	state := strings.ToLower(strings.TrimSpace(d.LiquidityState))
-	if state != "drained" && state != "extreme-drained" {
-		return AutomationIntent{}, false
-	}
 	runtime, ok := e.rebalanceRuntime[ch.ChannelID]
-	if !ok || !runtime.EligibleAsTarget || (!runtime.AutoEnabled && !runtime.ManualRestartEnabled) {
+	if !ok || !runtime.EligibleAsTarget || runtime.TargetAmountSat <= 0 || (!runtime.AutoEnabled && !runtime.ManualRestartEnabled) {
 		return AutomationIntent{}, false
 	}
-	confidence := 0.78
-	if state == "extreme-drained" {
-		confidence = 0.90
+	state := strings.ToLower(strings.TrimSpace(d.LiquidityState))
+	reasonCode := ""
+	confidence := 0.0
+	switch state {
+	case autofeeLiquidityStateExtremeDrained:
+		reasonCode, confidence = "autofee_extreme_drained_target", 0.92
+	case autofeeLiquidityStateDrained:
+		reasonCode, confidence = "autofee_drained_target", 0.86
+	case autofeeLiquidityStateLow:
+		reasonCode, confidence = "autofee_low_outbound_target", 0.80
+	default:
+		// The effective AutoFee liquidity class may be normalized by channel
+		// size. Preserve a productive target signal when Rebalance confirms a
+		// real deficit and the channel has recent revenue.
+		if runtime.LocalBalancePct < runtime.TargetOutboundPct && runtime.Revenue7dSat > 0 {
+			reasonCode, confidence = "autofee_productive_refill_target", 0.75
+		}
+	}
+	if reasonCode == "" {
+		return AutomationIntent{}, false
 	}
 	if d.FwdCount > 0 {
 		confidence += 0.05
+	}
+	if runtime.TargetOutboundPct > 0 && runtime.LocalBalancePct < runtime.TargetOutboundPct/2 {
+		confidence += 0.03
 	}
 	if d.NewPpm > d.LocalPpm || d.Target > d.LocalPpm {
 		confidence += 0.05
@@ -4410,10 +4432,6 @@ func (e *autofeeEngine) deriveRefillTargetIntent(ch lndclient.ChannelInfo, d *de
 	ttl := time.Duration(e.automationIntentConfig.RefillTargetTTLSec) * time.Second
 	if ttl <= 0 {
 		ttl = 6 * time.Hour
-	}
-	reasonCode := "autofee_drained_target"
-	if state == "extreme-drained" {
-		reasonCode = "autofee_extreme_drained_target"
 	}
 	return AutomationIntent{
 		ChannelID:              ch.ChannelID,
@@ -4439,6 +4457,10 @@ func (e *autofeeEngine) deriveRefillTargetIntent(ch lndclient.ChannelInfo, d *de
 			"forward_count":       d.FwdCount,
 			"rebalance_roi":       runtime.ROIEstimate,
 			"rebalance_roi_valid": runtime.ROIEstimateValid,
+			"target_outbound_pct": runtime.TargetOutboundPct,
+			"target_amount_sat":   runtime.TargetAmountSat,
+			"local_balance_pct":   runtime.LocalBalancePct,
+			"revenue_7d_sat":      runtime.Revenue7dSat,
 		},
 	}, true
 }

--- a/lightningos-light/internal/server/automation_intent_service_test.go
+++ b/lightningos-light/internal/server/automation_intent_service_test.go
@@ -119,7 +119,7 @@ func TestDeriveRefillTargetIntentUsesAutofeeCalibrationAndRebalanceEligibility(t
 			RefillScoreMultiplier: 1.2, MinConfidence: 0.7,
 		},
 		rebalanceRuntime: map[uint64]autofeeRebalanceRuntimeSnapshot{
-			42: {AutoEnabled: true, EligibleAsTarget: true, ROIEstimate: 1.4, ROIEstimateValid: true},
+			42: {AutoEnabled: true, EligibleAsTarget: true, TargetAmountSat: 500_000, TargetOutboundPct: 20, LocalBalancePct: 1, ROIEstimate: 1.4, ROIEstimateValid: true},
 		},
 	}
 	channel := lndclient.ChannelInfo{ChannelID: 42, ChannelPoint: "tx:0", Active: true}
@@ -138,5 +138,27 @@ func TestDeriveRefillTargetIntentUsesAutofeeCalibrationAndRebalanceEligibility(t
 	engine.rebalanceRuntime[42] = autofeeRebalanceRuntimeSnapshot{AutoEnabled: true, EligibleAsTarget: false}
 	if _, ok := engine.deriveRefillTargetIntent(channel, decision, "run-2"); ok {
 		t.Fatal("intent must not bypass rebalance eligibility")
+	}
+}
+
+func TestDeriveRefillTargetIntentUsesLiveDeficitForLowLiquidity(t *testing.T) {
+	engine := &autofeeEngine{
+		now:                    time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC),
+		automationIntentConfig: AutomationIntentConfig{Mode: automationIntentModeEnforce, MinConfidence: .8, RefillTargetTTLSec: 3600},
+		rebalanceRuntime: map[uint64]autofeeRebalanceRuntimeSnapshot{
+			7: {AutoEnabled: true, EligibleAsTarget: true, TargetAmountSat: 300_000, TargetOutboundPct: 20, LocalBalancePct: 9},
+		},
+	}
+	channel := lndclient.ChannelInfo{ChannelID: 7, ChannelPoint: "low:0"}
+	intent, ok := engine.deriveRefillTargetIntent(channel, &decision{LiquidityState: autofeeLiquidityStateLow}, "run-low")
+	if !ok || intent.ReasonCode != "autofee_low_outbound_target" {
+		t.Fatalf("expected low-liquidity intent, got ok=%v intent=%+v", ok, intent)
+	}
+
+	runtime := engine.rebalanceRuntime[7]
+	runtime.TargetAmountSat = 0
+	engine.rebalanceRuntime[7] = runtime
+	if _, ok := engine.deriveRefillTargetIntent(channel, &decision{LiquidityState: autofeeLiquidityStateExtremeDrained}, "run-full"); ok {
+		t.Fatal("target without a live deficit must not publish a refill intent")
 	}
 }

--- a/lightningos-light/internal/server/channel_capital_plan.go
+++ b/lightningos-light/internal/server/channel_capital_plan.go
@@ -3,10 +3,12 @@ package server
 import (
 	"sort"
 	"strings"
+	"time"
 )
 
 const (
 	channelCapitalActionRefill    = "refill"
+	channelCapitalActionRecycle   = "recycle_source"
 	channelCapitalActionReprice   = "reprice"
 	channelCapitalActionExpand    = "expand"
 	channelCapitalActionMaintain  = "maintain"
@@ -32,6 +34,11 @@ type ChannelCapitalPlanItem struct {
 	RecoverableLocalSat int64                     `json:"recoverable_local_sat"`
 	PrimaryAction       *ChannelCapitalPlanAction `json:"primary_action,omitempty"`
 	MagmaCommitment     *MagmaChannelCommitment   `json:"magma_commitment,omitempty"`
+	AutomationReady     bool                      `json:"automation_ready"`
+	AutomationBlockers  []string                  `json:"automation_blockers,omitempty"`
+	TargetOutboundPct   float64                   `json:"target_outbound_pct,omitempty"`
+	TargetAmountSat     int64                     `json:"target_amount_sat,omitempty"`
+	ActiveRefillIntent  bool                      `json:"active_refill_intent,omitempty"`
 }
 
 type ChannelCapitalPlanSummary struct {
@@ -88,7 +95,7 @@ func buildChannelCapitalPlan(items []ChannelRankingItem, commitments []MagmaChan
 		item.Priority = channelCapitalPlanPriority(item)
 		plan.Summary.ActionCounts[item.Action]++
 		switch item.Action {
-		case channelCapitalActionExpand, channelCapitalActionMaintain, channelCapitalActionRefill, channelCapitalActionReprice:
+		case channelCapitalActionExpand, channelCapitalActionMaintain, channelCapitalActionRefill, channelCapitalActionRecycle, channelCapitalActionReprice:
 			plan.Summary.ProductiveCapitalSat += rankingMaxInt64(0, channel.CapacitySat)
 		case channelCapitalActionProtected:
 			plan.Summary.ProtectedCapitalSat += rankingMaxInt64(0, channel.CapacitySat)
@@ -146,6 +153,9 @@ func buildChannelCapitalPlanItem(channel ChannelRankingItem) ChannelCapitalPlanI
 		if channelCapitalPlanNeedsRefill(channel) {
 			item.Action = channelCapitalActionRefill
 			item.PrimaryAction = &ChannelCapitalPlanAction{Code: "manual_rebalance", TargetModule: "rebalance"}
+		} else if channelCapitalPlanNeedsSourceRecycle(channel) {
+			item.Action = channelCapitalActionRecycle
+			item.PrimaryAction = &ChannelCapitalPlanAction{Code: "review_source_liquidity", TargetModule: "rebalance-sources"}
 		} else if channelCapitalPlanNeedsReprice(channel) {
 			item.Action = channelCapitalActionReprice
 			item.PrimaryAction = &ChannelCapitalPlanAction{Code: "review_fees", TargetModule: "autofee"}
@@ -161,7 +171,10 @@ func buildChannelCapitalPlanItem(channel ChannelRankingItem) ChannelCapitalPlanI
 			item.Blockers = append(item.Blockers, "observation_30d")
 		}
 	case "monitor":
-		if channelCapitalPlanNeedsReprice(channel) {
+		if channelCapitalPlanNeedsSourceRecycle(channel) {
+			item.Action = channelCapitalActionRecycle
+			item.PrimaryAction = &ChannelCapitalPlanAction{Code: "review_source_liquidity", TargetModule: "rebalance-sources"}
+		} else if channelCapitalPlanNeedsReprice(channel) {
 			item.Action = channelCapitalActionReprice
 			item.PrimaryAction = &ChannelCapitalPlanAction{Code: "review_fees", TargetModule: "autofee"}
 		} else {
@@ -173,8 +186,65 @@ func buildChannelCapitalPlanItem(channel ChannelRankingItem) ChannelCapitalPlanI
 
 func channelCapitalPlanNeedsRefill(channel ChannelRankingItem) bool {
 	state := strings.TrimSpace(strings.ToLower(channel.LiquidityState))
-	return state == autofeeLiquidityStateDrained || state == autofeeLiquidityStateExtremeDrained ||
+	stateFresh := true
+	if channel.LiquidityStateAt != nil && !channel.LiquidityStateAt.IsZero() {
+		reference := channel.ComputedAt
+		if reference.IsZero() {
+			reference = time.Now()
+		}
+		stateFresh = !channel.LiquidityStateAt.Before(reference.Add(-12 * time.Hour))
+	}
+	return (stateFresh && (state == autofeeLiquidityStateDrained || state == autofeeLiquidityStateExtremeDrained)) ||
 		(channel.LocalBalancePct < 25 && channel.ProfitFee7dSat > 0)
+}
+
+// A source reservoir can look deceptively healthy in the economic score: it
+// assists other channels and has no rebalance cost, while most of its capital
+// remains local. Surface the operational role without ever turning the
+// recommendation into an automatic close.
+func channelCapitalPlanNeedsSourceRecycle(channel ChannelRankingItem) bool {
+	return applySourceReservoirCapitalPenalty(100, channel.CapacitySat, channel.LocalBalancePct,
+		channelTrafficStat{AmountSat: channel.ForwardAmt7dSat, FeeSat: channel.ForwardFee7dSat},
+		channelTrafficStat{AmountSat: channel.AssistedForwardAmt7dSat, FeeSat: channel.AssistedForwardFee7dSat}, 7) < 100
+}
+
+func enrichChannelCapitalPlanAutomation(plan *ChannelCapitalPlan, channels []RebalanceChannel, intents map[uint64][]AutomationIntent) {
+	if plan == nil {
+		return
+	}
+	byID := make(map[uint64]RebalanceChannel, len(channels))
+	byPoint := make(map[string]RebalanceChannel, len(channels))
+	for _, channel := range channels {
+		byID[channel.ChannelID] = channel
+		byPoint[strings.ToLower(strings.TrimSpace(channel.ChannelPoint))] = channel
+	}
+	for i := range plan.Items {
+		item := &plan.Items[i]
+		if item.Action != channelCapitalActionRefill {
+			continue
+		}
+		channel, ok := byID[uint64(item.Channel.ChannelID)]
+		if !ok {
+			channel, ok = byPoint[strings.ToLower(strings.TrimSpace(item.Channel.ChannelPoint))]
+		}
+		if !ok {
+			item.AutomationBlockers = append(item.AutomationBlockers, "rebalance_state_unavailable")
+			continue
+		}
+		item.TargetOutboundPct = channel.TargetOutboundPct
+		item.TargetAmountSat = channel.TargetAmountSat
+		if !channel.AutoEnabled && !channel.ManualRestartEnabled {
+			item.AutomationBlockers = append(item.AutomationBlockers, "rebalance_not_automated")
+		}
+		if channel.TargetAmountSat <= 0 {
+			item.AutomationBlockers = append(item.AutomationBlockers, "target_satisfied")
+		}
+		if !channel.EligibleAsTarget {
+			item.AutomationBlockers = append(item.AutomationBlockers, "rebalance_target_ineligible")
+		}
+		item.AutomationReady = len(item.AutomationBlockers) == 0
+		item.ActiveRefillIntent = selectRefillTargetIntent(intents[channel.ChannelID], 0) != nil
+	}
 }
 
 func channelCapitalPlanNeedsReprice(channel ChannelRankingItem) bool {
@@ -197,6 +267,8 @@ func channelCapitalPlanPriority(item ChannelCapitalPlanItem) int {
 		return 100
 	case channelCapitalActionRefill:
 		return 500 + score
+	case channelCapitalActionRecycle:
+		return 450 + score
 	case channelCapitalActionExpand:
 		return 400 + score
 	case channelCapitalActionReprice:

--- a/lightningos-light/internal/server/channel_capital_plan_handlers.go
+++ b/lightningos-light/internal/server/channel_capital_plan_handlers.go
@@ -29,6 +29,17 @@ func (s *Server) handleChannelCapitalPlanGet(w http.ResponseWriter, r *http.Requ
 
 	commitments, magmaStateKnown := s.channelCapitalPlanCommitments(ctx)
 	plan := buildChannelCapitalPlan(items, commitments, magmaStateKnown)
+	if s.rebalance != nil {
+		if channels, channelErr := s.rebalance.Channels(ctx); channelErr == nil {
+			activeIntents := map[uint64][]AutomationIntent{}
+			if s.automationIntents != nil {
+				if loaded, intentErr := s.automationIntents.ActiveForConsumer(ctx, automationIntentProducerRebalance, time.Now()); intentErr == nil {
+					activeIntents = loaded
+				}
+			}
+			enrichChannelCapitalPlanAutomation(&plan, channels, activeIntents)
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"available":         status.Available,
 		"last_sync_at":      status.LastSyncAt,

--- a/lightningos-light/internal/server/channel_capital_plan_test.go
+++ b/lightningos-light/internal/server/channel_capital_plan_test.go
@@ -1,6 +1,9 @@
 package server
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestBuildChannelCapitalPlanUsesRankingWithoutChangingIt(t *testing.T) {
 	channel := ChannelRankingItem{
@@ -96,5 +99,63 @@ func TestBuildChannelCapitalPlanRequiresInitialObservation(t *testing.T) {
 	}
 	if len(item.Blockers) != 1 || item.Blockers[0] != "observation_7d" {
 		t.Fatalf("unexpected blockers: %#v", item.Blockers)
+	}
+}
+
+func TestBuildChannelCapitalPlanRecognizesUsefulSourceReservoir(t *testing.T) {
+	channel := ChannelRankingItem{
+		ChannelPoint:            "source:0",
+		State:                   "maintain",
+		Score:                   61,
+		CapacitySat:             22_000_000,
+		LocalBalanceSat:         18_000_000,
+		LocalBalancePct:         81.8,
+		ForwardAmt7dSat:         0,
+		AssistedForwardAmt7dSat: 766_506,
+		PeerSampleCount30d:      channelRankingFull30dObservationSamples,
+	}
+	item := buildChannelCapitalPlan([]ChannelRankingItem{channel}, nil, true).Items[0]
+	if item.Action != channelCapitalActionRecycle || !item.Eligible {
+		t.Fatalf("expected source recycle recommendation, got action=%q eligible=%v", item.Action, item.Eligible)
+	}
+	if item.PrimaryAction == nil || item.PrimaryAction.Code != "review_source_liquidity" {
+		t.Fatalf("unexpected primary action: %#v", item.PrimaryAction)
+	}
+}
+
+func TestChannelCapitalPlanIgnoresStaleAutofeeDrainState(t *testing.T) {
+	computedAt := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	stateAt := computedAt.Add(-24 * time.Hour)
+	channel := ChannelRankingItem{
+		State: "maintain", CapacitySat: 5_000_000, LocalBalancePct: 60,
+		LiquidityState: autofeeLiquidityStateDrained, LiquidityStateAt: &stateAt,
+		ComputedAt: computedAt, PeerSampleCount30d: channelRankingFull30dObservationSamples,
+	}
+	if item := buildChannelCapitalPlanItem(channel); item.Action == channelCapitalActionRefill {
+		t.Fatalf("stale liquidity state produced refill: %#v", item)
+	}
+}
+
+func TestEnrichChannelCapitalPlanSeparatesRecommendationFromAutomationReadiness(t *testing.T) {
+	plan := ChannelCapitalPlan{Items: []ChannelCapitalPlanItem{{
+		Channel: ChannelRankingItem{ChannelID: 42, ChannelPoint: "target:0"},
+		Action:  channelCapitalActionRefill,
+	}}}
+	intent := AutomationIntent{ChannelID: 42, Kind: automationIntentKindRefillTarget, Confidence: .9}
+	enrichChannelCapitalPlanAutomation(&plan, []RebalanceChannel{{
+		ChannelID: 42, ChannelPoint: "target:0", AutoEnabled: true, EligibleAsTarget: true,
+		TargetOutboundPct: 20, TargetAmountSat: 500_000,
+	}}, map[uint64][]AutomationIntent{42: {intent}})
+	item := plan.Items[0]
+	if !item.AutomationReady || !item.ActiveRefillIntent || item.TargetAmountSat != 500_000 {
+		t.Fatalf("expected actionable refill metadata, got %#v", item)
+	}
+
+	plan.Items[0].AutomationBlockers = nil
+	enrichChannelCapitalPlanAutomation(&plan, []RebalanceChannel{{
+		ChannelID: 42, ChannelPoint: "target:0", AutoEnabled: true, EligibleAsTarget: false,
+	}}, nil)
+	if plan.Items[0].AutomationReady || len(plan.Items[0].AutomationBlockers) == 0 {
+		t.Fatalf("strategic recommendation must expose automation blockers: %#v", plan.Items[0])
 	}
 }

--- a/lightningos-light/internal/server/channel_ranking_service.go
+++ b/lightningos-light/internal/server/channel_ranking_service.go
@@ -1019,7 +1019,13 @@ func buildChannelRankingItem(
 	score7d = applyIdle7dPenalty(score7d, noEconomicMovement7d)
 	score7d = applyRebalanceNoPaybackPenalty(score7d, rebalanceNoPayback)
 	score7d = applyIdle30dPenalty(score7d, noEconomicMovement30d || rebalanceOnly30d)
+	if full7dObservation {
+		score7d = applySourceReservoirCapitalPenalty(score7d, capacity, localPct, forward7d, assisted7d, 7)
+	}
 	score30d := computeChannelRankingScore(ch, capacity, localPct, effectiveForward30d, rebal30d, effectiveProfitSat30d, peerAggregate.Score30d, htlcAggregate, rebalanceDependenceScore)
+	if full30dObservation {
+		score30d = applySourceReservoirCapitalPenalty(score30d, capacity, localPct, forward30d, assisted30d, 30)
+	}
 	trendDirection, trendDelta := computeChannelRankingTrend(score7d, score30d)
 	state, reasons, recommendations := classifyChannelRanking(
 		ch,
@@ -1189,6 +1195,32 @@ func applyIdle30dPenalty(score int, weakIdleSignal bool) int {
 		return score
 	}
 	return clampInt(score-channelRankingIdle30dPenalty, 0, channelRankingIdle30dScoreCap)
+}
+
+func applySourceReservoirCapitalPenalty(score int, capacity int64, localPct float64, direct channelTrafficStat, assisted channelTrafficStat, days int) int {
+	if capacity <= 0 || localPct < 70 || days <= 0 {
+		return score
+	}
+	minimumAssisted := rankingMaxInt64(100_000, capacity/100) * int64(days) / 7
+	if assisted.AmountSat < minimumAssisted || direct.AmountSat*4 > assisted.AmountSat {
+		return score
+	}
+	localCapital := float64(capacity) * localPct / 100
+	if localCapital <= 0 {
+		return score
+	}
+	effectiveVolume := float64(direct.AmountSat) + float64(assisted.AmountSat)*channelRankingAssistedRevenueWeight
+	weeklyTurnover := (effectiveVolume / localCapital) * (7 / float64(days))
+	penalty := 0
+	switch {
+	case weeklyTurnover < 0.025:
+		penalty = 20
+	case weeklyTurnover < 0.05:
+		penalty = 14
+	case weeklyTurnover < 0.10:
+		penalty = 8
+	}
+	return clampInt(score-penalty, 0, 100)
 }
 
 func appendUniqueRecommendation(list []ChannelRankingRecommendation, candidate ChannelRankingRecommendation) []ChannelRankingRecommendation {
@@ -1398,6 +1430,9 @@ func classifyChannelRanking(
 	if rebalanceDependenceScore >= 65 {
 		reasons = append(reasons, ChannelRankingReason{Code: "rebalance_dependence_high"})
 	}
+	if full7dObservation && applySourceReservoirCapitalPenalty(100, capacity, localPct, forward7d, assisted7d, 7) < 100 {
+		reasons = append(reasons, ChannelRankingReason{Code: "source_liquidity_underused"})
+	}
 	if capacity > 0 {
 		netPpm := (float64(effectiveProfitSat7d) / float64(capacity)) * 1_000_000
 		if netPpm >= 75 {
@@ -1498,6 +1533,9 @@ func classifyChannelRanking(
 		if len(recommendations) == 0 {
 			recommendations = appendUniqueRecommendation(recommendations, ChannelRankingRecommendation{Code: "keep_channel_under_observation", TargetModule: "lightning-ops"})
 		}
+	}
+	if full7dObservation && applySourceReservoirCapitalPenalty(100, capacity, localPct, forward7d, assisted7d, 7) < 100 {
+		recommendations = appendUniqueRecommendation(recommendations, ChannelRankingRecommendation{Code: "recycle_source_liquidity", TargetModule: "rebalance-sources"})
 	}
 
 	if len(reasons) > 5 {

--- a/lightningos-light/internal/server/channel_ranking_service_test.go
+++ b/lightningos-light/internal/server/channel_ranking_service_test.go
@@ -8,6 +8,21 @@ import (
 	"lightningos-light/internal/lndclient"
 )
 
+func TestSourceReservoirCapitalPenaltyUsesWeeklyCapitalTurnover(t *testing.T) {
+	direct := channelTrafficStat{}
+	assisted := channelTrafficStat{AmountSat: 766_506, FeeSat: 1_062}
+	if got := applySourceReservoirCapitalPenalty(61, 22_000_000, 81.5, direct, assisted, 7); got != 41 {
+		t.Fatalf("expected low-turnover source score 61->41, got %d", got)
+	}
+	productive := channelTrafficStat{AmountSat: 5_000_000, FeeSat: 2_000}
+	if got := applySourceReservoirCapitalPenalty(61, 22_000_000, 81.5, direct, productive, 7); got != 61 {
+		t.Fatalf("productive source reservoir must keep its score, got %d", got)
+	}
+	if got := applySourceReservoirCapitalPenalty(61, 22_000_000, 50, direct, assisted, 7); got != 61 {
+		t.Fatalf("balanced channel must not receive source-reservoir penalty, got %d", got)
+	}
+}
+
 func TestClassifyChannelRankingKeepsStrong30dChannelUnderMonitor(t *testing.T) {
 	ch := lndclient.ChannelInfo{
 		Active:           true,

--- a/lightningos-light/internal/server/rebalance_service.go
+++ b/lightningos-light/internal/server/rebalance_service.go
@@ -73,6 +73,10 @@ const (
 	targetDistinctSourceCooldownWindow  = rebalanceMaxCooldown
 	sourceCooldownMinAttempts           = 25
 	sourceCooldownMaxSuccess            = 1
+	sourceRouteabilityWindow            = 6 * time.Hour
+	sourceRouteabilityTTL               = 6 * time.Hour
+	sourceRouteabilityMinAttempts       = 12
+	sourceRouteabilityMinTargets        = 4
 	targetCooldownMinAttempts           = 25
 	targetCooldownMaxSuccess            = 0
 	targetNoAttemptCooldownMinFailures  = 3
@@ -1325,6 +1329,7 @@ type recentCooldownStat struct {
 	Failures        int
 	Successes       int
 	DistinctSources int
+	DistinctTargets int
 	LastAttemptAt   time.Time
 	LastFailureAt   time.Time
 	LastSuccessAt   time.Time
@@ -3298,6 +3303,23 @@ func shouldCooldownDistinctSourceFailures(stat recentCooldownStat, minSources in
 	return now.Sub(lastFailureAt) <= recentCooldownTTL
 }
 
+func shouldQuarantineBroadSourceFailures(stat recentCooldownStat, now time.Time) bool {
+	if stat.Attempts < sourceRouteabilityMinAttempts || stat.Failures < sourceRouteabilityMinAttempts || stat.DistinctTargets < sourceRouteabilityMinTargets {
+		return false
+	}
+	lastFailureAt := stat.LastFailureAt
+	if lastFailureAt.IsZero() {
+		lastFailureAt = stat.LastAttemptAt
+	}
+	if lastFailureAt.IsZero() || (!stat.LastSuccessAt.IsZero() && !stat.LastSuccessAt.Before(lastFailureAt)) {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return now.Sub(lastFailureAt) <= sourceRouteabilityTTL
+}
+
 func shouldCooldownTargetRecentFailures(attemptStat recentCooldownStat, noAttemptStat recentCooldownStat, failedStat recentCooldownStat, distinctSourceStat recentCooldownStat, now time.Time) bool {
 	if shouldCooldownRecentFailures(attemptStat, targetCooldownMinAttempts, targetCooldownMaxSuccess, now) {
 		return true
@@ -5055,11 +5077,13 @@ func buildAndOrderRebalanceCandidates(input rebalanceAutoScanCandidateInput) reb
 			}
 		}
 	}
-	applyRefillTargetIntents(plan.Candidates, input.AutomationIntents, input.AutomationIntentConfig, input.Cfg.Profile)
+	preSettlingScores := captureRebalanceTargetScores(plan.Candidates)
 	plan.AutofeeDampened = applyAutofeeSettlingPenalty(plan.Candidates, input.AutofeeRecentAdjustments, input.Cfg, input.ScanAt)
 	if plan.AutofeeDampened > 0 {
 		noteSkip("autofee_settling_target") // observability counter; candidate still queued
 	}
+	applyRefillTargetIntents(plan.Candidates, input.AutomationIntents, input.AutomationIntentConfig, input.Cfg.Profile)
+	preserveRefillIntentPriority(plan.Candidates, preSettlingScores)
 	plan.TopScore = 0
 	plan.TopScoreSet = false
 	for _, candidate := range plan.Candidates {
@@ -5112,6 +5136,13 @@ func sortRebalanceTargets(candidates []rebalanceTarget, topScore int64, topScore
 		bUrgency := sovereignOutboundUrgency(b.Channel)
 		if aUrgency != bUrgency {
 			return aUrgency > bUrgency
+		}
+		// An enforced refill intent is an operational priority lane, not an
+		// exemption from ROI, profit, budget, cooldown, or source gates. Sort it
+		// ahead of comparable candidates so Automation Intent can affect which
+		// job gets the limited slot even when scores are close.
+		if a.IntentApplied != b.IntentApplied {
+			return a.IntentApplied
 		}
 		aBucket := inTopBucket(a.Score)
 		bBucket := inTopBucket(b.Score)
@@ -6104,11 +6135,13 @@ func (r *rebalanceJobRunner) prepare(st *rebalanceJobRunState) {
 	sources := filterSources(channelSnapshots, targetChannelID)
 	if useRecentFailureCache {
 		sourceCooldowns := s.loadRecentSourceCooldowns(ctx, time.Now().Add(-recentCooldownWindow))
-		if len(sourceCooldowns) > 0 {
+		sourceRouteability := s.loadSourceRouteabilityCooldowns(ctx, time.Now().Add(-sourceRouteabilityWindow))
+		if len(sourceCooldowns) > 0 || len(sourceRouteability) > 0 {
 			filteredSources := make([]RebalanceChannel, 0, len(sources))
 			now := time.Now()
 			for _, source := range sources {
-				if shouldCooldownRecentFailures(sourceCooldowns[source.ChannelID], sourceCooldownMinAttempts, sourceCooldownMaxSuccess, now) {
+				if shouldCooldownRecentFailures(sourceCooldowns[source.ChannelID], sourceCooldownMinAttempts, sourceCooldownMaxSuccess, now) ||
+					shouldQuarantineBroadSourceFailures(sourceRouteability[source.ChannelID], now) {
 					continue
 				}
 				filteredSources = append(filteredSources, source)
@@ -8935,6 +8968,67 @@ group by source_channel_id
 			stat.LastSuccessAt = lastSuccess.Time
 		}
 		stats[uint64(channelID)] = stat
+	}
+	return stats
+}
+
+func (s *RebalanceService) loadSourceRouteabilityCooldowns(ctx context.Context, since time.Time) map[uint64]recentCooldownStat {
+	stats := map[uint64]recentCooldownStat{}
+	if s == nil || s.db == nil {
+		return stats
+	}
+	rows, err := s.db.Query(ctx, `
+with events as (
+  select a.source_channel_id, j.target_channel_id, a.status,
+    coalesce(a.finished_at, a.started_at) as occurred_at
+  from rebalance_attempts a
+  join rebalance_jobs j on j.id=a.job_id
+  where coalesce(a.finished_at, a.started_at) >= $1
+),
+last_success as (
+  select source_channel_id, max(occurred_at) as last_success_at
+  from events where status='succeeded' group by source_channel_id
+),
+pressure as (
+  select e.*, ls.last_success_at from events e
+  left join last_success ls using (source_channel_id)
+  where ls.last_success_at is null or e.occurred_at > ls.last_success_at
+)
+select source_channel_id,
+  count(*) as attempts,
+  coalesce(sum(case when status='succeeded' then 1 else 0 end), 0) as successes,
+  coalesce(sum(case when status<>'succeeded' then 1 else 0 end), 0) as failures,
+  count(distinct target_channel_id) as distinct_targets,
+  max(occurred_at) as last_attempt_at,
+  max(case when status<>'succeeded' then occurred_at else null end) as last_failure_at,
+  max(last_success_at) as last_success_at
+from pressure group by source_channel_id
+`, since)
+	if err != nil {
+		return stats
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var channelID int64
+		var stat recentCooldownStat
+		var lastAttempt, lastFailure, lastSuccess pgtype.Timestamptz
+		if err := rows.Scan(&channelID, &stat.Attempts, &stat.Successes, &stat.Failures, &stat.DistinctTargets, &lastAttempt, &lastFailure, &lastSuccess); err != nil {
+			return stats
+		}
+		if channelID <= 0 {
+			continue
+		}
+		stat.ChannelID = uint64(channelID)
+		if lastAttempt.Valid {
+			stat.LastAttemptAt = lastAttempt.Time
+		}
+		if lastFailure.Valid {
+			stat.LastFailureAt = lastFailure.Time
+		}
+		if lastSuccess.Valid {
+			stat.LastSuccessAt = lastSuccess.Time
+		}
+		stats[stat.ChannelID] = stat
 	}
 	return stats
 }
@@ -12006,6 +12100,39 @@ func applyRefillTargetIntents(candidates []rebalanceTarget, intents map[uint64][
 		applied++
 	}
 	return applied
+}
+
+func captureRebalanceTargetScores(candidates []rebalanceTarget) map[uint64]int64 {
+	scores := make(map[uint64]int64, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.CooldownProbe || candidate.Channel.ChannelID == 0 {
+			continue
+		}
+		scores[candidate.Channel.ChannelID] = candidate.Score
+	}
+	return scores
+}
+
+// AutoFee settling protects the system from reacting twice to the same fee
+// movement. An explicit, admitted refill intent describes a distinct liquidity
+// need, so settling may neutralize its boost but must not invert it into a score
+// below the pre-settling baseline.
+func preserveRefillIntentPriority(candidates []rebalanceTarget, baselines map[uint64]int64) int {
+	restored := 0
+	for i := range candidates {
+		candidate := &candidates[i]
+		if !candidate.IntentApplied || candidate.AutomationIntent == nil {
+			continue
+		}
+		baseline, ok := baselines[candidate.Channel.ChannelID]
+		if !ok || candidate.Score >= baseline {
+			continue
+		}
+		candidate.Score = baseline
+		candidate.IntentScoreAfter = baseline
+		restored++
+	}
+	return restored
 }
 
 func (s *RebalanceService) recordRebalanceIntentEffects(ctx context.Context, plan rebalanceAutoScanCandidatePlan, cfg RebalanceConfig, scanAt time.Time, decisionPath string, decisions []RebalanceSovereignDecision) {

--- a/lightningos-light/internal/server/rebalance_service_test.go
+++ b/lightningos-light/internal/server/rebalance_service_test.go
@@ -19,6 +19,55 @@ func ptrBool(v bool) *bool    { return &v }
 func ptrFloat64(v float64) *float64 {
 	return &v
 }
+
+func TestRefillIntentPrioritySurvivesAutofeeSettling(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	candidates := []rebalanceTarget{{Channel: RebalanceChannel{ChannelID: 42}, Score: 100}}
+	baseline := captureRebalanceTargetScores(candidates)
+	if got := applyAutofeeSettlingPenalty(candidates, map[uint64]time.Time{42: now}, RebalanceConfig{
+		AutofeeSettlingWindowSec: 3600, AutofeeSettlingMultiplier: .75,
+	}, now); got != 1 || candidates[0].Score != 75 {
+		t.Fatalf("expected settling score 75, got count=%d score=%d", got, candidates[0].Score)
+	}
+	intent := AutomationIntent{ChannelID: 42, Kind: automationIntentKindRefillTarget, Confidence: 1}
+	applyRefillTargetIntents(candidates, map[uint64][]AutomationIntent{42: {intent}}, AutomationIntentConfig{
+		Mode: automationIntentModeEnforce, RefillScoreMultiplier: 1.2, MinConfidence: .8,
+	}, rebalanceProfileBalanced)
+	if got := preserveRefillIntentPriority(candidates, baseline); got != 1 || candidates[0].Score != 100 || candidates[0].IntentScoreAfter != 100 {
+		t.Fatalf("refill intent was inverted by settling: restored=%d candidate=%+v", got, candidates[0])
+	}
+}
+
+func TestSortRebalanceTargetsGivesEnforcedIntentOperationalPriority(t *testing.T) {
+	candidates := []rebalanceTarget{
+		{Channel: RebalanceChannel{ChannelID: 1}, Score: 100},
+		{Channel: RebalanceChannel{ChannelID: 2}, Score: 80, IntentApplied: true},
+	}
+	sortRebalanceTargets(candidates, 100, true, 30)
+	if candidates[0].Channel.ChannelID != 2 {
+		t.Fatalf("expected intent-bearing target first, got order=%d,%d", candidates[0].Channel.ChannelID, candidates[1].Channel.ChannelID)
+	}
+}
+
+func TestBroadSourceFailureQuarantineRequiresMultipleTargetsAndRecovers(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	stat := recentCooldownStat{
+		Attempts: 12, Failures: 12, DistinctTargets: 4,
+		LastAttemptAt: now.Add(-time.Hour), LastFailureAt: now.Add(-time.Hour),
+	}
+	if !shouldQuarantineBroadSourceFailures(stat, now) {
+		t.Fatal("expected broadly failing source to enter routeability quarantine")
+	}
+	stat.DistinctTargets = 1
+	if shouldQuarantineBroadSourceFailures(stat, now) {
+		t.Fatal("single-target failures belong to pair learning, not global source quarantine")
+	}
+	stat.DistinctTargets = 4
+	stat.LastFailureAt = now.Add(-sourceRouteabilityTTL - time.Minute)
+	if shouldQuarantineBroadSourceFailures(stat, now) {
+		t.Fatal("source must receive a recovery probe after quarantine expires")
+	}
+}
 func ptrString(v string) *string { return &v }
 
 func TestBuildOperatorRebalancePreviewDefaultsAndOverrides(t *testing.T) {

--- a/lightningos-light/ui/src/i18n/en.json
+++ b/lightningos-light/ui/src/i18n/en.json
@@ -2217,6 +2217,7 @@
       "lightning": "Lightning",
       "onchain": "On-chain",
       "rebalance": "Rebalance",
+      "rebalance-sources": "Rebalance sources",
       "security": "Security"
     },
     "liveUpdatesUnavailable": "Live updates unavailable.",
@@ -5597,9 +5598,14 @@
       "inspect": "View details",
       "constraintsTitle": "Effective constraints",
       "blocked": "Blocked",
+      "automationReady": "Autopilot ready: the live Rebalance target is eligible and in automation scope.",
+      "automationAdvisory": "Strategic refill recommendation; Autopilot cannot act on it right now.",
+      "refillTarget": "Live deficit: {{amount}} to reach {{pct}} outbound",
+      "activeIntent": "Automation Intent is actively prioritizing this target.",
       "reviewDue": "Manual review scheduled for {{value}}. The channel will not be released automatically.",
       "actions": {
         "refill": "Refill",
+        "recycle_source": "Recycle source liquidity",
         "reprice": "Review fees",
         "expand": "Expand",
         "maintain": "Maintain",
@@ -5610,6 +5616,7 @@
       },
       "actionHints": {
         "refill": "Productive channels that are short on local liquidity.",
+        "recycle_source": "Source reservoirs with useful assisted flow but too much idle local liquidity. Reuse them before considering capital rotation.",
         "reprice": "Channels whose current recommendation calls for fee positioning or AutoFee bound review.",
         "expand": "Efficient channels that may justify additional capacity.",
         "maintain": "Healthy channels with no urgent operational action.",
@@ -5620,6 +5627,7 @@
       },
       "primaryActions": {
         "manual_rebalance": "Open Rebalance Center",
+        "review_source_liquidity": "Review as Rebalance source",
         "review_fees": "Open Fee Center",
         "review_expansion": "Review in Lightning Ops",
         "prepare_coop_close": "Prepare close"
@@ -5629,7 +5637,11 @@
         "observation_30d": "30-day observation is incomplete",
         "magma_active": "Active Magma commitment",
         "magma_state_unavailable": "Magma state unavailable",
-        "parked": "Channel is Parked"
+        "parked": "Channel is Parked",
+        "rebalance_state_unavailable": "Live Rebalance state unavailable",
+        "rebalance_not_automated": "Channel is outside the automatic Rebalance scope",
+        "target_satisfied": "Live target is already satisfied",
+        "rebalance_target_ineligible": "Current Rebalance economic or liquidity rules make the target ineligible"
       }
     },
     "states": {
@@ -5781,6 +5793,7 @@
       "no_economic_movement_30d": "No economic movement in 30 days",
       "rebalance_only_30d": "Only 30d movement was rebalance",
       "assisted_revenue_support": "Channel is relevant as a forward entry path",
+      "source_liquidity_underused": "Useful source role, but local capital turnover is low",
       "capital_efficiency_high": "High capital efficiency",
       "capital_efficiency_low": "Low capital efficiency"
     },
@@ -5798,6 +5811,7 @@
       "observe_30d_before_close": "Observe until weakness persists for 30 days before closing",
       "review_fee_positioning": "Review fee positioning and liquidity shape",
       "review_inbound_assist_role": "Review the channel's role as a forward entry path",
+      "recycle_source_liquidity": "Prioritize recycling this channel's local liquidity as a Rebalance source",
       "keep_channel_under_observation": "Keep channel under observation",
       "stop_nonessential_rebalances": "Stop non-essential rebalances",
       "reduce_rebalance_dependence": "Reduce rebalance dependence on this channel",
@@ -5930,7 +5944,7 @@
       "enforce": "Applies admitted intents after each consumer's own eligibility and safety gates."
     },
     "autofeeToRebalance": "AutoFee → Rebalance",
-    "autofeeToRebalanceHint": "Drained-channel evidence can prioritize an eligible refill target in Rules Auto and Autopilot.",
+    "autofeeToRebalanceHint": "A live outbound deficit with low/drained or productive-channel evidence can prioritize an eligible refill target in Rules Auto and Autopilot.",
     "rebalanceToAutofee": "Rebalance → AutoFee",
     "rebalanceToAutofeeHint": "A successful refill can protect its cost basis from an immediate downward fee move.",
     "profile": "User profile",
@@ -5976,7 +5990,7 @@
     "intentHelp": {
       "title": "What is happening with {{alias}}?",
       "kinds": {
-        "refill_target": "AutoFee detected that this channel is drained and published a request for Rebalance to consider replenishing its outbound liquidity.",
+        "refill_target": "AutoFee confirmed a live outbound deficit and published a request for Rebalance to consider replenishing this channel.",
         "protect_fee_floor": "Rebalance calculated a temporary economic floor from the peer policy, known actual cost, and effective econ ratio. AutoFee can raise a fee below the floor or prevent a reduction through it."
       },
       "refillInfluenced": "In the latest known evaluation, the Rebalance score changed from {{before}} to {{after}} sats. {{reason}}",

--- a/lightningos-light/ui/src/i18n/pt-BR.json
+++ b/lightningos-light/ui/src/i18n/pt-BR.json
@@ -2217,6 +2217,7 @@
       "lightning": "Lightning",
       "onchain": "On-chain",
       "rebalance": "Rebalance",
+      "rebalance-sources": "Sources do Rebalance",
       "security": "Segurança"
     },
     "liveUpdatesUnavailable": "Atualizações ao vivo indisponíveis.",
@@ -5597,9 +5598,14 @@
       "inspect": "Ver detalhes",
       "constraintsTitle": "Restrições efetivas",
       "blocked": "Bloqueado",
+      "automationReady": "Autopilot pronto: o alvo atual do Rebalance está elegível e dentro do escopo automático.",
+      "automationAdvisory": "Recomendação estratégica de refill; o Autopilot não pode executá-la neste momento.",
+      "refillTarget": "Déficit atual: {{amount}} para chegar a {{pct}} outbound",
+      "activeIntent": "O Automation Intent está priorizando ativamente este alvo.",
       "reviewDue": "Revisão manual programada para {{value}}. O canal não será liberado automaticamente.",
       "actions": {
         "refill": "Reabastecer",
+        "recycle_source": "Reciclar liquidez source",
         "reprice": "Revisar fees",
         "expand": "Expandir",
         "maintain": "Manter",
@@ -5610,6 +5616,7 @@
       },
       "actionHints": {
         "refill": "Canais produtivos com falta de liquidez local.",
+        "recycle_source": "Reservatórios source com fluxo assistido útil, mas liquidez local ociosa em excesso. Reutilize antes de considerar rotação de capital.",
         "reprice": "Canais cuja recomendação atual pede revisão de posicionamento ou limites do AutoFee.",
         "expand": "Canais eficientes que podem justificar mais capacidade.",
         "maintain": "Canais saudáveis sem ação operacional urgente.",
@@ -5620,6 +5627,7 @@
       },
       "primaryActions": {
         "manual_rebalance": "Abrir Rebalance Center",
+        "review_source_liquidity": "Revisar como source no Rebalance",
         "review_fees": "Abrir Fee Center",
         "review_expansion": "Revisar no Lightning Ops",
         "prepare_coop_close": "Preparar fechamento"
@@ -5629,7 +5637,11 @@
         "observation_30d": "Observação de 30 dias incompleta",
         "magma_active": "Compromisso Magma ativo",
         "magma_state_unavailable": "Estado do Magma indisponível",
-        "parked": "Canal em Parked"
+        "parked": "Canal em Parked",
+        "rebalance_state_unavailable": "Estado atual do Rebalance indisponível",
+        "rebalance_not_automated": "Canal fora do escopo automático do Rebalance",
+        "target_satisfied": "O alvo atual já está satisfeito",
+        "rebalance_target_ineligible": "As regras econômicas ou de liquidez atuais tornam o target inelegível"
       }
     },
     "states": {
@@ -5781,6 +5793,7 @@
       "no_economic_movement_30d": "Sem movimento econômico em 30 dias",
       "rebalance_only_30d": "Único movimento em 30 dias foi rebalance",
       "assisted_revenue_support": "Canal relevante como entrada de forwards",
+      "source_liquidity_underused": "Papel source útil, mas com baixo giro do capital local",
       "capital_efficiency_high": "Boa eficiência de capital",
       "capital_efficiency_low": "Eficiência de capital baixa"
     },
@@ -5798,6 +5811,7 @@
       "observe_30d_before_close": "Observar até a fraqueza persistir por 30 dias antes de fechar",
       "review_fee_positioning": "Revisar posicionamento de fee e liquidez",
       "review_inbound_assist_role": "Validar papel do canal como entrada de forwards",
+      "recycle_source_liquidity": "Priorizar a reciclagem da liquidez local deste canal como source de Rebalance",
       "keep_channel_under_observation": "Manter canal sob observação",
       "stop_nonessential_rebalances": "Parar rebalances não essenciais",
       "reduce_rebalance_dependence": "Reduzir dependência de rebalance neste canal",
@@ -5930,7 +5944,7 @@
       "enforce": "Aplica intents admitidos depois dos gates de elegibilidade e segurança do consumidor."
     },
     "autofeeToRebalance": "AutoFee → Rebalance",
-    "autofeeToRebalanceHint": "Evidência de canal drenado pode priorizar um alvo elegível de refill no Rules Auto e no Autopilot.",
+    "autofeeToRebalanceHint": "Um déficit outbound atual, com evidência de liquidez baixa/drenada ou canal produtivo, pode priorizar um target elegível no Rules Auto e no Autopilot.",
     "rebalanceToAutofee": "Rebalance → AutoFee",
     "rebalanceToAutofeeHint": "Um refill bem-sucedido pode proteger sua base de custo contra uma redução imediata da fee.",
     "profile": "Perfil do usuário",
@@ -5976,7 +5990,7 @@
     "intentHelp": {
       "title": "O que está acontecendo com {{alias}}?",
       "kinds": {
-        "refill_target": "O AutoFee detectou que este canal está drenado e publicou um pedido para o Rebalance considerar a reposição da liquidez outbound.",
+        "refill_target": "O AutoFee confirmou um déficit outbound atual e publicou um pedido para o Rebalance considerar a reposição deste canal.",
         "protect_fee_floor": "O Rebalance calculou um piso econômico temporário usando a policy do peer, o custo real conhecido e o econ ratio efetivo. O AutoFee pode elevar uma fee abaixo do piso ou impedir que ela seja reduzida através dele."
       },
       "refillInfluenced": "Na avaliação mais recente conhecida, o score do Rebalance mudou de {{before}} para {{after}} sats. {{reason}}",

--- a/lightningos-light/ui/src/pages/channel-ranking/ChannelCapitalPlanPanel.tsx
+++ b/lightningos-light/ui/src/pages/channel-ranking/ChannelCapitalPlanPanel.tsx
@@ -15,6 +15,7 @@ type Props = {
 const actionOrder: ChannelCapitalPlanItem['action'][] = [
   'rotate',
   'refill',
+  'recycle_source',
   'reprice',
   'expand',
   'maintain',
@@ -29,6 +30,8 @@ const actionClass = (action: ChannelCapitalPlanItem['action']) => {
       return 'border-rose-400/35 bg-rose-500/10 text-rose-100'
     case 'refill':
       return 'border-cyan-400/35 bg-cyan-500/10 text-cyan-100'
+    case 'recycle_source':
+      return 'border-teal-400/35 bg-teal-500/10 text-teal-100'
     case 'reprice':
       return 'border-violet-400/35 bg-violet-500/10 text-violet-100'
     case 'expand':
@@ -135,10 +138,30 @@ export default function ChannelCapitalPlanPanel({ items, summary, magmaStateKnow
                     </div>
                   )}
 
+                  {planItem.action === 'refill' && (
+                    <div className={`mt-3 rounded-xl border px-3 py-2 text-xs ${planItem.automation_ready ? 'border-emerald-300/25 bg-emerald-950/20 text-emerald-100/85' : 'border-amber-300/25 bg-amber-950/20 text-amber-100/85'}`}>
+                      <div>{t(planItem.automation_ready ? 'channelRanking.plan.automationReady' : 'channelRanking.plan.automationAdvisory')}</div>
+                      {(planItem.target_amount_sat || 0) > 0 && (
+                        <div className="mt-1 opacity-75">{t('channelRanking.plan.refillTarget', { amount: format.sats(planItem.target_amount_sat), pct: format.pct(planItem.target_outbound_pct) })}</div>
+                      )}
+                      {planItem.active_refill_intent && <div className="mt-1 opacity-75">{t('channelRanking.plan.activeIntent')}</div>}
+                    </div>
+                  )}
+
                   {(planItem.blockers || []).length > 0 && (
                     <div className="mt-3 flex flex-wrap gap-2">
                       {planItem.blockers!.map((blocker) => (
                         <span key={blocker} className="rounded-full border border-current/20 px-2 py-0.5 text-[11px] opacity-80">
+                          {t(`channelRanking.plan.blockers.${blocker}` as any, { defaultValue: blocker })}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {(planItem.automation_blockers || []).length > 0 && (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {planItem.automation_blockers!.map((blocker) => (
+                        <span key={blocker} className="rounded-full border border-amber-200/20 px-2 py-0.5 text-[11px] text-amber-100/80">
                           {t(`channelRanking.plan.blockers.${blocker}` as any, { defaultValue: blocker })}
                         </span>
                       ))}

--- a/lightningos-light/ui/src/pages/channel-ranking/links.ts
+++ b/lightningos-light/ui/src/pages/channel-ranking/links.ts
@@ -22,6 +22,8 @@ export const moduleHash = (item: ChannelRankingItem, targetModule?: string) => {
   switch (String(targetModule || '').trim()) {
     case 'rebalance':
       return paramsHash('rebalance-center', { channel_point: item.channel_point })
+    case 'rebalance-sources':
+      return paramsHash('rebalance-center', {})
     case 'autofee':
       return paramsHash('fee-center', { channel_point: item.channel_point })
     case 'close-manager':

--- a/lightningos-light/ui/src/pages/channel-ranking/types.ts
+++ b/lightningos-light/ui/src/pages/channel-ranking/types.ts
@@ -140,7 +140,7 @@ export type ChannelCapitalPlanAction = {
 
 export type ChannelCapitalPlanItem = {
   channel: ChannelRankingItem
-  action: 'refill' | 'reprice' | 'expand' | 'maintain' | 'observe' | 'rotate' | 'parked' | 'protected'
+  action: 'refill' | 'recycle_source' | 'reprice' | 'expand' | 'maintain' | 'observe' | 'rotate' | 'parked' | 'protected'
   priority: number
   eligible: boolean
   blockers?: string[]
@@ -149,6 +149,11 @@ export type ChannelCapitalPlanItem = {
   recoverable_local_sat: number
   primary_action?: ChannelCapitalPlanAction
   magma_commitment?: MagmaChannelCommitment
+  automation_ready: boolean
+  automation_blockers?: string[]
+  target_outbound_pct?: number
+  target_amount_sat?: number
+  active_refill_intent?: boolean
 }
 
 export type ChannelCapitalPlanSummary = {


### PR DESCRIPTION
## Summary

- make Channel Ranking capacity- and role-aware for mature source reservoirs: assisted revenue remains valuable, while low weekly turnover of large local balances receives a bounded score penalty
- add a `recycle_source` Capital Plan recommendation that is explicitly advisory and never closes channels automatically
- join Capital Plan refill recommendations with live Rebalance targets and Automation Intent state, exposing whether each recommendation is currently executable and why it may be blocked
- publish `refill_target` intents only for a live eligible deficit, while extending coverage to low-liquidity and productive-under-target channels
- give enforced refill intents an operational priority lane without bypassing ROI, profit, budget, cooldown, busy-channel, or source gates; AutoFee settling can neutralize but no longer invert the intent
- quarantine sources that fail broadly across at least four targets, with an automatic recovery opportunity after six hours
- preserve adaptive exploration behavior when the normal candidate pool is scarce

## Validation

- `go test ./...`
- `npm.cmd run build`
- i18n JSON parse validation for English and Portuguese
- `git diff --check`

## Known unrelated check

- `go vet ./...` still reports the pre-existing unreachable code at `internal/privileged/apps.go:1242`; this PR does not touch that file.