### PR TITLE
0.5.26-Beta: update BTCPay Server to 2.4.4

### DIFF
--- a/lightningos-light/internal/appmanifest/btcpay.go
+++ b/lightningos-light/internal/appmanifest/btcpay.go
@@ -16,8 +16,8 @@ const (
 	BTCPayPort                   = 23000
 	BTCPayNbxplorerPort          = 32838
 	BTCPayStopTimeout            = 30
-	BTCPayRelease                = "2.4.2"
-	BTCPayNbxplorerRelease       = "2.6.10"
+	BTCPayRelease                = "2.4.4"
+	BTCPayNbxplorerRelease       = "2.6.13"
 
 	// BTCPayServerImage is the newest stable tag published by the official
 	// BTCPay Docker project. Upstream does not publish a usable `latest` tag.
@@ -94,9 +94,9 @@ func BTCPayCompose(paths BTCPayComposePaths, joinBitcoinNetwork bool, useTorProx
 	return btcpayCompose(paths, joinBitcoinNetwork, useTorProxy, BTCPayMacaroonFile)
 }
 
-// BTCPayExecutionCompose is the broker-only catalog form. BTCPay 2.4.2 fixes
-// the credential-disclosure vulnerability and requires the dedicated LND
-// credential path to use the .macaroon extension.
+// BTCPayExecutionCompose is the broker-only catalog form. Current releases
+// retain the dedicated LND credential requirement introduced by the 2.4.2
+// security fix, including the .macaroon filename extension.
 func BTCPayExecutionCompose(paths BTCPayComposePaths, joinBitcoinNetwork bool, useTorProxy bool) string {
 	return btcpayCompose(paths, joinBitcoinNetwork, useTorProxy, BTCPayMacaroonFile)
 }

--- a/lightningos-light/internal/appmanifest/catalog_test.go
+++ b/lightningos-light/internal/appmanifest/catalog_test.go
@@ -133,15 +133,15 @@ func TestLNbitsCatalogPinsOfficialStableManifest(t *testing.T) {
 	}
 }
 
-// 2.4.2 closes the actively exploited LND macaroon disclosure fixed by
-// upstream on 2026-08-07. NBXplorer 2.6.10 is the matching release upstream
-// explicitly recommends to integrators. Keep this guard when advancing the
-// catalog so the security floor cannot regress silently.
+// 2.4.2 established the security floor for the LND macaroon disclosure fixed
+// upstream on 2026-08-07. The catalog now follows the official 2.4.4 stack and
+// its NBXplorer 2.6.13 companion. Keep this exact guard current when advancing
+// the catalog so either component cannot regress silently.
 func TestBTCPayCatalogSecurityFloor(t *testing.T) {
-	if BTCPayRelease != "2.4.2" || BTCPayServerImage != "btcpayserver/btcpayserver:2.4.2" {
+	if BTCPayRelease != "2.4.4" || BTCPayServerImage != "btcpayserver/btcpayserver:2.4.4" {
 		t.Fatalf("BTCPay catalog fell below the 2.4.2 security floor: %q", BTCPayServerImage)
 	}
-	if BTCPayNbxplorerRelease != "2.6.10" || BTCPayNbxplorerImage != "nicolasdorier/nbxplorer:2.6.10" {
+	if BTCPayNbxplorerRelease != "2.6.13" || BTCPayNbxplorerImage != "nicolasdorier/nbxplorer:2.6.13" {
 		t.Fatalf("unexpected NBXplorer security companion: %q", BTCPayNbxplorerImage)
 	}
 }

--- a/lightningos-light/internal/server/apps_btcpay_test.go
+++ b/lightningos-light/internal/server/apps_btcpay_test.go
@@ -192,10 +192,10 @@ func TestBtcpayImageTracksLatestStableRelease(t *testing.T) {
 	if btcpayImage != appmanifest.BTCPayServerImage {
 		t.Fatalf("server and catalog BTCPay images differ: %q != %q", btcpayImage, appmanifest.BTCPayServerImage)
 	}
-	if btcpayImage != "btcpayserver/btcpayserver:2.4.2" || appmanifest.BTCPayRelease != "2.4.2" {
+	if btcpayImage != "btcpayserver/btcpayserver:2.4.4" || appmanifest.BTCPayRelease != "2.4.4" {
 		t.Fatalf("BTCPay image must track the latest stable release, got %q", btcpayImage)
 	}
-	if btcpayNbxplorerImage != "nicolasdorier/nbxplorer:2.6.10" {
+	if btcpayNbxplorerImage != "nicolasdorier/nbxplorer:2.6.13" {
 		t.Fatalf("NBXplorer must track the companion release recommended by BTCPay, got %q", btcpayNbxplorerImage)
 	}
 }

--- a/lightningos-light/internal/server/apps_versions_test.go
+++ b/lightningos-light/internal/server/apps_versions_test.go
@@ -81,7 +81,7 @@ func TestDecorateAppVersionsDistinguishesAvailableAppliedAndUnknown(t *testing.T
 	versions := map[string]appVersionRecord{
 		appmanifest.MempoolID:  {CatalogVersion: "3.4.0", AppliedVersion: "3.3.1"},
 		appmanifest.ElectrsID:  {CatalogVersion: "0.11.1"},
-		appmanifest.BTCPayID:   {CatalogVersion: "2.4.2", AppliedVersion: "2.3.0"},
+		appmanifest.BTCPayID:   {CatalogVersion: "2.4.4", AppliedVersion: "2.3.0"},
 		appmanifest.PeerSwapID: {CatalogVersion: "should-not-appear", AppliedVersion: "should-not-appear"},
 	}
 
@@ -93,7 +93,7 @@ func TestDecorateAppVersionsDistinguishesAvailableAppliedAndUnknown(t *testing.T
 	if apps[1].AvailableVersion != "0.11.1" || apps[1].InstalledVersion != "" || apps[1].UpdateAvailable {
 		t.Fatalf("legacy Electrs install must remain unknown: %+v", apps[1])
 	}
-	if apps[2].AvailableVersion != "2.4.2" || apps[2].InstalledVersion != "" || apps[2].UpdateAvailable {
+	if apps[2].AvailableVersion != "2.4.4" || apps[2].InstalledVersion != "" || apps[2].UpdateAvailable {
 		t.Fatalf("not-installed BTCPay must expose only the catalog version: %+v", apps[2])
 	}
 	if apps[3].AvailableVersion != "" || apps[3].InstalledVersion != "" || apps[3].UpdateAvailable {


### PR DESCRIPTION
## Summary

- update BTCPay Server from 2.4.2 to the stable 2.4.4 release
- update the official companion NBXplorer image from 2.6.10 to 2.6.13
- preserve the existing PostgreSQL 16, Tor, dedicated LND macaroon, storage, and broker lifecycle configuration
- update catalog and App Store version guards

## Upstream

- https://blog.btcpayserver.org/btcpay-server-2-4-4/
- https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.4
- the official btcpayserver-docker stack currently pairs BTCPay 2.4.4 with NBXplorer 2.6.13
- both images publish linux/amd64, linux/arm, and linux/arm64 manifests

## Validation

- go test ./...