### PR TITLE
0.5.26-Beta: update Elements to 23.3.4

### DIFF
--- a/lightningos-light/internal/appmanifest/elements.go
+++ b/lightningos-light/internal/appmanifest/elements.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	ElementsID             = "elements"
-	ElementsVersion        = "23.3.3"
+	ElementsVersion        = "23.3.4"
 	ElementsUser           = "lightningos-elements"
 	ElementsManagerGroup   = "lightningos"
 	ElementsService        = "lightningos-elements"
@@ -63,10 +63,10 @@ func ElementsAssetForArch(goarch string) (ElementsReleaseAsset, error) {
 	switch goarch {
 	case "amd64":
 		suffix = "x86_64-linux-gnu"
-		checksum = "90d6659a4f5d6d94bbf2321f6114e1286fbec8031cfc614b2f2319ddfcd9b3e1"
+		checksum = "a758151ace3f21008ab162067ffce9e0e526a1b5d55995e2c30d9cd7ccda41a0"
 	case "arm64":
 		suffix = "aarch64-linux-gnu"
-		checksum = "279c6cf96ca0583e93fa8531ca671ffde91694254fce4719e6f3b1d0d883dd34"
+		checksum = "ee20cc20302bf7a41a063241f59f17a0a2e4d18479c2fff9cbdbfc6c25919510"
 	default:
 		return ElementsReleaseAsset{}, fmt.Errorf("Elements does not support architecture %s", goarch)
 	}

--- a/lightningos-light/internal/privileged/elements_test.go
+++ b/lightningos-light/internal/privileged/elements_test.go
@@ -32,10 +32,11 @@ func TestNativeElementsApplicationTraversalIsLimitedToFixedParents(t *testing.T)
 }
 
 func TestExtractElementsBinariesRejectsMissingAndExtractsFixedNames(t *testing.T) {
+	releaseRoot := "elements-" + appmanifest.ElementsVersion + "/bin/"
 	archive := elementsTestArchive(t, map[string]string{
-		"elements-23.3.3/bin/elementsd":    "daemon",
-		"elements-23.3.3/bin/elements-cli": "client",
-		"elements-23.3.3/bin/other":        "ignored",
+		releaseRoot + "elementsd":    "daemon",
+		releaseRoot + "elements-cli": "client",
+		releaseRoot + "other":        "ignored",
 	})
 	binaries, err := extractElementsBinaries(archive)
 	if err != nil {
@@ -44,7 +45,7 @@ func TestExtractElementsBinariesRejectsMissingAndExtractsFixedNames(t *testing.T
 	if string(binaries["elementsd"]) != "daemon" || string(binaries["elements-cli"]) != "client" || len(binaries) != 2 {
 		t.Fatalf("unexpected extracted binaries: %#v", binaries)
 	}
-	if _, err := extractElementsBinaries(elementsTestArchive(t, map[string]string{"elements-23.3.3/bin/elementsd": "daemon"})); err == nil {
+	if _, err := extractElementsBinaries(elementsTestArchive(t, map[string]string{releaseRoot + "elementsd": "daemon"})); err == nil {
 		t.Fatal("expected missing elements-cli rejection")
 	}
 }


### PR DESCRIPTION
## Summary
- update the native Elements App Store binary from 23.3.3 to stable 23.3.4
- pin the official amd64 and arm64 archive SHA256 digests
- preserve the existing native service, data directory, configuration, RPC boundary, and PeerSwap integration
- make archive extraction fixtures follow the pinned release version

## Upstream
- https://github.com/ElementsProject/elements/releases/tag/elements-23.3.4
- signed annotated tag verified by GitHub
- upstream includes range-proof cache-key hardening and secp256k1-zkp updates

## Validation
- downloaded official x86_64 and aarch64 Linux archives
- both SHA256 hashes match the official SHA256SUMS
- both archives contain the expected elementsd and elements-cli paths
- go test ./...