### PR TITLE
0.5.25-Beta: Magma - insistir na abertura de canal já pago até o prazo da Amboss

### DIFF
--- a/lightningos-light/internal/server/magma_amboss.go
+++ b/lightningos-light/internal/server/magma_amboss.go
@@ -550,6 +550,17 @@ const (
 	magmaMarketAcceptOrderMutation = `mutation AcceptOrder($input: SellerAcceptOrdersInput!) {
   market { order { seller { accept(input: $input) { success } } } }
 }`
+	// The deadline lives only on the replacement endpoint. OrderType.timeout on
+	// api.amboss.space is an empty string on every order, including live ones,
+	// while MarketOrder.timeout carries an absolute UTC instant - and goes null
+	// once the order settles. Amboss's own UI counts down against it.
+	//
+	// This is fetched separately rather than by migrating the whole order query,
+	// because the replacement order type drops fields we still use and nothing
+	// about a deadline requires paying that cost today.
+	magmaMarketOrderTimeoutsQuery = `query SellerOrderTimeouts($page: PageInput!) {
+  user { market { orders { sales(page: $page) { total list { id timeout } } } } }
+}`
 	magmaMarketRejectOrderMutation = `mutation RejectOrder($input: SellerRejectOrdersInput!) {
   market { order { seller { reject(input: $input) { success } } } }
 }`
@@ -651,6 +662,58 @@ func (c *magmaAmbossClient) AcceptOrder(ctx context.Context, token, orderID, pay
 			return magmaMutationSucceeded(out.SellerAcceptOrder), err
 		},
 		refused)
+}
+
+// magmaOrderTimeoutPageSize follows the example in Amboss's own migration guide.
+// Both PageInput fields are required - offset is Float! and omitting it is a
+// validation error, not a default - so both are always sent.
+const magmaOrderTimeoutPageSize = 50
+
+// OrderTimeouts returns the deadline Amboss holds for each live order.
+//
+// Orders that have settled report a null timeout and are simply absent from the
+// result: a missing entry means "no deadline to honour", never "the deadline is
+// now". Reading it the other way would abandon orders that are perfectly fine.
+func (c *magmaAmbossClient) OrderTimeouts(ctx context.Context, token string) (map[string]time.Time, error) {
+	deadlines := make(map[string]time.Time, 8)
+	for offset := 0; ; offset += magmaOrderTimeoutPageSize {
+		var result struct {
+			User struct {
+				Market struct {
+					Orders struct {
+						Sales struct {
+							Total int `json:"total"`
+							List  []struct {
+								ID      string `json:"id"`
+								Timeout string `json:"timeout"`
+							} `json:"list"`
+						} `json:"sales"`
+					} `json:"orders"`
+				} `json:"market"`
+			} `json:"user"`
+		}
+		if err := c.doMarket(ctx, token, magmaMarketOrderTimeoutsQuery, map[string]any{
+			"page": map[string]any{"limit": magmaOrderTimeoutPageSize, "offset": offset},
+		}, &result); err != nil {
+			return nil, err
+		}
+		list := result.User.Market.Orders.Sales.List
+		for _, item := range list {
+			id := strings.TrimSpace(item.ID)
+			raw := strings.TrimSpace(item.Timeout)
+			if id == "" || raw == "" {
+				continue
+			}
+			when, err := time.Parse(time.RFC3339, raw)
+			if err != nil {
+				continue
+			}
+			deadlines[id] = when.UTC()
+		}
+		if len(list) < magmaOrderTimeoutPageSize || offset+len(list) >= result.User.Market.Orders.Sales.Total {
+			return deadlines, nil
+		}
+	}
 }
 
 // RejectOrder declines an order explicitly. Letting an unwanted order lapse is

--- a/lightningos-light/internal/server/magma_buyer_deadline_test.go
+++ b/lightningos-light/internal/server/magma_buyer_deadline_test.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func magmaSaneTestPolicy() MagmaPolicy {
+	policy := defaultMagmaPolicy()
+	policy.MinRevenueSat, policy.MinPricePPM, policy.MinPricePPMPerDay = 0, 0, 0
+	policy.MinFeeRateCapPPM = 0
+	return policy
+}
+
+func magmaSaneTestOrder() magmaPolicyInputs {
+	return magmaPolicyInputs{
+		Order:            MagmaOrder{SizeSat: 1_500_000, RevenueSat: 6000, CommitmentBlocks: 4320},
+		AvailableSat:     9_000_000,
+		OnchainReachable: true,
+		SatPerVbyte:      2,
+		EstimatedFeeSat:  300,
+	}
+}
+
+// A buyer whose node is down is waited for, not refused. LND will not open a
+// channel to a peer that is not connected, so accepting while it is down
+// promises a delivery on a connection we do not have - but an unreachable buyer
+// has been observed paying in full, so it predicts nothing either. Waiting costs
+// nothing while there is window left.
+func TestMagmaUnreachableBuyerDefersRatherThanRefuses(t *testing.T) {
+	in := magmaSaneTestOrder()
+	in.BuyerUnreachable = true
+	in.PendingFor = time.Minute
+
+	d := evaluateMagmaOrder(magmaSaneTestPolicy(), in)
+	if d.Accept {
+		t.Fatal("must not accept while the peer needed to deliver is down")
+	}
+	if d.Reject {
+		t.Fatalf("must not refuse either, there is still time: %s", d.Reason)
+	}
+}
+
+// The zero value has to be the harmless one. A caller that never learned whether
+// the buyer answered must not silently stop every sale.
+func TestMagmaUnknownReachabilityDoesNotBlock(t *testing.T) {
+	if d := evaluateMagmaOrder(magmaSaneTestPolicy(), magmaSaneTestOrder()); !d.Accept {
+		t.Fatalf("an order nobody flagged must still be accepted: %s", d.Reason)
+	}
+}
+
+// Terms that can never be met are refused on their own account. Deferring them
+// for a peer would spend the window waiting on a node whose order we were never
+// going to take.
+func TestMagmaBadTermsAreRefusedEvenWithTheBuyerDown(t *testing.T) {
+	policy := magmaSaneTestPolicy()
+	policy.MaxChannelSizeSat = 1_000_000
+
+	in := magmaSaneTestOrder()
+	in.BuyerUnreachable = true
+
+	d := evaluateMagmaOrder(policy, in)
+	if !d.Reject {
+		t.Fatalf("an oversized channel is refused whatever the peer is doing: %s", d.Reason)
+	}
+}
+
+// Amboss's own deadline replaces the estimate when we have it. The grace period
+// was derived from a single order that lapsed 2h04m after creation; a published
+// instant is not a guess.
+func TestMagmaRealDeadlineDrivesTheRefusal(t *testing.T) {
+	policy := magmaSaneTestPolicy()
+	now := time.Now()
+
+	plenty := magmaSaneTestOrder()
+	plenty.BuyerUnreachable = true
+	plenty.PendingFor = 5 * time.Minute
+	far := now.Add(90 * time.Minute)
+	plenty.Deadline = &far
+	if d := evaluateMagmaOrder(policy, plenty); d.Reject {
+		t.Fatalf("with 90 minutes left the order is still worth waiting for: %s", d.Reason)
+	}
+
+	// Refusing happens with time to spare, deliberately before the deadline:
+	// refusing at it is not refusing at all, it is the lapse Amboss records.
+	closing := magmaSaneTestOrder()
+	closing.BuyerUnreachable = true
+	closing.PendingFor = 5 * time.Minute
+	near := now.Add(20 * time.Minute)
+	closing.Deadline = &near
+	d := evaluateMagmaOrder(policy, closing)
+	if !d.Reject {
+		t.Fatalf("close to the deadline the refusal must be explicit: %s", d.Reason)
+	}
+	if !strings.Contains(d.Reason, "refusing explicitly") {
+		t.Fatalf("the reason should say what it did, got %q", d.Reason)
+	}
+}
+
+// A short PendingFor with no published deadline still falls back to the observed
+// window, so nothing regresses on orders Amboss gives no instant for.
+func TestMagmaFallsBackToTheObservedWindow(t *testing.T) {
+	policy := magmaSaneTestPolicy()
+
+	fresh := magmaSaneTestOrder()
+	fresh.BuyerUnreachable = true
+	fresh.PendingFor = time.Minute
+	if d := evaluateMagmaOrder(policy, fresh); d.Reject {
+		t.Fatalf("a minute in, the order has almost all its window: %s", d.Reason)
+	}
+
+	late := magmaSaneTestOrder()
+	late.BuyerUnreachable = true
+	late.PendingFor = magmaApprovalGrace + time.Minute
+	if d := evaluateMagmaOrder(policy, late); !d.Reject {
+		t.Fatalf("past the grace period it must be refused explicitly: %s", d.Reason)
+	}
+}

--- a/lightningos-light/internal/server/magma_buyer_reach_test.go
+++ b/lightningos-light/internal/server/magma_buyer_reach_test.go
@@ -50,6 +50,9 @@ func (f *magmaReachLND) PreviewOpenChannel(context.Context, int64, int64, int64)
 func (f *magmaReachLND) ListPendingChannels(context.Context) ([]lndclient.PendingChannelInfo, error) {
 	return nil, nil
 }
+func (f *magmaReachLND) ListLeases(context.Context) (map[string]lndclient.LeaseInfo, error) {
+	return nil, nil
+}
 func (f *magmaReachLND) ListChannels(context.Context) ([]lndclient.ChannelInfo, error) {
 	return nil, nil
 }

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -77,6 +77,7 @@ type magmaExecutionRecord struct {
 	SizeSat        int64
 	RevenueSat     int64
 	MagmaStatus    string
+	PaymentStatus  string
 	LocalState     string
 	PaymentRequest string
 	InvoiceHash    string
@@ -89,13 +90,14 @@ type magmaExecutionRecord struct {
 func (s *MagmaService) execRecord(ctx context.Context, orderID string) (magmaExecutionRecord, error) {
 	var record magmaExecutionRecord
 	err := s.db.QueryRow(ctx, `
-select order_id, buyer_pubkey, size_sat, revenue_sat, magma_status, local_state,
-       invoice_payment_request, invoice_hash, funding_txid, channel_point,
+select order_id, buyer_pubkey, size_sat, revenue_sat, magma_status, payment_status,
+       local_state, invoice_payment_request, invoice_hash, funding_txid, channel_point,
        attempt_count, last_error
 from magma_orders where order_id=$1
 `, strings.TrimSpace(orderID)).Scan(
 		&record.OrderID, &record.BuyerPubkey, &record.SizeSat, &record.RevenueSat,
-		&record.MagmaStatus, &record.LocalState, &record.PaymentRequest, &record.InvoiceHash,
+		&record.MagmaStatus, &record.PaymentStatus, &record.LocalState,
+		&record.PaymentRequest, &record.InvoiceHash,
 		&record.FundingTxid, &record.ChannelPoint, &record.AttemptCount, &record.LastError,
 	)
 	if err != nil {
@@ -513,7 +515,17 @@ func (s *MagmaService) OpenChannelPreview(ctx context.Context, orderID string, s
 		}
 	}
 
-	if record.LocalState != magmaStateAccepted {
+	// `needs_attention` means an open failed, not that the debt went away. The
+	// buyer has paid and the channel is still owed, so refusing to fund it closes
+	// the only door left - which is what forced a database edit on order 8ea03637
+	// while the operator watched the deadline run.
+	//
+	// The reconciliation is what makes this safe: it asks the node first and puts
+	// the order back in line only when nothing was funded, so an open that
+	// broadcast before erroring is adopted rather than repeated.
+	fundable := record.LocalState == magmaStateAccepted ||
+		(record.LocalState == magmaStateNeedsAttention && record.PaymentStatus == magmaPaymentSuccessful)
+	if !fundable {
 		preview.Blockers = append(preview.Blockers, fmt.Sprintf(
 			"order is in local state %s; only an accepted-and-paid order can be funded", record.LocalState))
 	}
@@ -592,7 +604,16 @@ func (s *MagmaService) openChannelForOrderLocked(ctx context.Context, orderID st
 			"a channel to this buyer already exists at %s; refresh to reconcile instead of opening another", existing)
 	}
 
-	s.connectToBuyer(ctx, token, live.BuyerPubkey)
+	// Opening to a peer we are not connected to fails at the node with "peer
+	// disconnected", and that failure is expensive: the buyer has already paid,
+	// so the order lands in a state that owes a channel. Order 8ea03637 was
+	// accepted while the peer answered and dropped in the 96 seconds before the
+	// open. Reaching it first turns a failed open into a wait.
+	if err := s.reachBuyer(ctx, token, live.BuyerPubkey); err != nil {
+		s.appendEvent(ctx, record.OrderID, "auto_deferred", "info", fmt.Sprintf(
+			"waiting for the buyer's node to come back before opening: %v", err), nil)
+		return MagmaOrder{}, fmt.Errorf("the buyer's node is not reachable: %w", err)
+	}
 
 	// Write-ahead. From here on a crash must never look like "nothing happened".
 	if _, err := s.db.Exec(ctx, `
@@ -1022,6 +1043,112 @@ where local_state=$1 and magma_status='WAITING_FOR_CHANNEL_OPEN'
 	}
 }
 
+// magmaOpenRetryFallback bounds retrying when Amboss's deadline is unknown.
+// Deliberately generous: the observed window for opening after payment is about
+// two days, and the cost of stopping early - an unopened channel that was paid
+// for - is far worse than the cost of trying for longer than needed.
+const magmaOpenRetryFallback = 24 * time.Hour
+
+// magmaShouldKeepTryingToOpen reports whether a paid order still has time.
+//
+// The deadline comes from Amboss when we have it. When we do not, a missing
+// deadline means "unknown", never "expired": abandoning a paid order because a
+// field was absent is the one outcome this whole path exists to prevent.
+func magmaShouldKeepTryingToOpen(deadline *time.Time, firstSeen time.Time, now time.Time) bool {
+	if deadline != nil {
+		return now.Before(*deadline)
+	}
+	return now.Before(firstSeen.Add(magmaOpenRetryFallback))
+}
+
+// retryPaidOrdersThatFailedToOpen puts a paid order back in line after a failed
+// open, for as long as Amboss still allows it.
+//
+// The buyer has paid and we owe a channel: from that moment giving up costs a
+// SELLER_FAILED_TO_OPEN_CHANNEL, so the only acceptable reason to stop is that
+// the window closed. Order 8ea03637 hit "peer disconnected" once, landed in
+// needs_attention, and stayed there - nothing retried it, and the funding guard
+// refuses that state, so even the manual button was closed. It took an UPDATE by
+// hand 23 minutes later.
+//
+// Nothing about this lives in memory. The work is re-derived from the database
+// every cycle, so a node that was off for hours - a restart, an upgrade, a power
+// cut - resumes on its own the moment it comes back, which is precisely when a
+// paid order most needs someone to still be trying.
+//
+// `needs_attention` exists because an open can broadcast before its error
+// surfaces, and returning to `accepted` blindly could fund the same channel
+// twice. So the node is asked first: a channel that already exists is adopted
+// rather than reopened, and only an order with nothing funded goes back in line.
+func (s *MagmaService) retryPaidOrdersThatFailedToOpen(ctx context.Context) {
+	rows, err := s.db.Query(ctx, `
+select order_id, buyer_pubkey, size_sat, timeout_at, first_seen_at, attempt_count
+from magma_orders
+where local_state = $1
+  and magma_status = 'WAITING_FOR_CHANNEL_OPEN'
+  and payment_status = $2
+  and not (magma_status = any($3))
+`, magmaStateNeedsAttention, magmaPaymentSuccessful, magmaTerminalStatusList())
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Printf("magma: paid-retry query failed: %v", err)
+		}
+		return
+	}
+	type stuck struct {
+		orderID     string
+		buyerPubkey string
+		sizeSat     int64
+		deadline    *time.Time
+		firstSeen   time.Time
+		attempts    int
+	}
+	items := make([]stuck, 0, 4)
+	for rows.Next() {
+		var item stuck
+		if err := rows.Scan(&item.orderID, &item.buyerPubkey, &item.sizeSat,
+			&item.deadline, &item.firstSeen, &item.attempts); err == nil {
+			items = append(items, item)
+		}
+	}
+	rows.Close()
+
+	now := time.Now().UTC()
+	for _, item := range items {
+		point, err := s.existingChannelFor(ctx, MagmaOrder{
+			BuyerPubkey: item.buyerPubkey,
+			SizeSat:     item.sizeSat,
+		})
+		if err != nil {
+			continue
+		}
+		if point != "" {
+			// The open did land. Adopt it instead of retrying, which is the whole
+			// reason this checks before releasing the order.
+			if _, err := s.db.Exec(ctx, `
+update magma_orders
+set local_state=$2, channel_point=$3, funding_txid=$4, last_error='', updated_at=now()
+where order_id=$1
+`, item.orderID, magmaStateConfirming, point, magmaTxidFromPoint(point)); err == nil {
+				s.appendEvent(ctx, item.orderID, "recovered", "info", fmt.Sprintf(
+					"the failed open had in fact broadcast; adopting channel %s", point), nil)
+			}
+			continue
+		}
+		if !magmaShouldKeepTryingToOpen(item.deadline, item.firstSeen, now) {
+			continue
+		}
+		if _, err := s.db.Exec(ctx, `
+update magma_orders set local_state=$2, updated_at=now() where order_id=$1
+`, item.orderID, magmaStateAccepted); err != nil {
+			continue
+		}
+		s.appendEvent(ctx, item.orderID, "retrying", "info", fmt.Sprintf(
+			"nothing was funded by the failed open, and the buyer has paid; "+
+				"queued to try again (attempt %d so far)", item.attempts), nil)
+	}
+}
+
 // magmaStatusMeansChannelIsOut reports the statuses where Amboss has seen the
 // funding transaction. Past that point the sale is no longer waiting on us to
 // spend anything, so it must stop reserving wallet balance.
@@ -1122,6 +1249,9 @@ func (s *MagmaService) reconcileExecution(ctx context.Context, token string) {
 	// And the mirror of it: an order this app accepted whose channel was then
 	// opened by hand. Runs before the resume paths for the same reason.
 	s.adoptOrdersOpenedElsewhere(ctx)
+	// And orders whose open failed. Runs before the resume paths so a rescued
+	// order is funded in the same cycle rather than waiting for the next.
+	s.retryPaidOrdersThatFailedToOpen(ctx)
 
 	rows, err := s.db.Query(ctx, `
 select order_id, local_state, funding_txid, channel_point, buyer_pubkey, size_sat

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -55,6 +55,7 @@ type magmaLND interface {
 	ListPendingChannels(ctx context.Context) ([]lndclient.PendingChannelInfo, error)
 	ListChannels(ctx context.Context) ([]lndclient.ChannelInfo, error)
 	ListPeers(ctx context.Context) ([]lndclient.PeerInfo, error)
+	ListLeases(ctx context.Context) (map[string]lndclient.LeaseInfo, error)
 }
 
 // magmaOnchainTxLister is split out because only the P&L needs it; keeping it
@@ -231,6 +232,29 @@ where local_state = any($1) and not (magma_status = any($2))
 		capacity.AvailableSat = 0
 	}
 	return capacity, nil
+}
+
+// lockedFundsNote describes funds held by a lease, or nothing at all. It never
+// fails the preview: this is an explanation, and an explanation that cannot be
+// fetched simply is not appended.
+func (s *MagmaService) lockedFundsNote(ctx context.Context) string {
+	if s.lnd == nil {
+		return ""
+	}
+	leases, err := s.lnd.ListLeases(ctx)
+	if err != nil || len(leases) == 0 {
+		return ""
+	}
+	var locked int64
+	for _, lease := range leases {
+		locked += int64(lease.Value)
+	}
+	if locked <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		" (%s sat is locked by %d leased utxo(s) and cannot be spent until the lease expires)",
+		formatInt(locked), len(leases))
 }
 
 // ensureCapacityFor refuses an order the wallet cannot honour once every already
@@ -462,9 +486,16 @@ func (s *MagmaService) OpenChannelPreview(ctx context.Context, orderID string, s
 		preview.SpendableSat = estimate.SpendableSat
 		preview.EnoughFunds = estimate.EnoughFunds
 		if !estimate.EnoughFunds {
+			// Say where the rest of the money is. LND's ListUnspent omits leased
+			// outputs, so a wallet holding 1.7M can be reported as holding 209k
+			// with nothing on screen to explain the gap - which is exactly how
+			// issue #131 was read as a phantom balance bug. The lease is real and
+			// the funds are genuinely unspendable until it lapses; the failure was
+			// only ever in not saying so.
 			preview.Blockers = append(preview.Blockers, fmt.Sprintf(
-				"not enough confirmed on-chain balance: need %s sat, have %s sat",
-				formatInt(estimate.TotalDebitSat), formatInt(estimate.SpendableSat)))
+				"not enough confirmed on-chain balance: need %s sat, have %s sat%s",
+				formatInt(estimate.TotalDebitSat), formatInt(estimate.SpendableSat),
+				s.lockedFundsNote(ctx)))
 		}
 	} else {
 		preview.Warnings = append(preview.Warnings, fmt.Sprintf("could not estimate the on-chain cost: %v", err))
@@ -991,10 +1022,106 @@ where local_state=$1 and magma_status='WAITING_FOR_CHANNEL_OPEN'
 	}
 }
 
+// magmaStatusMeansChannelIsOut reports the statuses where Amboss has seen the
+// funding transaction. Past that point the sale is no longer waiting on us to
+// spend anything, so it must stop reserving wallet balance.
+//
+// Deliberately not the terminal list: these are successes in flight, and a
+// successful order is exactly the one the terminal list is built to keep. The
+// question here is different - not "is this order over" but "has the money
+// already left".
+func magmaStatusMeansChannelIsOut(status string) bool {
+	switch status {
+	case "SELLER_SENT_TRANSACTION", "SELLER_OPENED_CHANNEL", "VALID_CHANNEL_OPENING",
+		"WAITING_FOR_ON_CHAIN_CONFIRMATION", "ON_CHAIN_CONFIRMATION",
+		"CHANNEL_MONITORING_FINISHED":
+		return true
+	}
+	return false
+}
+
+// adoptOrdersOpenedElsewhere finishes an order whose channel was opened outside
+// this app.
+//
+// Reported as issue #131: auto-open declined, the operator opened the channel by
+// hand, Amboss saw it and moved the order to VALID_CHANNEL_OPENING - and the
+// local state stayed `accepted`. `accepted` is one of the states that reserves
+// wallet balance against a channel still owed, so the app went on holding
+// 500,000 sat for a channel that was already open, and said so on screen. The
+// only way out was editing the database by hand.
+//
+// The channel is looked up on the node rather than assumed from the status:
+// Amboss can only tell us a channel exists, not which one, and writing a channel
+// point we did not verify is how an order ends up pointing at the wrong funding
+// transaction.
+func (s *MagmaService) adoptOrdersOpenedElsewhere(ctx context.Context) {
+	rows, err := s.db.Query(ctx, `
+select order_id, magma_status, buyer_pubkey, size_sat
+from magma_orders
+where local_state = $1 and not (magma_status = any($2))
+`, magmaStateAccepted, magmaTerminalStatusList())
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Printf("magma: opened-elsewhere query failed: %v", err)
+		}
+		return
+	}
+	type candidate struct {
+		orderID     string
+		magmaStatus string
+		buyerPubkey string
+		sizeSat     int64
+	}
+	candidates := make([]candidate, 0, 4)
+	for rows.Next() {
+		var item candidate
+		if err := rows.Scan(&item.orderID, &item.magmaStatus, &item.buyerPubkey, &item.sizeSat); err == nil {
+			candidates = append(candidates, item)
+		}
+	}
+	rows.Close()
+
+	for _, item := range candidates {
+		if !magmaStatusMeansChannelIsOut(item.magmaStatus) {
+			continue
+		}
+		point, err := s.existingChannelFor(ctx, MagmaOrder{
+			BuyerPubkey: item.buyerPubkey,
+			SizeSat:     item.sizeSat,
+		})
+		if err != nil || point == "" {
+			// Amboss says the channel is out and the node cannot show it. Say so
+			// rather than guessing: the balance stays reserved, which is the safe
+			// direction, and the operator has something to act on.
+			s.appendEvent(ctx, item.orderID, "needs_attention", "warning", fmt.Sprintf(
+				"Amboss reports %s but no channel of %s sat to %s is on this node; "+
+					"the order still reserves that balance until it can be matched",
+				item.magmaStatus, formatInt(item.sizeSat), magmaShortPubkey(item.buyerPubkey)), nil)
+			continue
+		}
+		if _, err := s.db.Exec(ctx, `
+update magma_orders
+set local_state=$2, channel_point=$3, funding_txid=$4, last_error='', updated_at=now()
+where order_id=$1
+`, item.orderID, magmaStateConfirmed, point, magmaTxidFromPoint(point)); err != nil {
+			if s.logger != nil {
+				s.logger.Printf("magma: could not finish order %s opened elsewhere: %v", item.orderID, err)
+			}
+			continue
+		}
+		s.appendEvent(ctx, item.orderID, "adopted", "info", fmt.Sprintf(
+			"Channel %s was opened outside this app and Amboss has seen it; "+
+				"the order no longer reserves balance", point), nil)
+	}
+}
+
 func (s *MagmaService) reconcileExecution(ctx context.Context, token string) {
 	// Runs first: an order approved elsewhere has to be owned before any of the
 	// resume paths below can see it.
 	s.adoptOrdersAcceptedElsewhere(ctx)
+	// And the mirror of it: an order this app accepted whose channel was then
+	// opened by hand. Runs before the resume paths for the same reason.
+	s.adoptOrdersOpenedElsewhere(ctx)
 
 	rows, err := s.db.Query(ctx, `
 select order_id, local_state, funding_txid, channel_point, buyer_pubkey, size_sat

--- a/lightningos-light/internal/server/magma_execution.go
+++ b/lightningos-light/internal/server/magma_execution.go
@@ -1149,6 +1149,102 @@ update magma_orders set local_state=$2, updated_at=now() where order_id=$1
 	}
 }
 
+const (
+	// magmaOpenAlertGrace holds the first alert back. A peer that drops for a
+	// minute is normal and resolves itself; saying so immediately would train the
+	// operator to ignore the message that matters.
+	magmaOpenAlertGrace = 8 * time.Minute
+	// magmaOpenAlertInterval repeats it while the channel is still owed. Amboss
+	// nudges the seller on roughly this cadence for the same reason: something
+	// pending for hours has to stay visible without becoming noise.
+	magmaOpenAlertInterval = 30 * time.Minute
+)
+
+// alertOnPaidOrdersStillWaitingToOpen tells the operator when a paid order is
+// not turning into a channel.
+//
+// The automation retries on its own and usually wins, so most of this stays
+// silent by design. But after payment the operator is the last line of defence -
+// they can open by hand, reach the buyer, or talk to Amboss - and nothing told
+// them anything: the deferral is recorded at info level and never left the
+// database. Worse, that silence replaced a warning that used to fire on the
+// first failed open, so retrying harder had quietly traded loud-and-useless for
+// quiet-and-invisible.
+//
+// The cadence lives in the database, not in memory, so a restart neither repeats
+// the backlog nor resets the clock on an order that has waited for hours.
+func (s *MagmaService) alertOnPaidOrdersStillWaitingToOpen(ctx context.Context) {
+	rows, err := s.db.Query(ctx, `
+select order_id, buyer_pubkey, size_sat, revenue_sat, timeout_at, open_alert_at,
+       open_expiry_notified, coalesce(revenue_settled_at, first_seen_at)
+from magma_orders
+where local_state = any($1)
+  and magma_status = 'WAITING_FOR_CHANNEL_OPEN'
+  and payment_status = $2
+`, []string{magmaStateAccepted, magmaStateNeedsAttention}, magmaPaymentSuccessful)
+	if err != nil {
+		return
+	}
+	type waiting struct {
+		orderID        string
+		buyerPubkey    string
+		sizeSat        int64
+		revenueSat     int64
+		deadline       *time.Time
+		lastAlert      *time.Time
+		expiryNotified bool
+		owedSince      time.Time
+	}
+	items := make([]waiting, 0, 4)
+	for rows.Next() {
+		var item waiting
+		if err := rows.Scan(&item.orderID, &item.buyerPubkey, &item.sizeSat, &item.revenueSat,
+			&item.deadline, &item.lastAlert, &item.expiryNotified, &item.owedSince); err == nil {
+			items = append(items, item)
+		}
+	}
+	rows.Close()
+
+	now := time.Now().UTC()
+	for _, item := range items {
+		if item.deadline != nil && now.After(*item.deadline) {
+			if item.expiryNotified {
+				continue
+			}
+			s.appendEvent(ctx, item.orderID, "open_window_closed", "error", fmt.Sprintf(
+				"the window to open this paid channel has closed; %s sat to %s was never delivered",
+				formatInt(item.sizeSat), magmaShortPubkey(item.buyerPubkey)), nil)
+			s.notifyTelegram(ctx, MagmaOrder{ID: item.orderID}, fmt.Sprintf(`Order %s: the window to open this channel has CLOSED.
+The buyer paid %s sat and the %s sat channel to %s was never opened.
+Amboss will record a seller failure for this order.`,
+				item.orderID, formatInt(item.revenueSat), formatInt(item.sizeSat),
+				magmaShortPubkey(item.buyerPubkey)))
+			_, _ = s.db.Exec(ctx,
+				`update magma_orders set open_expiry_notified=true, updated_at=now() where order_id=$1`,
+				item.orderID)
+			continue
+		}
+		if now.Sub(item.owedSince) < magmaOpenAlertGrace {
+			continue
+		}
+		if item.lastAlert != nil && now.Sub(*item.lastAlert) < magmaOpenAlertInterval {
+			continue
+		}
+		left := "an unknown amount of time"
+		if item.deadline != nil {
+			left = fmt.Sprintf("%d minutes", int(item.deadline.Sub(now)/time.Minute))
+		}
+		s.notifyTelegram(ctx, MagmaOrder{ID: item.orderID}, fmt.Sprintf(`Order %s: the buyer has paid and the %s sat channel to %s is still not open.
+Waiting %d minutes so far, %s left to open it.
+Retrying automatically; opening it by hand also resolves the order.`,
+			item.orderID, formatInt(item.sizeSat), magmaShortPubkey(item.buyerPubkey),
+			int(now.Sub(item.owedSince)/time.Minute), left))
+		_, _ = s.db.Exec(ctx,
+			`update magma_orders set open_alert_at=now(), updated_at=now() where order_id=$1`,
+			item.orderID)
+	}
+}
+
 // magmaStatusMeansChannelIsOut reports the statuses where Amboss has seen the
 // funding transaction. Past that point the sale is no longer waiting on us to
 // spend anything, so it must stop reserving wallet balance.
@@ -1252,6 +1348,7 @@ func (s *MagmaService) reconcileExecution(ctx context.Context, token string) {
 	// And orders whose open failed. Runs before the resume paths so a rescued
 	// order is funded in the same cycle rather than waiting for the next.
 	s.retryPaidOrdersThatFailedToOpen(ctx)
+	s.alertOnPaidOrdersStillWaitingToOpen(ctx)
 
 	rows, err := s.db.Query(ctx, `
 select order_id, local_state, funding_txid, channel_point, buyer_pubkey, size_sat

--- a/lightningos-light/internal/server/magma_external_open_test.go
+++ b/lightningos-light/internal/server/magma_external_open_test.go
@@ -1,0 +1,51 @@
+package server
+
+import "testing"
+
+// Issue #131. Order fd0a2cd0 was accepted by this app, the auto-open declined,
+// the operator opened the 500,000 sat channel by hand, and Amboss moved the
+// order to VALID_CHANNEL_OPENING. The local state stayed `accepted`, which is
+// one of the states that reserves wallet balance against a channel still owed -
+// so the app went on holding 500,000 sat for a channel that was already open,
+// and said so on screen. The only way out was an UPDATE by hand.
+func TestMagmaStatusMeansChannelIsOutCoversTheReportedCase(t *testing.T) {
+	for _, status := range []string{
+		"VALID_CHANNEL_OPENING", "SELLER_SENT_TRANSACTION", "SELLER_OPENED_CHANNEL",
+		"WAITING_FOR_ON_CHAIN_CONFIRMATION", "ON_CHAIN_CONFIRMATION",
+		"CHANNEL_MONITORING_FINISHED",
+	} {
+		if !magmaStatusMeansChannelIsOut(status) {
+			t.Fatalf("%s means the funding is already out, so the order must stop reserving", status)
+		}
+	}
+}
+
+// Before the funding exists the reservation is doing its job: the money is owed
+// and has not left. Releasing it here would let two orders spend the same coins.
+func TestMagmaStatusBeforeTheChannelKeepsTheReservation(t *testing.T) {
+	for _, status := range []string{
+		"WAITING_FOR_SELLER_APPROVAL", "WAITING_FOR_BUYER_PAYMENT", "WAITING_FOR_CHANNEL_OPEN", "",
+	} {
+		if magmaStatusMeansChannelIsOut(status) {
+			t.Fatalf("%s still owes a channel, so the balance stays reserved", status)
+		}
+	}
+}
+
+// The terminal list answers "is this order over"; this answers "has the money
+// left". They are different questions, and a successful order in flight belongs
+// to the second and not the first - which is why the terminal list could not be
+// reused here.
+func TestMagmaChannelIsOutIsNotTheTerminalList(t *testing.T) {
+	if magmaTerminalStatuses["VALID_CHANNEL_OPENING"] {
+		t.Fatal("a successful opening must not be treated as a closed order")
+	}
+	if !magmaStatusMeansChannelIsOut("VALID_CHANNEL_OPENING") {
+		t.Fatal("but its funding has left the wallet, so it must release the reservation")
+	}
+	for status := range magmaTerminalStatuses {
+		if status == "INVALID_CHANNEL_OPENING" && magmaStatusMeansChannelIsOut(status) {
+			t.Fatal("an invalid opening is a failure, not a funded channel")
+		}
+	}
+}

--- a/lightningos-light/internal/server/magma_offer_guard.go
+++ b/lightningos-light/internal/server/magma_offer_guard.go
@@ -205,7 +205,7 @@ func (s *MagmaService) syncOfferBalanceGuard(ctx context.Context, token string) 
 		}
 		s.markOfferAutoDisabled(ctx, offer.ID, availableSat, required)
 		s.notifyOfferGuard(ctx, offer, "disabled", remaining, policy.MinOnchainReserve,
-			required, availableSat)
+			required, availableSat, unfulfillable)
 	}
 
 	// Restore in a fixed order so the same balance always brings back the same
@@ -242,7 +242,7 @@ func (s *MagmaService) syncOfferBalanceGuard(ctx context.Context, token string) 
 		budget -= remaining
 		s.clearOfferAutoDisable(ctx, offer.ID)
 		s.notifyOfferGuard(ctx, offer, "enabled", remaining, policy.MinOnchainReserve,
-			remaining+policy.MinOnchainReserve, availableSat)
+			remaining+policy.MinOnchainReserve, availableSat, false)
 	}
 }
 
@@ -277,22 +277,48 @@ func magmaOfferHasBlockingConflict(conflicts []MagmaOfferConflict) bool {
 	return false
 }
 
+// magmaOfferDisableReason explains why an offer is coming down, in the terms
+// that decided it.
+//
+// The guard said "the on-chain balance no longer covers it" for every disable.
+// Once it also began taking down offers that cannot produce a valid order, that
+// sentence started appearing beside numbers contradicting it: an offer with
+// 135,910 sat left and a 1,000,000 sat minimum, reported as unaffordable
+// against 3,727,500 sat of free balance. The decision was right and the
+// explanation was wrong, which is worse than none - it sends the operator
+// hunting a balance problem that does not exist.
+func magmaOfferDisableReason(offer MagmaOffer, unfulfillable bool) string {
+	if !unfulfillable {
+		return fmt.Sprintf(
+			"Offer disabled automatically: the on-chain balance no longer covers the %s sat it needs",
+			formatInt(magmaOfferSmallestOrder(offer)))
+	}
+	return fmt.Sprintf(
+		"Offer disabled automatically: only %s sat left to sell, below the %s sat smallest channel it "+
+			"advertises, so it can no longer produce a valid order",
+		formatInt(magmaOfferRemaining(offer)), formatInt(offer.MinSizeSat))
+}
+
 func (s *MagmaService) notifyOfferGuard(ctx context.Context, offer MagmaOffer, action string,
-	remaining, reserve, required, available int64) {
+	remaining, reserve, required, available int64, unfulfillable bool) {
 	var header string
 	if action == "disabled" {
-		header = fmt.Sprintf(
-			"Offer disabled automatically: the on-chain balance no longer covers the %s sat it still has to sell",
-			formatInt(remaining))
+		header = magmaOfferDisableReason(offer, unfulfillable)
 	} else {
 		header = "Offer re-enabled automatically: the on-chain balance covers it again"
 	}
-	body := fmt.Sprintf("%s\nOffer remaining: %s sat\nPolicy reserve: %s sat\nRequired: %s sat\nAvailable: %s sat",
-		header, formatInt(remaining), formatInt(reserve), formatInt(required), formatInt(available))
+	// The figures below describe the balance test. An exhausted offer was not
+	// decided by it, and printing them there recreates the contradiction the
+	// header was just fixed to avoid.
+	body := header
+	if !unfulfillable || action != "disabled" {
+		body = fmt.Sprintf("%s\nOffer needs: %s sat\nPolicy reserve: %s sat\nRequired: %s sat\nAvailable: %s sat",
+			header, formatInt(remaining), formatInt(reserve), formatInt(required), formatInt(available))
+	}
 
 	if s.logger != nil {
-		s.logger.Printf("magma: offer %s %s automatically (remaining=%d required=%d available=%d)",
-			offer.ID, action, remaining, required, available)
+		s.logger.Printf("magma: offer %s %s automatically (remaining=%d required=%d available=%d unfulfillable=%t)",
+			offer.ID, action, remaining, required, available, unfulfillable)
 	}
 	// Offers have no order to hang an event on, so this goes straight to Telegram.
 	s.notifyTelegram(ctx, MagmaOrder{}, body)

--- a/lightningos-light/internal/server/magma_offer_reason_test.go
+++ b/lightningos-light/internal/server/magma_offer_reason_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+// The offer taken down on 2026-09-06: 7,600,000 sat published, 7,464,090 sold,
+// 135,910 left, and a 1,000,000 sat smallest channel. It could no longer produce
+// a valid order, so disabling it was right - but the message said the on-chain
+// balance no longer covered it, printed beside 3,727,500 sat of free balance.
+// A correct decision explained by a contradiction sends the operator hunting a
+// balance problem that does not exist.
+func TestMagmaOfferDisableReasonNamesExhaustionNotBalance(t *testing.T) {
+	offer := MagmaOffer{
+		TotalSizeSat: 7_600_000, SoldSat: 7_464_090, RemainingSat: 135_910,
+		MinSizeSat: 1_000_000, MaxSizeSat: 3_000_000,
+	}
+	reason := magmaOfferDisableReason(offer, true)
+	if strings.Contains(strings.ToLower(reason), "balance") {
+		t.Fatalf("an exhausted offer has nothing to do with the balance: %q", reason)
+	}
+	for _, want := range []string{"135,910", "1,000,000"} {
+		if !strings.Contains(reason, want) {
+			t.Fatalf("the reason must show %s so the numbers agree with the words: %q", want, reason)
+		}
+	}
+}
+
+// When the balance really is the reason, the message says so - and quotes what
+// the offer actually needs, which is the smallest order it can still produce
+// rather than the remainder that always fits.
+func TestMagmaOfferDisableReasonStillReportsRealShortfalls(t *testing.T) {
+	offer := MagmaOffer{
+		TotalSizeSat: 5_000_000, SoldSat: 0, RemainingSat: 5_000_000,
+		MinSizeSat: 1_000_000, MaxSizeSat: 5_000_000,
+	}
+	reason := magmaOfferDisableReason(offer, false)
+	if !strings.Contains(strings.ToLower(reason), "balance") {
+		t.Fatalf("a genuine shortfall must still be named as one: %q", reason)
+	}
+	if !strings.Contains(reason, "5,000,000") {
+		t.Fatalf("expected the amount the offer needs, got %q", reason)
+	}
+}

--- a/lightningos-light/internal/server/magma_open_alert_test.go
+++ b/lightningos-light/internal/server/magma_open_alert_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// After payment the operator is the last line of defence - they can open by
+// hand, reach the buyer, or talk to Amboss. Until now nothing told them
+// anything, and making the retry patient had quietly made it silent too: the
+// deferral is an info event that never leaves the database, replacing a warning
+// that used to fire on the first failed open.
+//
+// The first alert is held back because a peer that drops for a minute resolves
+// itself, and crying about that teaches the operator to ignore the message that
+// matters.
+func TestMagmaOpenAlertWaitsBeforeSpeakingUp(t *testing.T) {
+	if magmaOpenAlertGrace < 5*time.Minute {
+		t.Fatalf("alerting sooner than a peer takes to reconnect is noise: %s", magmaOpenAlertGrace)
+	}
+	if magmaOpenAlertGrace > 15*time.Minute {
+		t.Fatalf("a paid channel unopened this long must already have been reported: %s", magmaOpenAlertGrace)
+	}
+}
+
+// And it repeats while the channel is still owed. Amboss nudges the seller on
+// roughly this cadence for the same reason: something pending for hours has to
+// stay visible without becoming noise. A single alert at minute eight is lost by
+// the time it matters.
+func TestMagmaOpenAlertRepeatsWhileTheChannelIsOwed(t *testing.T) {
+	if magmaOpenAlertInterval < 15*time.Minute {
+		t.Fatalf("repeating this often turns the alert into noise: %s", magmaOpenAlertInterval)
+	}
+	if magmaOpenAlertInterval > time.Hour {
+		t.Fatalf("an unopened paid channel cannot go this long unmentioned: %s", magmaOpenAlertInterval)
+	}
+	// The window to open runs to about two days, so the reminder has to survive
+	// far longer than the grace period that starts it.
+	if magmaOpenAlertInterval <= magmaOpenAlertGrace {
+		t.Fatal("the repeat must be slower than the first alert, not faster")
+	}
+}
+
+// The retry gives up only when Amboss does; the alert cadence must not outlive
+// that, or the operator is reminded about an order nothing is working on.
+func TestMagmaAlertCadenceFitsInsideTheRetryWindow(t *testing.T) {
+	if magmaOpenAlertInterval >= magmaOpenRetryFallback {
+		t.Fatal("reminders must fit inside the window the order is still being retried in")
+	}
+}

--- a/lightningos-light/internal/server/magma_open_retry_test.go
+++ b/lightningos-light/internal/server/magma_open_retry_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// Order 8ea03637, 2026-09-06. The peer answered when the order was accepted at
+// 15:01:44 and was gone by the open at 15:03:20 - 96 seconds. The open failed
+// with "peer disconnected", the order landed in needs_attention, and nothing
+// retried it: the funding guard refuses that state, so the manual button was
+// closed too. It took a database edit 23 minutes later, with the buyer already
+// paid and the clock running.
+//
+// Amboss allows about two days to open after payment. Giving up in 75 seconds
+// was never the shape of the problem.
+func TestMagmaKeepsTryingWhileAmbossStillAllowsIt(t *testing.T) {
+	firstSeen := time.Date(2026, 9, 6, 18, 0, 39, 0, time.UTC)
+	deadline := time.Date(2026, 9, 8, 19, 1, 35, 0, time.UTC) // the real one, from Amboss
+
+	duringTheFailure := time.Date(2026, 9, 6, 18, 4, 35, 0, time.UTC)
+	if !magmaShouldKeepTryingToOpen(&deadline, firstSeen, duringTheFailure) {
+		t.Fatal("minutes in, with two days left, the order must go back in line")
+	}
+	nearlyOutOfTime := deadline.Add(-time.Minute)
+	if !magmaShouldKeepTryingToOpen(&deadline, firstSeen, nearlyOutOfTime) {
+		t.Fatal("a minute of window left is still a minute worth trying")
+	}
+	if magmaShouldKeepTryingToOpen(&deadline, firstSeen, deadline.Add(time.Second)) {
+		t.Fatal("past the deadline there is nothing left to win")
+	}
+}
+
+// A missing deadline means unknown, never expired. Amboss reports none once an
+// order settles, and a fetch can simply fail - abandoning a paid order because a
+// field was absent is the outcome this path exists to prevent.
+func TestMagmaMissingDeadlineDoesNotMeanExpired(t *testing.T) {
+	firstSeen := time.Date(2026, 9, 6, 18, 0, 0, 0, time.UTC)
+	if !magmaShouldKeepTryingToOpen(nil, firstSeen, firstSeen.Add(6*time.Hour)) {
+		t.Fatal("without a deadline the fallback window must still be honoured")
+	}
+	// The fallback has to be generous enough to survive a node that was off for
+	// hours: an outage is exactly when a paid order most needs someone trying.
+	if magmaOpenRetryFallback < 12*time.Hour {
+		t.Fatalf("the fallback window is too short to outlast an outage: %s", magmaOpenRetryFallback)
+	}
+	if magmaShouldKeepTryingToOpen(nil, firstSeen, firstSeen.Add(magmaOpenRetryFallback+time.Minute)) {
+		t.Fatal("the fallback still has to end somewhere")
+	}
+}

--- a/lightningos-light/internal/server/magma_policy.go
+++ b/lightningos-light/internal/server/magma_policy.go
@@ -103,6 +103,50 @@ type magmaPolicyInputs struct {
 	// the creation time is unknown, which disables the deadline rather than
 	// guessing an age and refusing something that just arrived.
 	PendingFor time.Duration
+	// Deadline is Amboss's own instant for this order, when they publish one.
+	// Everything below used to run on an estimate: the grace period was derived
+	// from a single order that lapsed 2h04m after creation. A real deadline
+	// replaces the guess; a missing one keeps it.
+	Deadline *time.Time
+	// BuyerUnreachable is set when the buyer's node did not answer. Phrased so the
+	// zero value is the harmless one: a caller that never learned the answer must
+	// not silently block every sale.
+	//
+	// It defers rather than refuses. An unreachable buyer has been observed paying
+	// in full, so it predicts nothing on its own - but LND will not open a channel
+	// to a peer that is not connected, so accepting while it is down promises a
+	// delivery on a connection we do not have. Deferring costs nothing while there
+	// is still window left, and the deadline turns it into a refusal if it lasts.
+	BuyerUnreachable bool
+}
+
+// magmaTimeLeft is how long this order still has. It prefers Amboss's own
+// deadline and falls back to the observed window, so an order is never judged by
+// an estimate when the real number is available.
+func magmaTimeLeft(in magmaPolicyInputs, now time.Time) (time.Duration, bool) {
+	if in.Deadline != nil {
+		return in.Deadline.Sub(now), true
+	}
+	if in.PendingFor <= 0 {
+		// Age unknown, so no deadline can be applied without inventing one.
+		return 0, false
+	}
+	return magmaApprovalWindow - in.PendingFor, true
+}
+
+// magmaShouldRefuseNow reports whether the window has closed far enough that an
+// explicit refusal is the only thing still worth doing.
+//
+// The order matters: refusing early throws away a sale that might still land,
+// and refusing late is not refusing at all - the lapse is recorded against the
+// account as SELLER_FAILED_TO_REACT. So the refusal happens with time to spare,
+// deliberately before the deadline rather than at it.
+func magmaShouldRefuseNow(in magmaPolicyInputs, now time.Time) bool {
+	left, known := magmaTimeLeft(in, now)
+	if !known {
+		return false
+	}
+	return left <= magmaApprovalWindow-magmaApprovalGrace
 }
 
 // evaluateMagmaOrder splits refusals into permanent and temporary on purpose.
@@ -115,10 +159,14 @@ func evaluateMagmaOrder(policy MagmaPolicy, in magmaPolicyInputs) magmaDecision 
 	// A deferral is a bet that the blocker clears before Amboss loses patience.
 	// Past the grace period that bet is lost, and the only thing left to choose is
 	// whether the order ends as our explicit "no" or as a failure record.
-	if !decision.Accept && !decision.Reject && in.PendingFor >= magmaApprovalGrace {
+	if !decision.Accept && !decision.Reject && magmaShouldRefuseNow(in, time.Now()) {
+		left, _ := magmaTimeLeft(in, time.Now())
+		if left < 0 {
+			left = 0
+		}
 		return magmaDecision{Reject: true, Reason: fmt.Sprintf(
 			"%s - refusing explicitly, the approval window closes in about %d minutes",
-			decision.Reason, int(magmaWindowRemaining(in.PendingFor)/time.Minute))}
+			decision.Reason, int(left/time.Minute))}
 	}
 	return decision
 }
@@ -181,6 +229,15 @@ func evaluateMagmaOrderTerms(policy MagmaPolicy, in magmaPolicyInputs) magmaDeci
 	}
 
 	// --- Temporary: the terms are fine, we are not ready. Defer, never reject. ---
+
+	// Checked here and not earlier: an order whose terms are unacceptable is
+	// refused on those terms whatever the peer is doing. Deferring it instead
+	// would spend the window waiting for a node whose order we were never going
+	// to take.
+	if in.BuyerUnreachable {
+		return magmaDecision{Reason: "the buyer's node is not answering, and LND cannot open " +
+			"a channel to a peer that is not connected; waiting for it to return"}
+	}
 	if !in.OnchainReachable {
 		return magmaDecision{Reason: "waiting: could not read the on-chain balance"}
 	}
@@ -366,6 +423,31 @@ order by coalesce(order_created_at, first_seen_at) asc limit 1
 	return true
 }
 
+// orderDeadlines reads the deadlines Amboss published for these orders. A
+// missing entry means no deadline is known, which leaves the estimate in place
+// rather than inventing one.
+func (s *MagmaService) orderDeadlines(ctx context.Context, orderIDs []string) map[string]time.Time {
+	deadlines := make(map[string]time.Time, len(orderIDs))
+	if len(orderIDs) == 0 {
+		return deadlines
+	}
+	rows, err := s.db.Query(ctx,
+		`select order_id, timeout_at from magma_orders where order_id = any($1) and timeout_at is not null`,
+		orderIDs)
+	if err != nil {
+		return deadlines
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var when time.Time
+		if err := rows.Scan(&id, &when); err == nil {
+			deadlines[id] = when.UTC()
+		}
+	}
+	return deadlines
+}
+
 // autoEvaluatePending runs the policy over orders waiting for our approval.
 func (s *MagmaService) autoEvaluatePending(ctx context.Context, token string, policy MagmaPolicy) {
 	rows, err := s.db.Query(ctx, `
@@ -392,6 +474,7 @@ order by coalesce(order_created_at, first_seen_at) asc
 	concurrent, _ := s.concurrentOpens(ctx)
 	ordersToday, sizeToday, _ := s.dailyUsage(ctx)
 
+	deadlines := s.orderDeadlines(ctx, pending)
 	for _, orderID := range pending {
 		order, err := s.orderByID(ctx, orderID)
 		if err != nil {
@@ -405,6 +488,13 @@ order by coalesce(order_created_at, first_seen_at) asc
 			OrdersToday:      ordersToday,
 			SizeToday:        sizeToday,
 			OnchainReachable: capErr == nil,
+			// Reaching the buyer is attempted once per pass. It is cheap when the
+			// peer is already connected - a peer list, no dial - and when it is
+			// not, this is exactly the retry that keeps the sale alive.
+			BuyerUnreachable: s.reachBuyer(ctx, token, order.BuyerPubkey) != nil,
+		}
+		if when, ok := deadlines[orderID]; ok {
+			inputs.Deadline = &when
 		}
 		if order.CreatedAt != nil {
 			inputs.PendingFor = time.Since(*order.CreatedAt)

--- a/lightningos-light/internal/server/magma_service.go
+++ b/lightningos-light/internal/server/magma_service.go
@@ -244,7 +244,13 @@ alter table magma_orders
   -- Amboss's own deadline for the order, read from the replacement endpoint.
   -- Null means no deadline is being tracked, never "expired": a settled order
   -- reports none, and so does a fetch that failed.
-  add column if not exists timeout_at timestamptz;
+  add column if not exists timeout_at timestamptz,
+  -- When the operator was last told this paid order still has no channel, and
+  -- whether the final "the window closed" warning already went out. Persisted
+  -- rather than held in memory so a restart neither repeats the whole history
+  -- nor silently resets the clock.
+  add column if not exists open_alert_at timestamptz,
+  add column if not exists open_expiry_notified boolean not null default false;
 
 create table if not exists magma_offer_state (
   offer_id text primary key,

--- a/lightningos-light/internal/server/magma_service.go
+++ b/lightningos-light/internal/server/magma_service.go
@@ -240,7 +240,11 @@ alter table magma_orders
   add column if not exists fee_guard_applied boolean not null default false,
   add column if not exists revenue_settled_at timestamptz,
   add column if not exists onchain_fee_sat bigint,
-  add column if not exists buyer_alias text;
+  add column if not exists buyer_alias text,
+  -- Amboss's own deadline for the order, read from the replacement endpoint.
+  -- Null means no deadline is being tracked, never "expired": a settled order
+  -- reports none, and so does a fetch that failed.
+  add column if not exists timeout_at timestamptz;
 
 create table if not exists magma_offer_state (
   offer_id text primary key,
@@ -566,6 +570,10 @@ func (s *MagmaService) syncLocked(ctx context.Context) error {
 		return err
 	}
 	s.noteOrderFetch(summary.PendingSellerOrders)
+	// Best effort and deliberately not fatal: the deadline sharpens decisions
+	// that already have conservative fallbacks, so failing to read it must never
+	// stop a sync that is otherwise fine.
+	s.syncOrderTimeouts(ctx, token)
 
 	settings, err := s.Settings(ctx)
 	if err != nil {
@@ -824,6 +832,33 @@ where order_id=$1 and revenue_settled_at is null
 		}
 	}
 	return nil
+}
+
+// syncOrderTimeouts records Amboss's deadline for each live order.
+//
+// Every decision that used to guess at a window can now read one. The approval
+// grace period was calibrated on a single order that expired 2h04m after it was
+// created - one sample, turned into a constant. A channel that must be opened
+// after payment has a window of about two days, which nothing in this app knew.
+//
+// A deadline is only ever written, never cleared here: Amboss reports null once
+// an order settles, and treating that as "no longer has a deadline" would be
+// harmless while treating it as "the deadline passed" would not.
+func (s *MagmaService) syncOrderTimeouts(ctx context.Context, token string) {
+	deadlines, err := s.amboss.OrderTimeouts(ctx, token)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Printf("magma: could not read order deadlines: %v", err)
+		}
+		return
+	}
+	for orderID, when := range deadlines {
+		if _, err := s.db.Exec(ctx,
+			`update magma_orders set timeout_at=$2 where order_id=$1 and timeout_at is distinct from $2`,
+			orderID, when); err != nil && s.logger != nil {
+			s.logger.Printf("magma: could not record the deadline of order %s: %v", orderID, err)
+		}
+	}
 }
 
 func magmaOrderEventFor(order MagmaOrder, isNew bool, previousStatus string) (string, string, string) {


### PR DESCRIPTION
> Empilha sobre a #133 (issue #131) — ambas mexem no mesmo trecho de `magma_execution.go`. O commit da #133 aparece aqui; se ela for mesclada antes, esta continua aplicando.

## O incidente

Ordem `8ea03637`, 06/09:

```
15:01:44  accepted        peer respondeu — conexão verificada e OK
15:03:18  comprador pagou
15:03:20  opening
15:04:35  error           "channel open failed: peer disconnected"
          → needs_attention, e ninguém mais tentou
15:27     UPDATE manual no banco → abriu em 18 segundos
```

O peer sumiu nos **96 segundos** entre aceitar e abrir. A partir daí: nada retoma `needs_attention`, e o guarda de financiamento **rejeita** esse estado — então nem o botão manual funcionava. Foram 23 minutos com o comprador já pago e o relógio correndo.

**A Amboss dá cerca de dois dias** para abrir depois do pagamento. Desistir em 75 segundos nunca foi o formato certo do problema.

## O que muda

Tudo do lado **pago** da venda, onde falhar custa `SELLER_FAILED_TO_OPEN_CHANNEL` e não apenas a venda.

**A abertura exige peer alcançável.** Antes conectávamos em best-effort, descartávamos o resultado e abríamos assim mesmo — produzindo exatamente o `peer disconnected`. Agora comprador inalcançável vira **espera**, não falha.

**Ordem paga que falhou volta para a fila**, enquanto a Amboss permitir.

`needs_attention` existe por um bom motivo: a abertura pode transmitir antes de o erro aparecer, e voltar para `accepted` às cegas financiaria o mesmo canal duas vezes. Por isso **o nó é consultado primeiro** — canal que já existe é adotado, não reaberto; só ordem sem nada financiado é retentada. É a mesma verificação que fiz à mão antes de recomendar o `UPDATE`.

**E esse estado deixa de bloquear o financiamento** quando o comprador pagou. A dívida não desapareceu porque uma tentativa falhou.

## Sobrevive a nós ficarmos offline

Nada disso vive em memória — sem timer, sem goroutine, sem contador em RAM. O trabalho é **re-derivado do banco a cada ciclo**, então um nó que ficou fora (restart, upgrade, falta de energia) retoma sozinho ao voltar. Que é justamente quando uma ordem paga mais precisa de alguém ainda tentando.

## O prazo vem da Amboss, não de chute

`MarketOrder.timeout` no endpoint novo traz um instante absoluto e **é populado** nas ordens vivas:

```
8ea03637  SELLER_SENT_TRANSACTION   timeout: 2026-09-08T19:01:35.000Z
2e8f851e  VALID_CHANNEL_OPENING     timeout: null
```

`OrderType.timeout` no endpoint antigo é string vazia em **todas** as ordens — por isso nunca tivemos esse dado.

Buscado isoladamente, sem migrar a query inteira de ordens: o tipo novo descarta campos que ainda usamos (`seller_close_side`, `buyer_close_side` e outros), e nada num prazo exige pagar esse preço agora.

Prazo ausente significa **desconhecido, nunca expirado** — com fallback de 24h, generoso de propósito para atravessar uma queda.

## Testes

`internal/server/magma_open_retry_test.go`, ancorados nos horários reais: minutos após a falha com dois dias de janela ainda retenta; um minuto restante ainda vale; passado o prazo, para. Prazo ausente cai no fallback, e o teste falha se alguém encurtar esse fallback para menos que uma queda típica.

`go test ./...` e `go vet ./internal/server/` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)