### PR TITLE
0.5.25-Beta: Magma - liberar o saldo reservado quando o canal já foi aberto (issue #131)

### DIFF
--- a/lightningos-light/internal/server/magma_buyer_reach_test.go
+++ b/lightningos-light/internal/server/magma_buyer_reach_test.go
@@ -50,6 +50,9 @@ func (f *magmaReachLND) PreviewOpenChannel(context.Context, int64, int64, int64)
 func (f *magmaReachLND) ListPendingChannels(context.Context) ([]lndclient.PendingChannelInfo, error) {
 	return nil, nil
 }
+func (f *magmaReachLND) ListLeases(context.Context) (map[string]lndclient.LeaseInfo, error) {
+	return nil, nil
+}
 func (f *magmaReachLND) ListChannels(context.Context) ([]lndclient.ChannelInfo, error) {
 	return nil, nil
 }

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -55,6 +55,7 @@ type magmaLND interface {
 	ListPendingChannels(ctx context.Context) ([]lndclient.PendingChannelInfo, error)
 	ListChannels(ctx context.Context) ([]lndclient.ChannelInfo, error)
 	ListPeers(ctx context.Context) ([]lndclient.PeerInfo, error)
+	ListLeases(ctx context.Context) (map[string]lndclient.LeaseInfo, error)
 }
 
 // magmaOnchainTxLister is split out because only the P&L needs it; keeping it
@@ -231,6 +232,29 @@ where local_state = any($1) and not (magma_status = any($2))
 		capacity.AvailableSat = 0
 	}
 	return capacity, nil
+}
+
+// lockedFundsNote describes funds held by a lease, or nothing at all. It never
+// fails the preview: this is an explanation, and an explanation that cannot be
+// fetched simply is not appended.
+func (s *MagmaService) lockedFundsNote(ctx context.Context) string {
+	if s.lnd == nil {
+		return ""
+	}
+	leases, err := s.lnd.ListLeases(ctx)
+	if err != nil || len(leases) == 0 {
+		return ""
+	}
+	var locked int64
+	for _, lease := range leases {
+		locked += int64(lease.Value)
+	}
+	if locked <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		" (%s sat is locked by %d leased utxo(s) and cannot be spent until the lease expires)",
+		formatInt(locked), len(leases))
 }
 
 // ensureCapacityFor refuses an order the wallet cannot honour once every already
@@ -462,9 +486,16 @@ func (s *MagmaService) OpenChannelPreview(ctx context.Context, orderID string, s
 		preview.SpendableSat = estimate.SpendableSat
 		preview.EnoughFunds = estimate.EnoughFunds
 		if !estimate.EnoughFunds {
+			// Say where the rest of the money is. LND's ListUnspent omits leased
+			// outputs, so a wallet holding 1.7M can be reported as holding 209k
+			// with nothing on screen to explain the gap - which is exactly how
+			// issue #131 was read as a phantom balance bug. The lease is real and
+			// the funds are genuinely unspendable until it lapses; the failure was
+			// only ever in not saying so.
 			preview.Blockers = append(preview.Blockers, fmt.Sprintf(
-				"not enough confirmed on-chain balance: need %s sat, have %s sat",
-				formatInt(estimate.TotalDebitSat), formatInt(estimate.SpendableSat)))
+				"not enough confirmed on-chain balance: need %s sat, have %s sat%s",
+				formatInt(estimate.TotalDebitSat), formatInt(estimate.SpendableSat),
+				s.lockedFundsNote(ctx)))
 		}
 	} else {
 		preview.Warnings = append(preview.Warnings, fmt.Sprintf("could not estimate the on-chain cost: %v", err))
@@ -991,10 +1022,106 @@ where local_state=$1 and magma_status='WAITING_FOR_CHANNEL_OPEN'
 	}
 }
 
+// magmaStatusMeansChannelIsOut reports the statuses where Amboss has seen the
+// funding transaction. Past that point the sale is no longer waiting on us to
+// spend anything, so it must stop reserving wallet balance.
+//
+// Deliberately not the terminal list: these are successes in flight, and a
+// successful order is exactly the one the terminal list is built to keep. The
+// question here is different - not "is this order over" but "has the money
+// already left".
+func magmaStatusMeansChannelIsOut(status string) bool {
+	switch status {
+	case "SELLER_SENT_TRANSACTION", "SELLER_OPENED_CHANNEL", "VALID_CHANNEL_OPENING",
+		"WAITING_FOR_ON_CHAIN_CONFIRMATION", "ON_CHAIN_CONFIRMATION",
+		"CHANNEL_MONITORING_FINISHED":
+		return true
+	}
+	return false
+}
+
+// adoptOrdersOpenedElsewhere finishes an order whose channel was opened outside
+// this app.
+//
+// Reported as issue #131: auto-open declined, the operator opened the channel by
+// hand, Amboss saw it and moved the order to VALID_CHANNEL_OPENING - and the
+// local state stayed `accepted`. `accepted` is one of the states that reserves
+// wallet balance against a channel still owed, so the app went on holding
+// 500,000 sat for a channel that was already open, and said so on screen. The
+// only way out was editing the database by hand.
+//
+// The channel is looked up on the node rather than assumed from the status:
+// Amboss can only tell us a channel exists, not which one, and writing a channel
+// point we did not verify is how an order ends up pointing at the wrong funding
+// transaction.
+func (s *MagmaService) adoptOrdersOpenedElsewhere(ctx context.Context) {
+	rows, err := s.db.Query(ctx, `
+select order_id, magma_status, buyer_pubkey, size_sat
+from magma_orders
+where local_state = $1 and not (magma_status = any($2))
+`, magmaStateAccepted, magmaTerminalStatusList())
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Printf("magma: opened-elsewhere query failed: %v", err)
+		}
+		return
+	}
+	type candidate struct {
+		orderID     string
+		magmaStatus string
+		buyerPubkey string
+		sizeSat     int64
+	}
+	candidates := make([]candidate, 0, 4)
+	for rows.Next() {
+		var item candidate
+		if err := rows.Scan(&item.orderID, &item.magmaStatus, &item.buyerPubkey, &item.sizeSat); err == nil {
+			candidates = append(candidates, item)
+		}
+	}
+	rows.Close()
+
+	for _, item := range candidates {
+		if !magmaStatusMeansChannelIsOut(item.magmaStatus) {
+			continue
+		}
+		point, err := s.existingChannelFor(ctx, MagmaOrder{
+			BuyerPubkey: item.buyerPubkey,
+			SizeSat:     item.sizeSat,
+		})
+		if err != nil || point == "" {
+			// Amboss says the channel is out and the node cannot show it. Say so
+			// rather than guessing: the balance stays reserved, which is the safe
+			// direction, and the operator has something to act on.
+			s.appendEvent(ctx, item.orderID, "needs_attention", "warning", fmt.Sprintf(
+				"Amboss reports %s but no channel of %s sat to %s is on this node; "+
+					"the order still reserves that balance until it can be matched",
+				item.magmaStatus, formatInt(item.sizeSat), magmaShortPubkey(item.buyerPubkey)), nil)
+			continue
+		}
+		if _, err := s.db.Exec(ctx, `
+update magma_orders
+set local_state=$2, channel_point=$3, funding_txid=$4, last_error='', updated_at=now()
+where order_id=$1
+`, item.orderID, magmaStateConfirmed, point, magmaTxidFromPoint(point)); err != nil {
+			if s.logger != nil {
+				s.logger.Printf("magma: could not finish order %s opened elsewhere: %v", item.orderID, err)
+			}
+			continue
+		}
+		s.appendEvent(ctx, item.orderID, "adopted", "info", fmt.Sprintf(
+			"Channel %s was opened outside this app and Amboss has seen it; "+
+				"the order no longer reserves balance", point), nil)
+	}
+}
+
 func (s *MagmaService) reconcileExecution(ctx context.Context, token string) {
 	// Runs first: an order approved elsewhere has to be owned before any of the
 	// resume paths below can see it.
 	s.adoptOrdersAcceptedElsewhere(ctx)
+	// And the mirror of it: an order this app accepted whose channel was then
+	// opened by hand. Runs before the resume paths for the same reason.
+	s.adoptOrdersOpenedElsewhere(ctx)
 
 	rows, err := s.db.Query(ctx, `
 select order_id, local_state, funding_txid, channel_point, buyer_pubkey, size_sat

--- a/lightningos-light/internal/server/magma_external_open_test.go
+++ b/lightningos-light/internal/server/magma_external_open_test.go
@@ -1,0 +1,51 @@
+package server
+
+import "testing"
+
+// Issue #131. Order fd0a2cd0 was accepted by this app, the auto-open declined,
+// the operator opened the 500,000 sat channel by hand, and Amboss moved the
+// order to VALID_CHANNEL_OPENING. The local state stayed `accepted`, which is
+// one of the states that reserves wallet balance against a channel still owed -
+// so the app went on holding 500,000 sat for a channel that was already open,
+// and said so on screen. The only way out was an UPDATE by hand.
+func TestMagmaStatusMeansChannelIsOutCoversTheReportedCase(t *testing.T) {
+	for _, status := range []string{
+		"VALID_CHANNEL_OPENING", "SELLER_SENT_TRANSACTION", "SELLER_OPENED_CHANNEL",
+		"WAITING_FOR_ON_CHAIN_CONFIRMATION", "ON_CHAIN_CONFIRMATION",
+		"CHANNEL_MONITORING_FINISHED",
+	} {
+		if !magmaStatusMeansChannelIsOut(status) {
+			t.Fatalf("%s means the funding is already out, so the order must stop reserving", status)
+		}
+	}
+}
+
+// Before the funding exists the reservation is doing its job: the money is owed
+// and has not left. Releasing it here would let two orders spend the same coins.
+func TestMagmaStatusBeforeTheChannelKeepsTheReservation(t *testing.T) {
+	for _, status := range []string{
+		"WAITING_FOR_SELLER_APPROVAL", "WAITING_FOR_BUYER_PAYMENT", "WAITING_FOR_CHANNEL_OPEN", "",
+	} {
+		if magmaStatusMeansChannelIsOut(status) {
+			t.Fatalf("%s still owes a channel, so the balance stays reserved", status)
+		}
+	}
+}
+
+// The terminal list answers "is this order over"; this answers "has the money
+// left". They are different questions, and a successful order in flight belongs
+// to the second and not the first - which is why the terminal list could not be
+// reused here.
+func TestMagmaChannelIsOutIsNotTheTerminalList(t *testing.T) {
+	if magmaTerminalStatuses["VALID_CHANNEL_OPENING"] {
+		t.Fatal("a successful opening must not be treated as a closed order")
+	}
+	if !magmaStatusMeansChannelIsOut("VALID_CHANNEL_OPENING") {
+		t.Fatal("but its funding has left the wallet, so it must release the reservation")
+	}
+	for status := range magmaTerminalStatuses {
+		if status == "INVALID_CHANNEL_OPENING" && magmaStatusMeansChannelIsOut(status) {
+			t.Fatal("an invalid opening is a failure, not a funded channel")
+		}
+	}
+}


### PR DESCRIPTION
Corrige os dois sintomas relatados na issue #131.

## Sintoma 2 — reserva fantasma de 500.000 sats

Uma ordem aceita por este app teve o auto-open recusado, o operador abriu o canal à mão, e a Amboss avançou para `VALID_CHANNEL_OPENING`. O `local_state` ficou em `accepted` — um dos estados que reservam saldo contra um canal ainda devido — então o app seguiu segurando 500.000 sats por um canal **já aberto**, e dizia isso na tela. A única saída era `UPDATE` no banco.

O reconcile agora conclui essas ordens. É o espelho do caso já coberto: um adota ordem *aprovada* fora do app, este adota ordem *aberta* fora dele.

**A regra é uma pergunta nova, não a existente.** A lista de status terminais responde *"esta ordem acabou?"*, e uma abertura bem-sucedida é justamente o que ela existe para **manter**. O que importa aqui é outra coisa: *"o dinheiro já saiu?"*. Por isso `VALID_CHANNEL_OPENING` libera a reserva continuando não-terminal, e há teste cruzando as duas listas para que nenhuma escorregue para o trabalho da outra.

**O canal é procurado no nó**, por comprador e capacidade, em vez de deduzido do status. A Amboss diz que um canal existe, não *qual* — e gravar um channel point não verificado é como uma ordem acaba apontando para a transação errada. Quando a Amboss reporta o canal e o nó não consegue mostrá-lo, a ordem **mantém** a reserva (direção segura) e emite um evento, em vez de adivinhar.

## Sintoma 1 — saldo insuficiente aparentemente falso

O bloqueio dizia `need 500,306 sat, have 209,289 sat` com ~1.709.289 sats confirmados na carteira.

Investiguei e o comportamento está correto: a mensagem vem do `PreviewOpenChannel` do LND, que usa `ListUnspent` — e o `ListUnspent` **omite outputs sob lease**. O UTXO grande estava travado e era, de fato, ingastável naquele momento. A abertura manual funcionou depois porque o lease expirou.

Ou seja: não havia saldo fantasma. **A falha estava em não dizer isso.** O operador via 1,7M na carteira e era informado de 209k, sem nada na tela explicando a diferença — e leu como bug, com razão.

O bloqueio agora diz onde o dinheiro está:

> `not enough confirmed on-chain balance: need 500,306 sat, have 209,289 sat (1,499,834 sat is locked by 1 leased utxo(s) and cannot be spent until the lease expires)`

Buscar essa explicação nunca pode derrubar o preview: se a consulta falhar, a mensagem sai sem o complemento.

**Não mudei o comportamento do preview.** Contar UTXOs sob lease como gastáveis produziria um preview otimista e uma abertura que falha — pior que o problema original.

## Testes

`internal/server/magma_external_open_test.go`: os seis status que significam funding no ar liberam a reserva; os anteriores à abertura a mantêm; e as duas listas são testadas uma contra a outra.

`go test ./...` e `go vet ./internal/server/` verdes.

## Nota

A correção manual que o relator aplicou (`accepted → confirmed` e preencher `funding_txid` a partir do `channel_point`) é exatamente o que este código passa a fazer sozinho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)