### PR TITLE
0.5.26-Beta: preserve LND-managed TLS during app lifecycle

### DIFF
--- a/lightningos-light/internal/appmanifest/lnbits.go
+++ b/lightningos-light/internal/appmanifest/lnbits.go
@@ -29,9 +29,8 @@ const (
 var lnbitsEnvKeyPattern = regexp.MustCompile(`^[A-Z_][A-Z0-9_]{0,127}$`)
 
 type LNbitsComposePaths struct {
-	DataDir      string
-	TLSCertPath  string
-	MacaroonPath string
+	DataDir string
+	LNDDir  string
 }
 
 // LNbitsImageForVariant selects only the stable official LNbits image pinned
@@ -169,7 +168,10 @@ func ValidateLNbitsEnv(raw []byte) error {
 // networking lets LNbits reach LND's loopback-only REST listener without
 // changing lnd.conf, rotating LND-managed TLS material, or exposing REST on a
 // Docker bridge. The container remains non-root, capability-free, read-only,
-// and receives only its dedicated macaroon and a public certificate copy.
+// and receives a narrow read-only LND directory containing only its dedicated
+// macaroon and the public certificate mirrored by the privileged broker. The
+// directory mount lets certificate replacement remain visible to the running
+// container without exposing the native LND data directory.
 func LNbitsCompose(paths LNbitsComposePaths) string {
 	return fmt.Sprintf(`services:
   lnbits:
@@ -202,9 +204,8 @@ func LNbitsCompose(paths LNbitsComposePaths) string {
       - /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777
     volumes:
       - %s:/app/data:rw
-      - %s:/etc/lnd/tls.cert:ro
-      - %s:/etc/lnd/lnbits.macaroon:ro
+      - %s:/etc/lnd:ro
 
 `, LNbitsImage, LNbitsContainerUID, LNbitsContainerGID, LNbitsStopTimeout,
-		paths.DataDir, paths.TLSCertPath, paths.MacaroonPath)
+		paths.DataDir, paths.LNDDir)
 }

--- a/lightningos-light/internal/appmanifest/lnbits.go
+++ b/lightningos-light/internal/appmanifest/lnbits.go
@@ -55,7 +55,7 @@ func LNbitsImageVariants() []AppImageVariant {
 func LNbitsManagedEnv() [][2]string {
 	return [][2]string{
 		{"LNBITS_BACKEND_WALLET_CLASS", "LndRestWallet"},
-		{"LND_REST_ENDPOINT", "https://host.docker.internal:8080/"},
+		{"LND_REST_ENDPOINT", "https://127.0.0.1:8080/"},
 		{"LND_REST_CERT", "/etc/lnd/" + LNbitsTLSCertFile},
 		{"LND_REST_MACAROON", "/etc/lnd/" + LNbitsMacaroonFile},
 		{"LNBITS_DATA_FOLDER", "/app/data"},
@@ -165,9 +165,11 @@ func ValidateLNbitsEnv(raw []byte) error {
 	return nil
 }
 
-// LNbitsCompose returns the only Compose document the broker accepts. The
-// application has no Docker socket or host namespace access; its two LND
-// inputs are individual read-only files and its root filesystem is read-only.
+// LNbitsCompose returns the only Compose document the broker accepts. Host
+// networking lets LNbits reach LND's loopback-only REST listener without
+// changing lnd.conf, rotating LND-managed TLS material, or exposing REST on a
+// Docker bridge. The container remains non-root, capability-free, read-only,
+// and receives only its dedicated macaroon and a public certificate copy.
 func LNbitsCompose(paths LNbitsComposePaths) string {
 	return fmt.Sprintf(`services:
   lnbits:
@@ -182,16 +184,13 @@ func LNbitsCompose(paths LNbitsComposePaths) string {
       - ALL
     security_opt:
       - no-new-privileges:true
+    network_mode: host
     env_file:
       - ./.env
     environment:
       HOME: /app/data
       XDG_CACHE_HOME: /app/data/.cache
       PYTHONDONTWRITEBYTECODE: "1"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    ports:
-      - "%d:%d"
     command:
       - /app/.venv/bin/lnbits
       - --port
@@ -206,9 +205,6 @@ func LNbitsCompose(paths LNbitsComposePaths) string {
       - %s:/etc/lnd/tls.cert:ro
       - %s:/etc/lnd/lnbits.macaroon:ro
 
-networks:
-  default:
-    name: lnbits_default
 `, LNbitsImage, LNbitsContainerUID, LNbitsContainerGID, LNbitsStopTimeout,
-		LNbitsPort, LNbitsPort, paths.DataDir, paths.TLSCertPath, paths.MacaroonPath)
+		paths.DataDir, paths.TLSCertPath, paths.MacaroonPath)
 }

--- a/lightningos-light/internal/appmanifest/lnbits_test.go
+++ b/lightningos-light/internal/appmanifest/lnbits_test.go
@@ -36,7 +36,7 @@ func TestNormalizeLNbitsEnvPreservesCustomSettingsAndScrubsLegacyCredentials(t *
 	got := string(normalized)
 	for _, required := range []string{
 		"LNBITS_SITE_TITLE=Preserved Node\n",
-		"LND_REST_ENDPOINT=https://host.docker.internal:8080/\n",
+		"LND_REST_ENDPOINT=https://127.0.0.1:8080/\n",
 		"LND_REST_MACAROON=/etc/lnd/lnbits.macaroon\n",
 		"AUTH_HTTPS_ONLY=false\n",
 	} {
@@ -69,7 +69,7 @@ func TestValidateLNbitsEnvRejectsRuntimeAndCredentialOverrides(t *testing.T) {
 
 func TestValidateLNbitsEnvRejectsManagedDriftAndDuplicates(t *testing.T) {
 	base := string(canonicalLNbitsEnvForTest())
-	if err := ValidateLNbitsEnv([]byte(strings.Replace(base, "LND_REST_ENDPOINT=https://host.docker.internal:8080/", "LND_REST_ENDPOINT=https://elsewhere:8080/", 1))); err == nil {
+	if err := ValidateLNbitsEnv([]byte(strings.Replace(base, "LND_REST_ENDPOINT=https://127.0.0.1:8080/", "LND_REST_ENDPOINT=https://elsewhere:8080/", 1))); err == nil {
 		t.Fatal("expected managed endpoint drift to be rejected")
 	}
 	if err := ValidateLNbitsEnv([]byte(base + "LNBITS_PORT=5000\n")); err == nil {
@@ -89,16 +89,16 @@ func TestLNbitsComposeClosesRuntimeAndMountsOnlyDedicatedCredential(t *testing.T
 		"read_only: true",
 		"cap_drop:\n      - ALL",
 		"no-new-privileges:true",
+		"network_mode: host",
 		"/apps-data/lnbits/data:/app/data:rw",
 		"/snapshot/lnbits/lnd/tls.cert:/etc/lnd/tls.cert:ro",
 		"/snapshot/lnbits/lnd/lnbits.macaroon:/etc/lnd/lnbits.macaroon:ro",
-		"name: lnbits_default",
 	} {
 		if !strings.Contains(compose, required) {
 			t.Fatalf("compose missing %q\n%s", required, compose)
 		}
 	}
-	for _, forbidden := range []string{"admin.macaroon", "/data/lnd", "/var/run/docker.sock", "privileged: true", "network_mode: host"} {
+	for _, forbidden := range []string{"admin.macaroon", "/data/lnd", "/var/run/docker.sock", "privileged: true", "host.docker.internal", "ports:"} {
 		if strings.Contains(compose, forbidden) {
 			t.Fatalf("compose contains forbidden input %q\n%s", forbidden, compose)
 		}

--- a/lightningos-light/internal/appmanifest/lnbits_test.go
+++ b/lightningos-light/internal/appmanifest/lnbits_test.go
@@ -79,9 +79,8 @@ func TestValidateLNbitsEnvRejectsManagedDriftAndDuplicates(t *testing.T) {
 
 func TestLNbitsComposeClosesRuntimeAndMountsOnlyDedicatedCredential(t *testing.T) {
 	compose := LNbitsCompose(LNbitsComposePaths{
-		DataDir:      "/apps-data/lnbits/data",
-		TLSCertPath:  "/snapshot/lnbits/lnd/tls.cert",
-		MacaroonPath: "/snapshot/lnbits/lnd/lnbits.macaroon",
+		DataDir: "/apps-data/lnbits/data",
+		LNDDir:  "/snapshot/lnbits/lnd",
 	})
 	for _, required := range []string{
 		"image: " + LNbitsImage,
@@ -91,8 +90,7 @@ func TestLNbitsComposeClosesRuntimeAndMountsOnlyDedicatedCredential(t *testing.T
 		"no-new-privileges:true",
 		"network_mode: host",
 		"/apps-data/lnbits/data:/app/data:rw",
-		"/snapshot/lnbits/lnd/tls.cert:/etc/lnd/tls.cert:ro",
-		"/snapshot/lnbits/lnd/lnbits.macaroon:/etc/lnd/lnbits.macaroon:ro",
+		"/snapshot/lnbits/lnd:/etc/lnd:ro",
 	} {
 		if !strings.Contains(compose, required) {
 			t.Fatalf("compose missing %q\n%s", required, compose)

--- a/lightningos-light/internal/appmanifest/lndg.go
+++ b/lightningos-light/internal/appmanifest/lndg.go
@@ -80,7 +80,9 @@ if [ -s "$SQLITE_FILE" ]; then
   legacy_sqlite=true
 fi
 
+fresh_settings=false
 if [ ! -f "$SETTINGS_FILE" ]; then
+  fresh_settings=true
   python initialize.py -d -net "$LNDG_NETWORK" -rpc "$LNDG_RPC_SERVER" -dir "$LNDG_LND_DIR" -tls "$LNDG_TLS_PATH" -mcrn "$LNDG_MACAROON_PATH" -lnddb "$LNDG_DATABASE_PATH" -u "$LNDG_ADMIN_USER" --adminpw="$LNDG_ADMIN_PASSWORD" -wn -f
 fi
 
@@ -92,10 +94,18 @@ if [ "$legacy_sqlite" = true ] && [ ! -f "$MIGRATION_MARKER" ]; then
   postgres_schema=$(PGPASSWORD="$LNDG_DB_PASSWORD" psql -h lndg-db -U lndg -d lndg -Atc "select to_regclass('public.django_migrations');")
   if [ ! -f "$MIGRATION_FIXTURE" ]; then
     if [ -n "$postgres_schema" ]; then
-      echo "Refusing automatic SQLite import into an initialized PostgreSQL schema" >&2
-      exit 1
-    fi
-    SETTINGS_FILE="$SETTINGS_FILE" SQLITE_SETTINGS_FILE="$SQLITE_SETTINGS_FILE" SQLITE_FILE="$SQLITE_FILE" python - <<'PY'
+      if grep -q "django.db.backends.postgresql_psycopg2" "$SETTINGS_FILE"; then
+        # A previous clean bootstrap already selected and initialized
+        # PostgreSQL. initialize.py also leaves a framework-only SQLite file;
+        # do not reinterpret that file as legacy data on the next start.
+        umask 077
+        : > "$MIGRATION_MARKER"
+      else
+        echo "Refusing automatic SQLite import into an initialized PostgreSQL schema" >&2
+        exit 1
+      fi
+    else
+      SETTINGS_FILE="$SETTINGS_FILE" SQLITE_SETTINGS_FILE="$SQLITE_SETTINGS_FILE" SQLITE_FILE="$SQLITE_FILE" python - <<'PY'
 import os
 
 source = os.environ["SETTINGS_FILE"]
@@ -127,12 +137,13 @@ raw = raw[:start] + replacement + raw[end+1:]
 with open(target, "w", encoding="utf-8") as f:
   f.write("\n".join(raw) + "\n")
 PY
-    umask 077
-    DJANGO_SETTINGS_MODULE=lndg.sqlite_migration_settings python manage.py dumpdata --natural-foreign --natural-primary \
-      --exclude contenttypes --exclude auth.permission --exclude admin.logentry --exclude sessions \
-      > "$MIGRATION_FIXTURE.tmp"
-    mv "$MIGRATION_FIXTURE.tmp" "$MIGRATION_FIXTURE"
-    rm -f "$SQLITE_SETTINGS_FILE"
+      umask 077
+      DJANGO_SETTINGS_MODULE=lndg.sqlite_migration_settings python manage.py dumpdata --natural-foreign --natural-primary \
+        --exclude contenttypes --exclude auth.permission --exclude admin.logentry --exclude sessions \
+        > "$MIGRATION_FIXTURE.tmp"
+      mv "$MIGRATION_FIXTURE.tmp" "$MIGRATION_FIXTURE"
+      rm -f "$SQLITE_SETTINGS_FILE"
+    fi
   fi
 fi
 
@@ -218,6 +229,13 @@ with open(path, "w", encoding="utf-8") as f:
 PY
 
 python manage.py migrate
+if [ "$fresh_settings" = true ] && [ ! -f "$MIGRATION_MARKER" ]; then
+  # initialize.py may create db.sqlite3 even though this clean installation
+  # immediately switches to PostgreSQL. Mark that bootstrap as complete so a
+  # later restart never mistakes the generated file for a legacy database.
+  umask 077
+  : > "$MIGRATION_MARKER"
+fi
 if [ -f "$MIGRATION_FIXTURE" ] && [ ! -f "$MIGRATION_MARKER" ]; then
   python manage.py loaddata "$MIGRATION_FIXTURE"
   umask 077

--- a/lightningos-light/internal/appmanifest/lndg.go
+++ b/lightningos-light/internal/appmanifest/lndg.go
@@ -101,8 +101,37 @@ if [ "$legacy_sqlite" = true ] && [ ! -f "$MIGRATION_MARKER" ]; then
         umask 077
         : > "$MIGRATION_MARKER"
       else
-        echo "Refusing automatic SQLite import into an initialized PostgreSQL schema" >&2
-        exit 1
+        sqlite_app_rows=$(SQLITE_FILE="$SQLITE_FILE" python - <<'PY'
+import os
+import sqlite3
+
+database = sqlite3.connect(os.environ["SQLITE_FILE"])
+try:
+    tables = [
+        row[0]
+        for row in database.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'gui_%'"
+        )
+    ]
+    total = 0
+    for table in tables:
+        escaped = table.replace('"', '""')
+        total += database.execute(f'SELECT COUNT(*) FROM "{escaped}"').fetchone()[0]
+    print(total)
+finally:
+    database.close()
+PY
+)
+        if [ "$sqlite_app_rows" = "0" ]; then
+          # Container recreation restores the image's SQLite settings. An
+          # empty gui_* dataset is the harmless bootstrap database left by
+          # initialize.py, so preserve the already initialized PostgreSQL DB.
+          umask 077
+          : > "$MIGRATION_MARKER"
+        else
+          echo "Refusing automatic SQLite import into an initialized PostgreSQL schema" >&2
+          exit 1
+        fi
       fi
     else
       SETTINGS_FILE="$SETTINGS_FILE" SQLITE_SETTINGS_FILE="$SQLITE_SETTINGS_FILE" SQLITE_FILE="$SQLITE_FILE" python - <<'PY'

--- a/lightningos-light/internal/appmanifest/lndg_test.go
+++ b/lightningos-light/internal/appmanifest/lndg_test.go
@@ -138,6 +138,8 @@ func TestLNDgEntrypointMigratesOnlyLegacySQLiteIntoEmptyPostgres(t *testing.T) {
 		`fresh_settings=true`,
 		`select to_regclass('public.django_migrations');`,
 		`grep -q "django.db.backends.postgresql_psycopg2" "$SETTINGS_FILE"`,
+		`name LIKE 'gui_%'`,
+		`if [ "$sqlite_app_rows" = "0" ]`,
 		`Refusing automatic SQLite import into an initialized PostgreSQL schema`,
 		`DJANGO_SETTINGS_MODULE=lndg.sqlite_migration_settings python manage.py dumpdata`,
 		`'ENGINE': 'django.db.backends.sqlite3'`,

--- a/lightningos-light/internal/appmanifest/lndg_test.go
+++ b/lightningos-light/internal/appmanifest/lndg_test.go
@@ -123,7 +123,7 @@ func TestLNDgEntrypointAlwaysSelectsPostgres(t *testing.T) {
 		}
 	}
 	csrfEnd := strings.Index(LNDgEntrypoint, "      csrf_trusted.append(f\"{scheme}://{host}:8889\")")
-	replacement := strings.Index(LNDgEntrypoint, "django.db.backends.postgresql_psycopg2")
+	replacement := strings.LastIndex(LNDgEntrypoint, "django.db.backends.postgresql_psycopg2")
 	if csrfEnd < 0 || replacement <= csrfEnd {
 		t.Fatal("PostgreSQL replacement is unexpectedly nested in the CSRF fallback")
 	}
@@ -135,7 +135,9 @@ func TestLNDgEntrypointAlwaysSelectsPostgres(t *testing.T) {
 func TestLNDgEntrypointMigratesOnlyLegacySQLiteIntoEmptyPostgres(t *testing.T) {
 	for _, required := range []string{
 		`if [ -s "$SQLITE_FILE" ]`,
+		`fresh_settings=true`,
 		`select to_regclass('public.django_migrations');`,
+		`grep -q "django.db.backends.postgresql_psycopg2" "$SETTINGS_FILE"`,
 		`Refusing automatic SQLite import into an initialized PostgreSQL schema`,
 		`DJANGO_SETTINGS_MODULE=lndg.sqlite_migration_settings python manage.py dumpdata`,
 		`'ENGINE': 'django.db.backends.sqlite3'`,

--- a/lightningos-light/internal/appmanifest/security_inventory_test.go
+++ b/lightningos-light/internal/appmanifest/security_inventory_test.go
@@ -68,7 +68,7 @@ func TestComposeCatalogSecurityInventory(t *testing.T) {
 		LNDgID + "/lndg-db": {noNewPrivileges: true, exception: "official Postgres entrypoint initializes the dedicated LNDg database volume before dropping privileges"},
 		LNDgID + "/lndg":    {nonRoot: true, capDropAll: true, noNewPrivileges: true, exception: "LNDg still needs writable application paths during startup; mounts and LND credentials remain narrowly scoped"},
 
-		LNbitsID + "/lnbits":   hardened,
+		LNbitsID + "/lnbits":   {nonRoot: true, readOnly: true, capDropAll: true, noNewPrivileges: true, allowHostNetwork: true, exception: "host networking is required to reach LND's loopback-only REST endpoint without mutating LND configuration or TLS material"},
 		ElectrsID + "/electrs": hardened,
 
 		MempoolID + "/mempool-web": hardened,

--- a/lightningos-light/internal/appmanifest/security_inventory_test.go
+++ b/lightningos-light/internal/appmanifest/security_inventory_test.go
@@ -215,7 +215,7 @@ func testCatalogComposeDocuments(t *testing.T) []catalogComposeDocument {
 		{appID: BitcoinCoreID, raw: bitcoin},
 		{appID: BTCPayID, raw: BTCPayExecutionCompose(btcpayPaths, true, true)},
 		{appID: LNDgID, raw: LNDgCompose(LNDgComposePaths{DataDir: "/data/lndg", PgDir: "/data/lndg-postgres", LogPath: "/data/lndg/controller.log", LndDir: "/snapshot/lndg/lnd", ChannelDBPath: "/snapshot/lndg/lnd/channel.db", EntrypointPath: "/snapshot/lndg/entrypoint.sh"})},
-		{appID: LNbitsID, raw: LNbitsCompose(LNbitsComposePaths{DataDir: "/data/lnbits", TLSCertPath: "/snapshot/lnbits/tls.cert", MacaroonPath: "/snapshot/lnbits/lnbits.macaroon"})},
+		{appID: LNbitsID, raw: LNbitsCompose(LNbitsComposePaths{DataDir: "/data/lnbits", LNDDir: "/snapshot/lnbits/lnd"})},
 		{appID: ElectrsID, raw: electrs},
 		{appID: MempoolID, raw: mempool},
 		{appID: FedimintGuardianID, raw: guardian},

--- a/lightningos-light/internal/lndclient/client.go
+++ b/lightningos-light/internal/lndclient/client.go
@@ -861,6 +861,13 @@ func (c *Client) sharedConn(ctx context.Context, role grpcConnRole) (*grpc.Clien
 	if c.grpcConns == nil {
 		c.grpcConns = make(map[grpcConnRole]*grpc.ClientConn)
 	}
+	// Tests and narrowly scoped in-process clients may inject an already-open
+	// shared connection without a certificate fingerprint. Production shared
+	// connections created below always record one, so only reuse this legacy
+	// state instead of trying to read an unrelated or empty TLS path.
+	if conn := c.grpcConns[role]; conn != nil && !c.grpcTLSKnown {
+		return conn, nil
+	}
 	fingerprint, err := c.tlsCertificateFingerprint()
 	if err != nil {
 		return nil, err

--- a/lightningos-light/internal/lndclient/client.go
+++ b/lightningos-light/internal/lndclient/client.go
@@ -3,6 +3,7 @@ package lndclient
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
@@ -77,6 +78,8 @@ type Client struct {
 	nodeAliasCache     map[string]nodeAliasCacheEntry
 	grpcMu             sync.Mutex
 	grpcConns          map[grpcConnRole]*grpc.ClientConn
+	grpcTLSFingerprint [sha256.Size]byte
+	grpcTLSKnown       bool
 }
 
 type nodeAliasCacheEntry struct {
@@ -804,6 +807,14 @@ func (c *Client) dialOptions(withMacaroon bool) ([]grpc.DialOption, error) {
 	return opts, nil
 }
 
+func (c *Client) tlsCertificateFingerprint() ([sha256.Size]byte, error) {
+	raw, err := os.ReadFile(c.cfg.LND.TLSCertPath)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256(raw), nil
+}
+
 func (c *Client) dial(ctx context.Context, withMacaroon bool) (*grpc.ClientConn, error) {
 	opts, err := c.dialOptions(withMacaroon)
 	if err != nil {
@@ -850,6 +861,13 @@ func (c *Client) sharedConn(ctx context.Context, role grpcConnRole) (*grpc.Clien
 	if c.grpcConns == nil {
 		c.grpcConns = make(map[grpcConnRole]*grpc.ClientConn)
 	}
+	fingerprint, err := c.tlsCertificateFingerprint()
+	if err != nil {
+		return nil, err
+	}
+	if c.grpcTLSKnown && fingerprint != c.grpcTLSFingerprint {
+		_ = c.closeSharedConnsLocked("LND TLS certificate changed")
+	}
 	if conn := c.grpcConns[role]; conn != nil {
 		return conn, nil
 	}
@@ -863,6 +881,8 @@ func (c *Client) sharedConn(ctx context.Context, role grpcConnRole) (*grpc.Clien
 		return nil, err
 	}
 	c.grpcConns[role] = conn
+	c.grpcTLSFingerprint = fingerprint
+	c.grpcTLSKnown = true
 	if c.logger != nil {
 		c.logger.Printf("lndclient: shared grpc connection opened role=%s host=%s", role, c.cfg.LND.GRPCHost)
 	}
@@ -875,7 +895,10 @@ func (c *Client) Close() error {
 	}
 	c.grpcMu.Lock()
 	defer c.grpcMu.Unlock()
+	return c.closeSharedConnsLocked("client closed")
+}
 
+func (c *Client) closeSharedConnsLocked(reason string) error {
 	var firstErr error
 	for role, conn := range c.grpcConns {
 		if conn == nil {
@@ -885,10 +908,11 @@ func (c *Client) Close() error {
 			firstErr = err
 		}
 		if c.logger != nil {
-			c.logger.Printf("lndclient: shared grpc connection closed role=%s", role)
+			c.logger.Printf("lndclient: shared grpc connection closed role=%s reason=%s", role, reason)
 		}
 		delete(c.grpcConns, role)
 	}
+	c.grpcTLSKnown = false
 	return firstErr
 }
 

--- a/lightningos-light/internal/lndclient/client_shared_tls_test.go
+++ b/lightningos-light/internal/lndclient/client_shared_tls_test.go
@@ -1,0 +1,66 @@
+package lndclient
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"lightningos-light/internal/config"
+)
+
+func TestSharedConnectionIsReplacedAfterLNDCertificateRotation(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.cert")
+	if err := os.WriteFile(certPath, testClientCertificate(t, 1), 0600); err != nil {
+		t.Fatal(err)
+	}
+	client := New(&config.Config{LND: config.LNDConfig{
+		GRPCHost:    "127.0.0.1:1",
+		TLSCertPath: certPath,
+	}}, nil)
+	t.Cleanup(func() { _ = client.Close() })
+
+	first, err := client.sharedConn(context.Background(), grpcRoleWalletUnlocker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certPath, testClientCertificate(t, 2), 0600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := client.sharedConn(context.Background(), grpcRoleWalletUnlocker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("shared gRPC connection retained credentials for the old LND certificate")
+	}
+}
+
+func testClientCertificate(t *testing.T, serial int64) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		DNSNames:     []string{"localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}

--- a/lightningos-light/internal/privileged/apps.go
+++ b/lightningos-light/internal/privileged/apps.go
@@ -838,23 +838,6 @@ func (manager *ComposeAppManager) Lifecycle(ctx context.Context, appID string, a
 			if err := manager.migrateLNbitsLegacySettings(ctx); err != nil {
 				return err
 			}
-			if err := manager.ensureLNbitsHostAccess(ctx); err != nil {
-				return err
-			}
-			// A clean install does not have lnbits_default yet. Materialize the
-			// reviewed container and its network without starting it, so the
-			// broker can bind the internal LND REST firewall rule to the actual
-			// Compose subnet before LNbits becomes reachable.
-			createArgs := append(append([]string(nil), args...), "create")
-			if _, err := manager.Runner.Run(ctx, commandPath, createArgs...); err != nil {
-				return errors.New("LNbits container preparation failed")
-			}
-			if err := manager.ensureLNbitsInternalFirewall(ctx); err != nil {
-				return err
-			}
-			if err := manager.refreshLNbitsSnapshotCertificate(snapshot.root); err != nil {
-				return err
-			}
 		}
 		if manifest.ID == appmanifest.FedimintGuardianID || manifest.ID == appmanifest.FedimintGatewayID {
 			if err := manager.migrateLegacyFedimint(ctx, manifest.ID); err != nil {

--- a/lightningos-light/internal/privileged/apps.go
+++ b/lightningos-light/internal/privileged/apps.go
@@ -578,6 +578,7 @@ func (manager *ComposeAppManager) Lifecycle(ctx context.Context, appID string, a
 	var cleanup func()
 	var images []string
 	var legacyBitcoin *preparedLegacyBitcoinMigration
+	var lnbitsRESTEndpoint string
 	switch manifest.ID {
 	case appmanifest.CPUMinerID:
 		composeRaw, envRaw, err := manager.validatedCPUMinerFiles()
@@ -677,6 +678,7 @@ func (manager *ComposeAppManager) Lifecycle(ctx context.Context, appID string, a
 			return err
 		}
 		images = []string{appmanifest.LNbitsImage}
+		lnbitsRESTEndpoint = files.restEndpoint
 		if dryRun {
 			return nil
 		}
@@ -835,7 +837,7 @@ func (manager *ComposeAppManager) Lifecycle(ctx context.Context, appID string, a
 			if err := prepareLNbitsWritableData(filepath.Join(appsDataRoot, appmanifest.LNbitsID, "data")); err != nil {
 				return errors.New("LNbits writable data preparation failed")
 			}
-			if err := manager.migrateLNbitsLegacySettings(ctx); err != nil {
+			if err := manager.migrateLNbitsLegacySettings(ctx, lnbitsRESTEndpoint); err != nil {
 				return err
 			}
 		}

--- a/lightningos-light/internal/privileged/apps.go
+++ b/lightningos-light/internal/privileged/apps.go
@@ -1194,8 +1194,11 @@ func (manager *ComposeAppManager) Inspect(ctx context.Context, appID string) (Ap
 		}
 		return manager.inspectCatalogRuntime(ctx, manifest, false)
 	case appmanifest.LNbitsID:
-		_, err := manager.validatedLNbitsFiles()
+		files, err := manager.validatedLNbitsFiles()
 		if err != nil {
+			return inspection, err
+		}
+		if err := manager.refreshLNbitsSnapshotCertificate(files.certificateRaw); err != nil {
 			return inspection, err
 		}
 		return manager.inspectCatalogRuntime(ctx, manifest, false)

--- a/lightningos-light/internal/privileged/fedimint.go
+++ b/lightningos-light/internal/privileged/fedimint.go
@@ -327,9 +327,8 @@ func (manager *ComposeAppManager) ensureFedimintGatewayHostAccess(ctx context.Co
 		}
 	}
 	if changed || certificateNeedsRefresh {
-		if err := manager.removeLNDServerCertificate(); err != nil {
-			return err
-		}
+		// LND exclusively owns tls.cert and tls.key. Let its configured
+		// tlsautorefresh behavior manage certificate rotation on restart.
 		if _, err := manager.Runner.Run(ctx, systemctlPath, "restart", "lnd"); err != nil {
 			return errors.New("LND restart failed")
 		}

--- a/lightningos-light/internal/privileged/fedimint.go
+++ b/lightningos-light/internal/privileged/fedimint.go
@@ -341,16 +341,8 @@ func (manager *ComposeAppManager) refreshFedimintGatewaySnapshotCertificate(root
 	if lndRoot == "" {
 		lndRoot = defaultLNDDataRoot
 	}
-	var certificate []byte
-	var err error
-	for attempt := 0; attempt < 20; attempt++ {
-		certificate, err = readRegularFile(filepath.Join(lndRoot, "tls.cert"), 64*1024)
-		if err == nil && validateTLSCertificate(certificate) == nil {
-			break
-		}
-		time.Sleep(250 * time.Millisecond)
-	}
-	if err != nil || validateTLSCertificate(certificate) != nil {
+	certificate, err := manager.waitForLNDDockerHostCertificate(20, 250*time.Millisecond)
+	if err != nil {
 		return errors.New("LND certificate refresh failed")
 	}
 	target := filepath.Join(root, "lnd", appmanifest.FedimintGatewayTLSFile)

--- a/lightningos-light/internal/privileged/fedimint_test.go
+++ b/lightningos-light/internal/privileged/fedimint_test.go
@@ -94,6 +94,35 @@ func TestFedimintGatewaySnapshotUsesDedicatedCredentialAndClosedPaths(t *testing
 	}
 }
 
+func TestFedimintGatewaySnapshotFollowsLNDCertificateRotation(t *testing.T) {
+	fixture := writeTestFedimintGateway(t)
+	files, err := fixture.manager.validatedFedimintFiles(appmanifest.FedimintGatewayID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, _, err := fixture.manager.createFedimintSnapshot(appmanifest.FedimintGatewayID, files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(snapshot.root, "lnd", appmanifest.FedimintGatewayTLSFile), 0600); err != nil {
+		t.Fatal(err)
+	}
+	rotated := testLNDgCertificate(t, "host.docker.internal")
+	if err := os.WriteFile(filepath.Join(fixture.lndRoot, "tls.cert"), rotated, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.manager.refreshFedimintGatewaySnapshotCertificate(snapshot.root); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(snapshot.root, "lnd", appmanifest.FedimintGatewayTLSFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, rotated) {
+		t.Fatal("Fedimint Gateway snapshot did not follow the LND-owned certificate rotation")
+	}
+}
+
 func TestFedimintGatewayRejectsAdminMacaroonAndTamperedDeclaration(t *testing.T) {
 	fixture := writeTestFedimintGateway(t)
 	admin, _ := os.ReadFile(filepath.Join(fixture.lndRoot, "data", "chain", "bitcoin", "mainnet", "admin.macaroon"))

--- a/lightningos-light/internal/privileged/lnbits_runtime.go
+++ b/lightningos-light/internal/privileged/lnbits_runtime.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"lightningos-light/internal/appmanifest"
 )
@@ -311,6 +312,11 @@ func (manager *ComposeAppManager) ensureBTCPayLNDHostAccess(ctx context.Context)
 		// replace either file.
 		if _, err := manager.Runner.Run(ctx, systemctlPath, "restart", "lnd"); err != nil {
 			return errors.New("LND restart failed")
+		}
+		if certificateNeedsRefresh {
+			if _, err := manager.waitForLNDDockerHostCertificate(30, time.Second); err != nil {
+				return errors.New("LND certificate refresh failed")
+			}
 		}
 	}
 	return nil

--- a/lightningos-light/internal/privileged/lnbits_runtime.go
+++ b/lightningos-light/internal/privileged/lnbits_runtime.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -31,7 +32,7 @@ try:
         raise SystemExit(0)
     desired = {
         "lnbits_backend_wallet_class": "LndRestWallet",
-        "lnd_rest_endpoint": "https://127.0.0.1:8080/",
+        "lnd_rest_endpoint": os.environ["LND_REST_ENDPOINT"],
         "lnd_rest_cert": "/etc/lnd/tls.cert",
         "lnd_rest_macaroon": "/etc/lnd/lnbits.macaroon",
     }
@@ -65,6 +66,7 @@ type lnbitsValidatedFiles struct {
 	envRaw         []byte
 	certificateRaw []byte
 	macaroonRaw    []byte
+	restEndpoint   string
 }
 
 func (manager *ComposeAppManager) validatedLNbitsFiles() (lnbitsValidatedFiles, error) {
@@ -133,6 +135,10 @@ func (manager *ComposeAppManager) validatedLNbitsFiles() (lnbitsValidatedFiles, 
 	if bytes.Equal(macaroonRaw, adminRaw) {
 		return files, errors.New("LNbits LND credential must not be the admin macaroon")
 	}
+	restEndpoint, err := manager.resolveLNbitsRESTEndpoint()
+	if err != nil {
+		return files, err
+	}
 
 	composeRaw, err := readRegularFile(filepath.Join(appRoot, appmanifest.LNbitsComposeFile), 64*1024)
 	if err != nil {
@@ -147,7 +153,7 @@ func (manager *ComposeAppManager) validatedLNbitsFiles() (lnbitsValidatedFiles, 
 		return files, errors.New("LNbits compose manifest does not match the catalog")
 	}
 
-	return lnbitsValidatedFiles{envRaw: envRaw, certificateRaw: certificateRaw, macaroonRaw: macaroonRaw}, nil
+	return lnbitsValidatedFiles{envRaw: envRaw, certificateRaw: certificateRaw, macaroonRaw: macaroonRaw, restEndpoint: restEndpoint}, nil
 }
 
 func (manager *ComposeAppManager) createLNbitsSnapshot(files lnbitsValidatedFiles) (composeAppSnapshot, func(), error) {
@@ -197,6 +203,10 @@ func (manager *ComposeAppManager) createLNbitsSnapshot(files lnbitsValidatedFile
 		TLSCertPath:  certificatePath,
 		MacaroonPath: macaroonPath,
 	})
+	executionEnv, err := lnbitsExecutionEnv(files.envRaw, files.restEndpoint)
+	if err != nil {
+		return snapshot, func() {}, err
+	}
 	for _, file := range []struct {
 		path string
 		raw  []byte
@@ -204,7 +214,7 @@ func (manager *ComposeAppManager) createLNbitsSnapshot(files lnbitsValidatedFile
 		gid  int
 	}{
 		{composePath, []byte(compose), 0600, 0},
-		{envPath, files.envRaw, 0600, 0},
+		{envPath, executionEnv, 0600, 0},
 		{certificatePath, files.certificateRaw, 0640, appmanifest.LNbitsContainerGID},
 		{macaroonPath, files.macaroonRaw, 0640, appmanifest.LNbitsContainerGID},
 	} {
@@ -285,7 +295,7 @@ func (manager *ComposeAppManager) EnsureLNDHostAccess(ctx context.Context, appID
 	return manager.ensureBTCPayLNDHostAccess(ctx)
 }
 
-func (manager *ComposeAppManager) migrateLNbitsLegacySettings(ctx context.Context) error {
+func (manager *ComposeAppManager) migrateLNbitsLegacySettings(ctx context.Context, restEndpoint string) error {
 	appsDataRoot := manager.AppsDataRoot
 	if appsDataRoot == "" {
 		appsDataRoot = defaultAppsDataRoot
@@ -298,6 +308,7 @@ func (manager *ComposeAppManager) migrateLNbitsLegacySettings(ctx context.Contex
 		"--security-opt", "no-new-privileges",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777",
 		"-e", "HOME=/app/data", "-e", "PYTHONDONTWRITEBYTECODE=1",
+		"-e", "LND_REST_ENDPOINT="+restEndpoint,
 		"-v", dataDir+":/app/data:rw",
 		appmanifest.LNbitsImage,
 		"/app/.venv/bin/python", "-c", lnbitsSettingsMigrationScript,
@@ -305,6 +316,89 @@ func (manager *ComposeAppManager) migrateLNbitsLegacySettings(ctx context.Contex
 		return errors.New("LNbits legacy settings migration failed")
 	}
 	return nil
+}
+
+func (manager *ComposeAppManager) resolveLNbitsRESTEndpoint() (string, error) {
+	configPath := manager.LNDConfigPath
+	if configPath == "" {
+		configPath = defaultLNDConfigPath
+	}
+	raw, err := readRegularFile(configPath, 1024*1024)
+	if err != nil {
+		return "", errors.New("LND configuration is unavailable")
+	}
+	return selectLNbitsRESTEndpoint(string(raw))
+}
+
+func selectLNbitsRESTEndpoint(config string) (string, error) {
+	loopback := make([]string, 0, 2)
+	private := make([]string, 0, 2)
+	hasRESTListener := false
+	for _, line := range strings.Split(config, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "restlisten=") {
+			continue
+		}
+		hasRESTListener = true
+		address := strings.TrimSpace(strings.TrimPrefix(trimmed, "restlisten="))
+		host, port, err := net.SplitHostPort(address)
+		if err != nil || strings.TrimSpace(port) == "" {
+			continue
+		}
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			continue
+		}
+		host = strings.Trim(strings.TrimSpace(host), "[]")
+		switch host {
+		case "", "*", "0.0.0.0":
+			host = "127.0.0.1"
+		case "::":
+			host = "::1"
+		}
+		candidate := "https://" + net.JoinHostPort(host, port) + "/"
+		if strings.EqualFold(host, "localhost") {
+			loopback = append(loopback, candidate)
+			continue
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			continue
+		}
+		if ip.IsLoopback() {
+			loopback = append(loopback, candidate)
+		} else if ip.IsPrivate() {
+			private = append(private, candidate)
+		}
+	}
+	if len(loopback) > 0 {
+		return loopback[0], nil
+	}
+	if len(private) > 0 {
+		return private[0], nil
+	}
+	if !hasRESTListener {
+		return "https://127.0.0.1:8080/", nil
+	}
+	return "", errors.New("LND REST has no safe local listener for LNbits")
+}
+
+func lnbitsExecutionEnv(raw []byte, restEndpoint string) ([]byte, error) {
+	if strings.TrimSpace(restEndpoint) == "" {
+		return nil, errors.New("LNbits LND REST endpoint is unavailable")
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	replaced := false
+	for index, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "LND_REST_ENDPOINT=") {
+			lines[index] = "LND_REST_ENDPOINT=" + restEndpoint
+			replaced = true
+		}
+	}
+	if !replaced {
+		return nil, errors.New("LNbits LND REST endpoint setting is unavailable")
+	}
+	return []byte(strings.Join(lines, "\n") + "\n"), nil
 }
 
 func updateLNDRESTHostAccessOptions(lines []string, gateway string) ([]string, bool) {

--- a/lightningos-light/internal/privileged/lnbits_runtime.go
+++ b/lightningos-light/internal/privileged/lnbits_runtime.go
@@ -100,7 +100,6 @@ func (manager *ComposeAppManager) validatedLNbitsFiles() (lnbitsValidatedFiles, 
 		}
 	}
 	if err := validateSnapshotDirectoryEntries(lndDir, map[string]bool{
-		appmanifest.LNbitsTLSCertFile:  true,
 		appmanifest.LNbitsMacaroonFile: true,
 	}); err != nil {
 		return files, errors.New("LNbits LND declaration contains unexpected assets")
@@ -115,7 +114,7 @@ func (manager *ComposeAppManager) validatedLNbitsFiles() (lnbitsValidatedFiles, 
 		return files, errors.New("LNbits environment does not match the catalog")
 	}
 
-	certificatePath := filepath.Join(lndDir, appmanifest.LNbitsTLSCertFile)
+	certificatePath := filepath.Join(lndDataRoot, appmanifest.LNbitsTLSCertFile)
 	certificateRaw, err := readRegularFile(certificatePath, maxLNbitsCredentialBytes)
 	if err != nil || validateTLSCertificate(certificateRaw) != nil {
 		return files, errors.New("LNbits LND certificate is invalid")
@@ -145,9 +144,8 @@ func (manager *ComposeAppManager) validatedLNbitsFiles() (lnbitsValidatedFiles, 
 		return files, errors.New("LNbits compose manifest is unavailable")
 	}
 	expectedCompose := appmanifest.LNbitsCompose(appmanifest.LNbitsComposePaths{
-		DataDir:      dataDir,
-		TLSCertPath:  certificatePath,
-		MacaroonPath: macaroonPath,
+		DataDir: dataDir,
+		LNDDir:  lndDir,
 	})
 	if !bytes.Equal(composeRaw, []byte(expectedCompose)) {
 		return files, errors.New("LNbits compose manifest does not match the catalog")
@@ -199,9 +197,8 @@ func (manager *ComposeAppManager) createLNbitsSnapshot(files lnbitsValidatedFile
 	certificatePath := filepath.Join(lndDir, appmanifest.LNbitsTLSCertFile)
 	macaroonPath := filepath.Join(lndDir, appmanifest.LNbitsMacaroonFile)
 	compose := appmanifest.LNbitsCompose(appmanifest.LNbitsComposePaths{
-		DataDir:      filepath.Join(appsDataRoot, appmanifest.LNbitsID, "data"),
-		TLSCertPath:  certificatePath,
-		MacaroonPath: macaroonPath,
+		DataDir: filepath.Join(appsDataRoot, appmanifest.LNbitsID, "data"),
+		LNDDir:  lndDir,
 	})
 	executionEnv, err := lnbitsExecutionEnv(files.envRaw, files.restEndpoint)
 	if err != nil {
@@ -228,6 +225,43 @@ func (manager *ComposeAppManager) createLNbitsSnapshot(files lnbitsValidatedFile
 		}
 	}
 	return composeAppSnapshot{root: snapshotRoot, composePath: composePath, envPath: envPath}, func() {}, nil
+}
+
+// refreshLNbitsSnapshotCertificate keeps the running container's narrow LND
+// directory aligned with the certificate currently owned by native LND. The
+// directory, rather than the individual file, is mounted into the container so
+// an atomic replacement remains visible after LND renews tls.cert.
+func (manager *ComposeAppManager) refreshLNbitsSnapshotCertificate(certificateRaw []byte) error {
+	privilegedAppsRoot := manager.PrivilegedAppsRoot
+	if privilegedAppsRoot == "" {
+		privilegedAppsRoot = defaultPrivilegedAppsRoot
+	}
+	lndDir := filepath.Join(privilegedAppsRoot, appmanifest.LNbitsID, appmanifest.LNbitsLNDDir)
+	if err := validateRegularDirectory(lndDir); err != nil {
+		// An app that has been declared but never started has no execution
+		// snapshot yet. Lifecycle start will create it with the current cert.
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.New("LNbits LND snapshot is invalid")
+	}
+	if err := validateExecutionSnapshotDirectoryEntries(lndDir, map[string]bool{
+		appmanifest.LNbitsTLSCertFile:  true,
+		appmanifest.LNbitsMacaroonFile: true,
+	}); err != nil {
+		return errors.New("LNbits LND snapshot contains unexpected assets")
+	}
+	certificatePath := filepath.Join(lndDir, appmanifest.LNbitsTLSCertFile)
+	if current, err := readRegularFile(certificatePath, maxLNbitsCredentialBytes); err == nil && bytes.Equal(current, certificateRaw) {
+		return nil
+	}
+	if err := writeAtomicRegularFile(certificatePath, certificateRaw, 0640); err != nil {
+		return errors.New("failed to refresh LNbits LND certificate")
+	}
+	if err := setPrivilegedPathGroup(certificatePath, appmanifest.LNbitsContainerGID); err != nil {
+		return errors.New("failed to assign LNbits certificate group")
+	}
+	return nil
 }
 
 func (manager *ComposeAppManager) removeLNbitsExecutionSnapshot(snapshotRoot string) error {

--- a/lightningos-light/internal/privileged/lnbits_runtime.go
+++ b/lightningos-light/internal/privileged/lnbits_runtime.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"lightningos-light/internal/appmanifest"
 )
@@ -32,7 +31,7 @@ try:
         raise SystemExit(0)
     desired = {
         "lnbits_backend_wallet_class": "LndRestWallet",
-        "lnd_rest_endpoint": "https://host.docker.internal:8080/",
+        "lnd_rest_endpoint": "https://127.0.0.1:8080/",
         "lnd_rest_cert": "/etc/lnd/tls.cert",
         "lnd_rest_macaroon": "/etc/lnd/lnbits.macaroon",
     }
@@ -236,49 +235,14 @@ func (manager *ComposeAppManager) removeLNbitsExecutionSnapshot(snapshotRoot str
 	return os.RemoveAll(expectedRoot)
 }
 
-func (manager *ComposeAppManager) refreshLNbitsSnapshotCertificate(snapshotRoot string) error {
-	privilegedAppsRoot := manager.PrivilegedAppsRoot
-	if privilegedAppsRoot == "" {
-		privilegedAppsRoot = defaultPrivilegedAppsRoot
-	}
-	expectedRoot := filepath.Join(filepath.Clean(privilegedAppsRoot), appmanifest.LNbitsID)
-	if filepath.Clean(snapshotRoot) != expectedRoot {
-		return errors.New("invalid LNbits execution snapshot")
-	}
-	lndDataRoot := manager.LNDDataRoot
-	if lndDataRoot == "" {
-		lndDataRoot = defaultLNDDataRoot
-	}
-	var certificateRaw []byte
-	var err error
-	for attempt := 0; attempt < 30; attempt++ {
-		certificateRaw, err = readRegularFile(filepath.Join(lndDataRoot, "tls.cert"), maxLNbitsCredentialBytes)
-		if err == nil && validateTLSCertificate(certificateRaw) == nil {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-	if err != nil || validateTLSCertificate(certificateRaw) != nil {
-		return errors.New("refreshed LND certificate is unavailable")
-	}
-	target := filepath.Join(expectedRoot, appmanifest.LNbitsLNDDir, appmanifest.LNbitsTLSCertFile)
-	if err := writeAtomicRegularFile(target, certificateRaw, 0640); err != nil {
-		return errors.New("failed to refresh LNbits certificate snapshot")
-	}
-	if err := setPrivilegedPathGroup(target, appmanifest.LNbitsContainerGID); err != nil {
-		return errors.New("failed to assign LNbits certificate group")
-	}
-	return nil
-}
-
-func (manager *ComposeAppManager) ensureLNbitsHostAccess(ctx context.Context) error {
+func (manager *ComposeAppManager) ensureBTCPayLNDHostAccess(ctx context.Context) error {
 	gatewayRaw, err := manager.Runner.Run(ctx, dockerPath, "network", "inspect", "bridge", "--format", "{{(index .IPAM.Config 0).Gateway}}")
 	if err != nil {
-		return errors.New("LNbits network gateway lookup failed")
+		return errors.New("BTCPay network gateway lookup failed")
 	}
 	gateway := strings.TrimSpace(gatewayRaw)
 	if !isPrivateDockerGateway(gateway) {
-		return errors.New("LNbits network gateway is invalid")
+		return errors.New("BTCPay network gateway is invalid")
 	}
 	configPath := manager.LNDConfigPath
 	if configPath == "" {
@@ -289,7 +253,7 @@ func (manager *ComposeAppManager) ensureLNbitsHostAccess(ctx context.Context) er
 		return errors.New("LND configuration is unavailable")
 	}
 	lines := strings.Split(strings.TrimRight(string(configRaw), "\n"), "\n")
-	updated, changed := updateLNbitsRESTOptions(lines, gateway)
+	updated, changed := updateLNDRESTHostAccessOptions(lines, gateway)
 	certificateNeedsRefresh := manager.lndCertificateNeedsDockerHostAccess()
 	if changed {
 		if err := replaceRegularFilePreservingMetadata(configPath, []byte(strings.Join(updated, "\n")+"\n")); err != nil {
@@ -297,9 +261,10 @@ func (manager *ComposeAppManager) ensureLNbitsHostAccess(ctx context.Context) er
 		}
 	}
 	if changed || certificateNeedsRefresh {
-		if err := manager.removeLNDServerCertificate(); err != nil {
-			return err
-		}
+		// LND exclusively owns tls.cert and tls.key. With tlsautorefresh
+		// enabled, LND decides whether its certificate needs regeneration
+		// after the configuration change; the broker must never remove or
+		// replace either file.
 		if _, err := manager.Runner.Run(ctx, systemctlPath, "restart", "lnd"); err != nil {
 			return errors.New("LND restart failed")
 		}
@@ -317,7 +282,7 @@ func (manager *ComposeAppManager) EnsureLNDHostAccess(ctx context.Context, appID
 	if dryRun {
 		return nil
 	}
-	return manager.ensureLNbitsHostAccess(ctx)
+	return manager.ensureBTCPayLNDHostAccess(ctx)
 }
 
 func (manager *ComposeAppManager) migrateLNbitsLegacySettings(ctx context.Context) error {
@@ -342,7 +307,7 @@ func (manager *ComposeAppManager) migrateLNbitsLegacySettings(ctx context.Contex
 	return nil
 }
 
-func updateLNbitsRESTOptions(lines []string, gateway string) ([]string, bool) {
+func updateLNDRESTHostAccessOptions(lines []string, gateway string) ([]string, bool) {
 	seen := make(map[string]bool)
 	hasWildcard := false
 	for _, line := range lines {
@@ -381,28 +346,4 @@ func updateLNbitsRESTOptions(lines []string, gateway string) ([]string, bool) {
 	updated = append(updated, block...)
 	updated = append(updated, lines[insert:]...)
 	return updated, true
-}
-
-func (manager *ComposeAppManager) ensureLNbitsInternalFirewall(ctx context.Context) error {
-	status, err := manager.Runner.Run(ctx, ufwPath, "status")
-	if err != nil || !strings.Contains(strings.ToLower(status), "status: active") {
-		return nil
-	}
-	networkID, err := manager.Runner.Run(ctx, dockerPath, "network", "inspect", appmanifest.LNbitsProject+"_default", "--format", "{{.Id}}")
-	if err != nil {
-		return errors.New("LNbits network lookup failed")
-	}
-	id := strings.TrimSpace(networkID)
-	if len(id) < 12 || len(id) > 64 {
-		return errors.New("LNbits network ID is invalid")
-	}
-	for _, char := range id {
-		if !strings.ContainsRune("0123456789abcdef", char) {
-			return errors.New("LNbits network ID is invalid")
-		}
-	}
-	if _, err := manager.Runner.Run(ctx, ufwPath, "allow", "in", "on", "br-"+id[:12], "to", "any", "port", "8080", "proto", "tcp"); err != nil {
-		return errors.New("LNbits internal firewall rule failed")
-	}
-	return nil
 }

--- a/lightningos-light/internal/privileged/lnbits_runtime_test.go
+++ b/lightningos-light/internal/privileged/lnbits_runtime_test.go
@@ -187,6 +187,10 @@ func TestLNbitsValidationRejectsDeclarationAndCredentialDrift(t *testing.T) {
 
 func TestLNbitsLifecycleUsesBrokerSnapshotWithoutRestartingConfiguredLND(t *testing.T) {
 	fixture := writeTestLNbitsFixture(t)
+	resolvedEndpoint, err := fixture.manager.resolveLNbitsRESTEndpoint()
+	if err != nil || resolvedEndpoint != "https://127.0.0.1:8080/" {
+		t.Fatalf("resolved endpoint=%q err=%v", resolvedEndpoint, err)
+	}
 	configBefore, err := os.ReadFile(fixture.configPath)
 	if err != nil {
 		t.Fatal(err)
@@ -223,7 +227,7 @@ func TestLNbitsLifecycleUsesBrokerSnapshotWithoutRestartingConfiguredLND(t *test
 		if command.path == dockerPath && len(command.args) > 2 && command.args[0] == "run" && command.args[len(command.args)-2] == "-c" {
 			migrationObserved = true
 			joined := strings.Join(command.args, " ")
-			for _, required := range []string{"--network none", "--user 65532:65532", "--read-only", "--cap-drop ALL", "no-new-privileges", fixture.dataDir + ":/app/data:rw"} {
+			for _, required := range []string{"--network none", "--user 65532:65532", "--read-only", "--cap-drop ALL", "no-new-privileges", fixture.dataDir + ":/app/data:rw", "LND_REST_ENDPOINT=https://127.0.0.1:8080/"} {
 				if !strings.Contains(joined, required) {
 					t.Fatalf("migration command missing %q: %#v", required, command)
 				}
@@ -244,6 +248,9 @@ func TestLNbitsLifecycleUsesBrokerSnapshotWithoutRestartingConfiguredLND(t *test
 	}
 	if !strings.Contains(fixture.runner.envSnapshot, "LNBITS_SITE_TITLE=Preserved Node") {
 		t.Fatal("safe existing LNbits configuration was not preserved")
+	}
+	if !strings.Contains(fixture.runner.envSnapshot, "LND_REST_ENDPOINT=https://127.0.0.1:8080/") {
+		t.Fatalf("LNbits execution snapshot did not select the existing local REST listener:\n%s", fixture.runner.envSnapshot)
 	}
 	dataRaw, err := os.ReadFile(filepath.Join(fixture.dataDir, "database.sqlite3"))
 	if err != nil || string(dataRaw) != "preserved-data" {
@@ -266,7 +273,7 @@ func TestLNbitsLifecycleUsesBrokerSnapshotWithoutRestartingConfiguredLND(t *test
 func TestLNbitsSettingsMigrationIsNarrowAndParameterized(t *testing.T) {
 	for _, required := range []string{
 		`"lnbits_backend_wallet_class": "LndRestWallet"`,
-		`"lnd_rest_endpoint": "https://127.0.0.1:8080/"`,
+		`"lnd_rest_endpoint": os.environ["LND_REST_ENDPOINT"]`,
 		`"lnd_rest_cert": "/etc/lnd/tls.cert"`,
 		`"lnd_rest_macaroon": "/etc/lnd/lnbits.macaroon"`,
 		"update system_settings set value=? where id=?",
@@ -280,6 +287,37 @@ func TestLNbitsSettingsMigrationIsNarrowAndParameterized(t *testing.T) {
 		if strings.Contains(strings.ToLower(lnbitsSettingsMigrationScript), forbidden) {
 			t.Fatalf("settings migration contains forbidden operation %q", forbidden)
 		}
+	}
+}
+
+func TestSelectLNbitsRESTEndpointUsesExistingSafeListenerWithoutConfigMutation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		want    string
+		wantErr bool
+	}{
+		{name: "native default", config: "[Application Options]\nalias=test\n", want: "https://127.0.0.1:8080/"},
+		{name: "legacy docker bridge", config: "[Application Options]\nrestlisten=172.17.0.1:8080\n", want: "https://172.17.0.1:8080/"},
+		{name: "wildcard maps to loopback", config: "[Application Options]\nrestlisten=0.0.0.0:8080\n", want: "https://127.0.0.1:8080/"},
+		{name: "loopback preferred", config: "[Application Options]\nrestlisten=172.17.0.1:8080\nrestlisten=127.0.0.1:8080\n", want: "https://127.0.0.1:8080/"},
+		{name: "public only rejected", config: "[Application Options]\nrestlisten=203.0.113.8:8080\n", wantErr: true},
+		{name: "hostname rejected", config: "[Application Options]\nrestlisten=example.com:8080\n", wantErr: true},
+		{name: "invalid port rejected", config: "[Application Options]\nrestlisten=127.0.0.1:not-a-port\n", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := selectLNbitsRESTEndpoint(test.config)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected unsafe REST listener to be rejected, got %q", got)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("endpoint=%q err=%v want=%q", got, err, test.want)
+			}
+		})
 	}
 }
 

--- a/lightningos-light/internal/privileged/lnbits_runtime_test.go
+++ b/lightningos-light/internal/privileged/lnbits_runtime_test.go
@@ -60,17 +60,14 @@ func writeTestLNbitsFixture(t *testing.T) *testLNbitsFixture {
 	}
 	composePath := filepath.Join(appRoot, appmanifest.LNbitsComposeFile)
 	envPath := filepath.Join(appRoot, appmanifest.LNbitsEnvFile)
-	certificatePath := filepath.Join(lndDir, appmanifest.LNbitsTLSCertFile)
 	macaroonPath := filepath.Join(lndDir, appmanifest.LNbitsMacaroonFile)
 	adminMacaroonPath := filepath.Join(lndDataRoot, "data", "chain", "bitcoin", "mainnet", "admin.macaroon")
 	certificate := testLNDgCertificate(t, "host.docker.internal")
 	mustWriteTestFile(t, composePath, []byte(appmanifest.LNbitsCompose(appmanifest.LNbitsComposePaths{
-		DataDir:      dataDir,
-		TLSCertPath:  certificatePath,
-		MacaroonPath: macaroonPath,
+		DataDir: dataDir,
+		LNDDir:  lndDir,
 	})), 0640)
 	mustWriteTestFile(t, envPath, testLNbitsEnv(), 0600)
-	mustWriteTestFile(t, certificatePath, certificate, 0640)
 	mustWriteTestFile(t, macaroonPath, []byte("dedicated-lnbits-macaroon"), 0600)
 	mustWriteTestFile(t, adminMacaroonPath, []byte("native-admin-macaroon"), 0600)
 	mustWriteTestFile(t, filepath.Join(lndDataRoot, "tls.cert"), certificate, 0640)
@@ -124,8 +121,7 @@ func TestLNbitsValidationAndSnapshotAreClosedAndPrivate(t *testing.T) {
 	for _, required := range []string{
 		appmanifest.LNbitsImage,
 		fixture.dataDir + ":/app/data:rw",
-		filepath.Join(wantRoot, appmanifest.LNbitsLNDDir, appmanifest.LNbitsTLSCertFile) + ":/etc/lnd/tls.cert:ro",
-		filepath.Join(wantRoot, appmanifest.LNbitsLNDDir, appmanifest.LNbitsMacaroonFile) + ":/etc/lnd/lnbits.macaroon:ro",
+		filepath.Join(wantRoot, appmanifest.LNbitsLNDDir) + ":/etc/lnd:ro",
 	} {
 		if !strings.Contains(compose, required) {
 			t.Fatalf("execution compose missing %q\n%s", required, compose)
@@ -149,6 +145,43 @@ func TestLNbitsValidationAndSnapshotAreClosedAndPrivate(t *testing.T) {
 	}
 	if _, _, err := fixture.manager.createLNbitsSnapshot(files); err != nil {
 		t.Fatalf("second idempotent LNbits snapshot failed: %v", err)
+	}
+}
+
+func TestLNbitsSnapshotCertificateRefreshFollowsNativeLNDRotation(t *testing.T) {
+	fixture := writeTestLNbitsFixture(t)
+	files, err := fixture.manager.validatedLNbitsFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := fixture.manager.createLNbitsSnapshot(files); err != nil {
+		t.Fatal(err)
+	}
+
+	rotated := testLNDgCertificate(t, "rotated.local")
+	mustWriteTestFile(t, filepath.Join(fixture.lndDataRoot, appmanifest.LNbitsTLSCertFile), rotated, 0640)
+	files, err = fixture.manager.validatedLNbitsFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.manager.refreshLNbitsSnapshotCertificate(files.certificateRaw); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshotCert := filepath.Join(fixture.privilegedRoot, appmanifest.LNbitsID, appmanifest.LNbitsLNDDir, appmanifest.LNbitsTLSCertFile)
+	got, err := os.ReadFile(snapshotCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, rotated) {
+		t.Fatal("LNbits snapshot did not follow the native LND certificate rotation")
+	}
+	compose, err := os.ReadFile(filepath.Join(fixture.privilegedRoot, appmanifest.LNbitsID, appmanifest.LNbitsComposeFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(compose), filepath.Dir(snapshotCert)+":/etc/lnd:ro") {
+		t.Fatal("LNbits must mount the credential directory so certificate replacement remains visible")
 	}
 }
 

--- a/lightningos-light/internal/privileged/lnbits_runtime_test.go
+++ b/lightningos-light/internal/privileged/lnbits_runtime_test.go
@@ -187,6 +187,18 @@ func TestLNbitsValidationRejectsDeclarationAndCredentialDrift(t *testing.T) {
 
 func TestLNbitsLifecycleUsesBrokerSnapshotWithoutRestartingConfiguredLND(t *testing.T) {
 	fixture := writeTestLNbitsFixture(t)
+	configBefore, err := os.ReadFile(fixture.configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificateBefore, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.cert"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyBefore, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	fixture.runner.hook = func(path string, args []string) (string, error, bool) {
 		switch {
 		case path == dockerPath && reflect.DeepEqual(args, []string{"network", "inspect", "bridge", "--format", "{{(index .IPAM.Config 0).Gateway}}"}):
@@ -200,7 +212,6 @@ func TestLNbitsLifecycleUsesBrokerSnapshotWithoutRestartingConfiguredLND(t *test
 		t.Fatal(err)
 	}
 	migrationObserved := false
-	createObserved := false
 	upObserved := false
 	for _, command := range fixture.runner.commands {
 		if command.path == systemctlPath && reflect.DeepEqual(command.args, []string{"restart", "lnd"}) {
@@ -218,21 +229,15 @@ func TestLNbitsLifecycleUsesBrokerSnapshotWithoutRestartingConfiguredLND(t *test
 				}
 			}
 		}
-		if hasArgsSuffix(command.args, "create") {
-			createObserved = true
-		}
 		if hasArgsSuffix(command.args, "up", "-d") {
-			if !createObserved {
-				t.Fatal("LNbits was started before its stopped container and network were prepared")
-			}
 			upObserved = true
 		}
 	}
 	if !migrationObserved {
 		t.Fatal("LNbits legacy settings migration was not executed")
 	}
-	if !createObserved || !upObserved {
-		t.Fatalf("LNbits lifecycle did not execute create then up: create=%v up=%v", createObserved, upObserved)
+	if !upObserved {
+		t.Fatal("LNbits lifecycle did not start the broker-owned Compose snapshot")
 	}
 	if !strings.Contains(fixture.runner.composeSnapshot, filepath.Join(fixture.privilegedRoot, appmanifest.LNbitsID)) {
 		t.Fatal("Compose did not execute the broker-owned LNbits snapshot")
@@ -244,12 +249,24 @@ func TestLNbitsLifecycleUsesBrokerSnapshotWithoutRestartingConfiguredLND(t *test
 	if err != nil || string(dataRaw) != "preserved-data" {
 		t.Fatalf("LNbits data changed during lifecycle: %q/%v", dataRaw, err)
 	}
+	configAfter, err := os.ReadFile(fixture.configPath)
+	if err != nil || !reflect.DeepEqual(configAfter, configBefore) {
+		t.Fatalf("LNbits lifecycle changed lnd.conf: equal=%v err=%v", reflect.DeepEqual(configAfter, configBefore), err)
+	}
+	certificateAfter, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.cert"))
+	if err != nil || !reflect.DeepEqual(certificateAfter, certificateBefore) {
+		t.Fatalf("LNbits lifecycle changed LND-managed tls.cert: equal=%v err=%v", reflect.DeepEqual(certificateAfter, certificateBefore), err)
+	}
+	keyAfter, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.key"))
+	if err != nil || !reflect.DeepEqual(keyAfter, keyBefore) {
+		t.Fatalf("LNbits lifecycle changed LND-managed tls.key: equal=%v err=%v", reflect.DeepEqual(keyAfter, keyBefore), err)
+	}
 }
 
 func TestLNbitsSettingsMigrationIsNarrowAndParameterized(t *testing.T) {
 	for _, required := range []string{
 		`"lnbits_backend_wallet_class": "LndRestWallet"`,
-		`"lnd_rest_endpoint": "https://host.docker.internal:8080/"`,
+		`"lnd_rest_endpoint": "https://127.0.0.1:8080/"`,
 		`"lnd_rest_cert": "/etc/lnd/tls.cert"`,
 		`"lnd_rest_macaroon": "/etc/lnd/lnbits.macaroon"`,
 		"update system_settings set value=? where id=?",
@@ -266,8 +283,16 @@ func TestLNbitsSettingsMigrationIsNarrowAndParameterized(t *testing.T) {
 	}
 }
 
-func TestLNbitsHostAccessPreservesListenersAndRestartsOnlyWhenRequired(t *testing.T) {
+func TestBTCPayLNDHostAccessPreservesListenersAndRestartsOnlyWhenRequired(t *testing.T) {
 	fixture := writeTestLNbitsFixture(t)
+	certificateBefore, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.cert"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyBefore, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	mustWriteTestFile(t, fixture.configPath, []byte("[Application Options]\nrestlisten=172.22.0.1:8080\nalias=test\n"), 0640)
 	fixture.runner.hook = func(path string, args []string) (string, error, bool) {
 		switch {
@@ -280,7 +305,7 @@ func TestLNbitsHostAccessPreservesListenersAndRestartsOnlyWhenRequired(t *testin
 		}
 		return "", nil, false
 	}
-	if err := fixture.manager.ensureLNbitsHostAccess(context.Background()); err != nil {
+	if err := fixture.manager.ensureBTCPayLNDHostAccess(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	raw, err := os.ReadFile(fixture.configPath)
@@ -306,11 +331,19 @@ func TestLNbitsHostAccessPreservesListenersAndRestartsOnlyWhenRequired(t *testin
 	if restarts != 1 {
 		t.Fatalf("LND restart count=%d want=1", restarts)
 	}
+	certificateAfter, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.cert"))
+	if err != nil || !reflect.DeepEqual(certificateAfter, certificateBefore) {
+		t.Fatalf("broker changed LND-managed tls.cert: equal=%v err=%v", reflect.DeepEqual(certificateAfter, certificateBefore), err)
+	}
+	keyAfter, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.key"))
+	if err != nil || !reflect.DeepEqual(keyAfter, keyBefore) {
+		t.Fatalf("broker changed LND-managed tls.key: equal=%v err=%v", reflect.DeepEqual(keyAfter, keyBefore), err)
+	}
 }
 
-func TestUpdateLNbitsRESTOptionsAcceptsExistingWildcardWithoutConflictingBinds(t *testing.T) {
+func TestUpdateLNDRESTHostAccessOptionsAcceptsExistingWildcardWithoutConflictingBinds(t *testing.T) {
 	lines := []string{"[Application Options]", "restlisten=0.0.0.0:8080", "alias=test"}
-	got, changed := updateLNbitsRESTOptions(lines, "172.17.0.1")
+	got, changed := updateLNDRESTHostAccessOptions(lines, "172.17.0.1")
 	if !changed {
 		t.Fatal("expected missing TLS identities to be added")
 	}

--- a/lightningos-light/internal/privileged/lndg_runtime.go
+++ b/lightningos-light/internal/privileged/lndg_runtime.go
@@ -344,9 +344,9 @@ func (manager *ComposeAppManager) ensureLNDgHostAccess(ctx context.Context) erro
 		}
 	}
 	if changed || certificateNeedsRefresh {
-		if err := manager.removeLNDServerCertificate(); err != nil {
-			return err
-		}
+		// LND exclusively owns tls.cert and tls.key. The broker only applies
+		// the reviewed configuration and lets LND's tlsautorefresh policy
+		// manage its own certificate lifecycle on restart.
 		if _, err := manager.Runner.Run(ctx, systemctlPath, "restart", "lnd"); err != nil {
 			return errors.New("LND restart failed")
 		}
@@ -424,27 +424,6 @@ func (manager *ComposeAppManager) lndCertificateNeedsDockerHostAccess() bool {
 		return true
 	}
 	return certificate.VerifyHostname("host.docker.internal") != nil
-}
-
-func (manager *ComposeAppManager) removeLNDServerCertificate() error {
-	lndDataRoot := manager.LNDDataRoot
-	if lndDataRoot == "" {
-		lndDataRoot = defaultLNDDataRoot
-	}
-	for _, name := range []string{"tls.cert", "tls.key"} {
-		path := filepath.Join(lndDataRoot, name)
-		info, err := os.Lstat(path)
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-			return errors.New("LND TLS material is unsafe")
-		}
-		if err := os.Remove(path); err != nil {
-			return errors.New("LND TLS material removal failed")
-		}
-	}
-	return nil
 }
 
 func (manager *ComposeAppManager) ensureLNDgInternalFirewall(ctx context.Context) error {

--- a/lightningos-light/internal/privileged/lndg_runtime.go
+++ b/lightningos-light/internal/privileged/lndg_runtime.go
@@ -288,20 +288,8 @@ func (manager *ComposeAppManager) refreshLNDgSnapshotCertificate(snapshotRoot st
 	if filepath.Clean(snapshotRoot) != expectedRoot {
 		return errors.New("invalid LNDg execution snapshot")
 	}
-	lndDataRoot := manager.LNDDataRoot
-	if lndDataRoot == "" {
-		lndDataRoot = defaultLNDDataRoot
-	}
-	var certificateRaw []byte
-	var err error
-	for attempt := 0; attempt < 30; attempt++ {
-		certificateRaw, err = readRegularFile(filepath.Join(lndDataRoot, "tls.cert"), maxLNDgCredentialBytes)
-		if err == nil && validateTLSCertificate(certificateRaw) == nil {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-	if err != nil || validateTLSCertificate(certificateRaw) != nil {
+	certificateRaw, err := manager.waitForLNDDockerHostCertificate(30, time.Second)
+	if err != nil {
 		return errors.New("refreshed LND certificate is unavailable")
 	}
 	target := filepath.Join(expectedRoot, appmanifest.LNDgLNDDir, appmanifest.LNDgTLSCertFile)
@@ -312,6 +300,31 @@ func (manager *ComposeAppManager) refreshLNDgSnapshotCertificate(snapshotRoot st
 		return errors.New("failed to assign LNDg certificate group")
 	}
 	return nil
+}
+
+func lndCertificateSupportsDockerHost(raw []byte) bool {
+	certificate, err := parseTLSCertificate(raw)
+	if err != nil {
+		return false
+	}
+	return certificate.VerifyHostname("host.docker.internal") == nil
+}
+
+func (manager *ComposeAppManager) waitForLNDDockerHostCertificate(attempts int, delay time.Duration) ([]byte, error) {
+	lndDataRoot := manager.LNDDataRoot
+	if lndDataRoot == "" {
+		lndDataRoot = defaultLNDDataRoot
+	}
+	for attempt := 0; attempt < attempts; attempt++ {
+		raw, err := readRegularFile(filepath.Join(lndDataRoot, "tls.cert"), maxLNDgCredentialBytes)
+		if err == nil && lndCertificateSupportsDockerHost(raw) {
+			return raw, nil
+		}
+		if attempt+1 < attempts {
+			time.Sleep(delay)
+		}
+	}
+	return nil, errors.New("LND certificate does not cover the Docker host")
 }
 
 func (manager *ComposeAppManager) ensureLNDgHostAccess(ctx context.Context) error {

--- a/lightningos-light/internal/privileged/lndg_runtime_test.go
+++ b/lightningos-light/internal/privileged/lndg_runtime_test.go
@@ -332,6 +332,14 @@ func TestLNDgLifecycleUsesOnlyBrokerSnapshotAndDoesNotRestartConfiguredLND(t *te
 
 func TestLNDgHostAccessPreservesUnrelatedListenersAndRestartsOnlyOnChange(t *testing.T) {
 	fixture := writeTestLNDgFixture(t)
+	certificateBefore, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.cert"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyBefore, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	mustWriteTestFile(t, fixture.configPath, []byte("[Application Options]\nrpclisten=127.0.0.1:10009\nrpclisten=172.22.0.1:10009\nalias=test\n"), 0640)
 	fixture.runner.hook = func(path string, args []string) (string, error, bool) {
 		if path == dockerPath && reflect.DeepEqual(args, []string{"network", "inspect", "bridge", "--format", "{{(index .IPAM.Config 0).Gateway}}"}) {
@@ -362,9 +370,6 @@ func TestLNDgHostAccessPreservesUnrelatedListenersAndRestartsOnlyOnChange(t *tes
 			t.Fatalf("updated LND config lost %q: %s", required, raw)
 		}
 	}
-	if _, err := os.Lstat(filepath.Join(fixture.lndDataRoot, "tls.cert")); !os.IsNotExist(err) {
-		t.Fatal("LND certificate was not removed before the required restart")
-	}
 	restarts := 0
 	for _, command := range fixture.runner.commands {
 		if command.path == systemctlPath && reflect.DeepEqual(command.args, []string{"restart", "lnd"}) {
@@ -373,6 +378,14 @@ func TestLNDgHostAccessPreservesUnrelatedListenersAndRestartsOnlyOnChange(t *tes
 	}
 	if restarts != 1 {
 		t.Fatalf("LND restart count=%d want=1", restarts)
+	}
+	certificateAfter, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.cert"))
+	if err != nil || !reflect.DeepEqual(certificateAfter, certificateBefore) {
+		t.Fatalf("broker changed LND-managed tls.cert: equal=%v err=%v", reflect.DeepEqual(certificateAfter, certificateBefore), err)
+	}
+	keyAfter, err := os.ReadFile(filepath.Join(fixture.lndDataRoot, "tls.key"))
+	if err != nil || !reflect.DeepEqual(keyAfter, keyBefore) {
+		t.Fatalf("broker changed LND-managed tls.key: equal=%v err=%v", reflect.DeepEqual(keyAfter, keyBefore), err)
 	}
 }
 

--- a/lightningos-light/internal/privileged/lndg_runtime_test.go
+++ b/lightningos-light/internal/privileged/lndg_runtime_test.go
@@ -436,6 +436,42 @@ func testLNDgCertificate(t *testing.T, dnsName string) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificateDER})
 }
 
+func TestLNDgCertificateSupportsDockerHost(t *testing.T) {
+	if lndCertificateSupportsDockerHost(testLNDgCertificate(t, "localhost")) {
+		t.Fatal("certificate without Docker host SAN was accepted")
+	}
+	if !lndCertificateSupportsDockerHost(testLNDgCertificate(t, "host.docker.internal")) {
+		t.Fatal("certificate with Docker host SAN was rejected")
+	}
+	if lndCertificateSupportsDockerHost([]byte("not a certificate")) {
+		t.Fatal("invalid certificate was accepted")
+	}
+}
+
+func TestRefreshLNDgSnapshotCertificateFollowsLNDRotation(t *testing.T) {
+	fixture := writeTestLNDgFixture(t)
+	files, err := fixture.manager.validatedLNDgFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, _, err := fixture.manager.createLNDgSnapshot(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotated := testLNDgCertificate(t, "host.docker.internal")
+	mustWriteTestFile(t, filepath.Join(fixture.lndDataRoot, "tls.cert"), rotated, 0640)
+	if err := fixture.manager.refreshLNDgSnapshotCertificate(snapshot.root); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(snapshot.root, appmanifest.LNDgLNDDir, appmanifest.LNDgTLSCertFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, rotated) {
+		t.Fatal("LNDg snapshot did not follow the LND-owned certificate rotation")
+	}
+}
+
 func TestLNDgHostAccessRejectsUntrustedGateway(t *testing.T) {
 	fixture := writeTestLNDgFixture(t)
 	fixture.runner.hook = func(path string, args []string) (string, error, bool) {

--- a/lightningos-light/internal/server/apps_lnbits.go
+++ b/lightningos-light/internal/server/apps_lnbits.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -24,7 +23,6 @@ type lnbitsPaths struct {
 	ComposePath  string
 	EnvPath      string
 	LndDir       string
-	TLSCertPath  string
 	MacaroonPath string
 }
 
@@ -98,7 +96,6 @@ func lnbitsAppPaths() lnbitsPaths {
 		ComposePath:  filepath.Join(root, appmanifest.LNbitsComposeFile),
 		EnvPath:      filepath.Join(root, appmanifest.LNbitsEnvFile),
 		LndDir:       lndDir,
-		TLSCertPath:  filepath.Join(lndDir, appmanifest.LNbitsTLSCertFile),
 		MacaroonPath: filepath.Join(lndDir, appmanifest.LNbitsMacaroonFile),
 	}
 }
@@ -111,6 +108,9 @@ func (s *Server) applyLnbits(ctx context.Context) error {
 	if err := ensureLnbitsPaths(paths); err != nil {
 		return err
 	}
+	if err := removeLegacyLNbitsCertificate(paths); err != nil {
+		return err
+	}
 	if _, err := ensureFileWithChange(paths.ComposePath, lnbitsComposeContents(paths)); err != nil {
 		return err
 	}
@@ -118,9 +118,6 @@ func (s *Server) applyLnbits(ctx context.Context) error {
 		return err
 	}
 	if err := s.ensureLnbitsMacaroon(ctx, paths); err != nil {
-		return err
-	}
-	if err := copyLnbitsLndCert(paths); err != nil {
 		return err
 	}
 	if handled, err := system.PrepareAppImageWithBroker(ctx, appmanifest.LNbitsID, string(appmanifest.LNbitsImageApp)); !handled {
@@ -186,11 +183,28 @@ func ensureLnbitsPaths(paths lnbitsPaths) error {
 	return nil
 }
 
+func removeLegacyLNbitsCertificate(paths lnbitsPaths) error {
+	legacyPath := filepath.Join(paths.LndDir, appmanifest.LNbitsTLSCertFile)
+	info, err := os.Lstat(legacyPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.New("LNbits legacy certificate state is unavailable")
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("LNbits legacy certificate state is invalid")
+	}
+	if err := os.Remove(legacyPath); err != nil {
+		return fmt.Errorf("failed to remove obsolete LNbits certificate copy: %w", err)
+	}
+	return nil
+}
+
 func lnbitsComposeContents(paths lnbitsPaths) string {
 	return appmanifest.LNbitsCompose(appmanifest.LNbitsComposePaths{
-		DataDir:      paths.DataDir,
-		TLSCertPath:  paths.TLSCertPath,
-		MacaroonPath: paths.MacaroonPath,
+		DataDir: paths.DataDir,
+		LNDDir:  paths.LndDir,
 	})
 }
 
@@ -297,39 +311,6 @@ func lnbitsMacaroonPermissions() []lndclient.MacaroonPermission {
 		{Entity: "peers", Action: "read"},
 		{Entity: "peers", Action: "write"},
 	}
-}
-
-func copyLnbitsLndCert(paths lnbitsPaths) error {
-	const source = "/data/lnd/tls.cert"
-	var raw []byte
-	var err error
-	for attempt := 0; attempt < 10; attempt++ {
-		raw, err = os.ReadFile(source)
-		if err == nil && len(raw) > 0 {
-			break
-		}
-		time.Sleep(2 * time.Second)
-	}
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", source, err)
-	}
-	if len(raw) == 0 {
-		return fmt.Errorf("%s is empty", source)
-	}
-	if info, statErr := os.Lstat(paths.TLSCertPath); statErr == nil {
-		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-			return errors.New("LNbits LND certificate must be a regular file")
-		}
-		if existing, readErr := os.ReadFile(paths.TLSCertPath); readErr == nil && bytes.Equal(existing, raw) {
-			return nil
-		}
-	} else if !os.IsNotExist(statErr) {
-		return errors.New("LNbits LND certificate is unavailable")
-	}
-	if err := os.WriteFile(paths.TLSCertPath, raw, 0640); err != nil {
-		return fmt.Errorf("failed to copy LND tls.cert for LNbits: %w", err)
-	}
-	return nil
 }
 
 // envValueState remains shared by the compatibility implementations which

--- a/lightningos-light/internal/server/apps_lnbits_test.go
+++ b/lightningos-light/internal/server/apps_lnbits_test.go
@@ -15,7 +15,6 @@ func TestLnbitsComposeUsesPinnedOfficialImageAndDedicatedCredential(t *testing.T
 	paths := lnbitsPaths{
 		DataDir:      "/var/lib/lightningos/apps-data/lnbits/data",
 		LndDir:       "/var/lib/lightningos/apps-data/lnbits/lnd",
-		TLSCertPath:  "/var/lib/lightningos/apps-data/lnbits/lnd/tls.cert",
 		MacaroonPath: "/var/lib/lightningos/apps-data/lnbits/lnd/lnbits.macaroon",
 	}
 	compose := lnbitsComposeContents(paths)
@@ -23,8 +22,7 @@ func TestLnbitsComposeUsesPinnedOfficialImageAndDedicatedCredential(t *testing.T
 	for _, required := range []string{
 		"image: " + appmanifest.LNbitsImage,
 		paths.DataDir + ":/app/data",
-		paths.TLSCertPath + ":/etc/lnd/tls.cert:ro",
-		paths.MacaroonPath + ":/etc/lnd/lnbits.macaroon:ro",
+		paths.LndDir + ":/etc/lnd:ro",
 		`user: "65532:65532"`,
 		"read_only: true",
 		"cap_drop:\n      - ALL",
@@ -57,6 +55,49 @@ func TestEnsureLnbitsEnvAllowsLocalHTTPAuth(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "LNBITS_DATA_FOLDER=/app/data\n") {
 		t.Fatalf("env must pin the persistent data folder\n%s", string(content))
+	}
+}
+
+func TestRemoveLegacyLNbitsCertificateRemovesOnlyObsoleteRegularCopy(t *testing.T) {
+	root := t.TempDir()
+	paths := lnbitsPaths{LndDir: filepath.Join(root, "lnd")}
+	if err := os.MkdirAll(paths.LndDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	legacyPath := filepath.Join(paths.LndDir, appmanifest.LNbitsTLSCertFile)
+	if err := os.WriteFile(legacyPath, []byte("obsolete public certificate"), 0640); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeLegacyLNbitsCertificate(paths); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("obsolete certificate copy still exists: %v", err)
+	}
+	if err := removeLegacyLNbitsCertificate(paths); err != nil {
+		t.Fatalf("idempotent cleanup failed: %v", err)
+	}
+}
+
+func TestRemoveLegacyLNbitsCertificateRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	paths := lnbitsPaths{LndDir: filepath.Join(root, "lnd")}
+	if err := os.MkdirAll(paths.LndDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "target")
+	if err := os.WriteFile(target, []byte("must remain"), 0640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(paths.LndDir, appmanifest.LNbitsTLSCertFile)); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := removeLegacyLNbitsCertificate(paths); err == nil {
+		t.Fatal("expected legacy certificate symlink to be rejected")
+	}
+	raw, err := os.ReadFile(target)
+	if err != nil || string(raw) != "must remain" {
+		t.Fatalf("symlink target changed: %q/%v", raw, err)
 	}
 }
 

--- a/lightningos-light/internal/server/apps_lnbits_test.go
+++ b/lightningos-light/internal/server/apps_lnbits_test.go
@@ -29,12 +29,13 @@ func TestLnbitsComposeUsesPinnedOfficialImageAndDedicatedCredential(t *testing.T
 		"read_only: true",
 		"cap_drop:\n      - ALL",
 		"no-new-privileges:true",
+		"network_mode: host",
 	} {
 		if !strings.Contains(compose, required) {
 			t.Fatalf("compose missing %q\n%s", required, compose)
 		}
 	}
-	for _, forbidden := range []string{"lnbits/lnbits:latest", "/data/lnd", "admin.macaroon", "/var/run/docker.sock", "privileged: true"} {
+	for _, forbidden := range []string{"lnbits/lnbits:latest", "/data/lnd", "admin.macaroon", "/var/run/docker.sock", "privileged: true", "host.docker.internal", "ports:"} {
 		if strings.Contains(compose, forbidden) {
 			t.Fatalf("compose exposes mutable or privileged input %q\n%s", forbidden, compose)
 		}
@@ -82,7 +83,7 @@ func TestEnsureLnbitsEnvMigratesLegacyAdminCredentialSelectors(t *testing.T) {
 	}
 	got := string(content)
 	for _, required := range []string{
-		"LND_REST_ENDPOINT=https://host.docker.internal:8080/",
+		"LND_REST_ENDPOINT=https://127.0.0.1:8080/",
 		"LND_REST_CERT=/etc/lnd/tls.cert",
 		"LND_REST_MACAROON=/etc/lnd/lnbits.macaroon",
 		"CUSTOM_SETTING=preserved",


### PR DESCRIPTION
## Summary

- stop LNbits lifecycle from changing `lnd.conf` or restarting LND
- run LNbits with host networking and select an already configured safe local LND REST listener
- prefer loopback for clean installs; accept only loopback/private IP listeners for legacy installs
- keep the dedicated LNbits macaroon inside the privileged broker boundary
- mirror only LND's public certificate into narrow read-only app directories and reconcile it after LND certificate rotation
- never expose the native LND directory, `tls.key`, `admin.macaroon`, or unrelated credentials to apps
- remove direct deletion or replacement of LND-owned `tls.cert` and `tls.key` from privileged app access helpers
- make shared manager gRPC connections automatically reload trust when LND rotates its certificate
- wait for the new Docker-host SAN before refreshing LNDg, Fedimint Gateway, and BTCPay runtime material
- make a clean LNDg PostgreSQL bootstrap idempotent so later starts do not mistake its generated SQLite file for a legacy migration
- add regression coverage for LND configuration, TLS ownership, certificate rotation, connection refresh, and process immutability

## Validation

- `go test ./...`
- LOS-TEST2 (install.sh, Ubuntu 24.04): LNbits start and HTTP passed
- LNbits performed an authenticated LND REST `getinfo` through the selected legacy private listener
- `lnd.conf`, `tls.cert`, `tls.key`, LND PID, and LND active timestamp remained unchanged
- LNDg, Fedimint Gateway, Taproot Assets, Lightning Loop, and BTCPay each passed start/running/stop cycles on LOS-TEST2
- final LND chain and graph synchronization remained healthy on LOS-TEST2
- LOS-TEST3 clean install: LNbits running, HTTP 200, and authenticated LND REST `getinfo` passed through the restricted runtime
- LOS-TEST3 exposes only the read-only broker LND directory containing `tls.cert` and the dedicated macaroon; native `lnd.conf`, `tls.cert`, `tls.key`, PID, and active timestamp stayed unchanged during LNbits installation
- LOS-TEST3 clean LNDg install exposed and reproduced the TLS rotation race and second-start bootstrap defect; both now have regression fixes in this PR, with the final lifecycle rerun pending authenticated UI access

Fixes #141