### PR TITLE
0.5.27: Repair missing Mesh executable after legacy upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1064,3 +1064,7 @@ sudo cp -a ui/dist/. /opt/lightningos/ui/
 
 
 **Disconnect radio** closes the connection and stops reconnection attempts while preserving settings and contacts. Reconnect radio starts it again. Finish/cancel pending transfers and previews first. TCP defaults to port 4403 when only a private IP is entered.
+
+### LOS Mesh / 0.5.27 upgrade
+
+Updates initiated by older releases may omit the standalone `lightningos-mesh` binary. Starting with 0.5.27, installing/connecting LOS Mesh automatically restores a missing executable from the locally installed, root-owned broker. No additional download or reinstall of LightningOS is needed. Existing executables and radio settings are preserved. Both endpoints must use 0.5.27 or later for new fragmented invoice/transaction sessions.

--- a/lightningos-light/cmd/lightningos-mesh/main.go
+++ b/lightningos-light/cmd/lightningos-mesh/main.go
@@ -1,45 +1,5 @@
 package main
 
-import (
-	"context"
-	"encoding/json"
-	"io"
-	"lightningos-light/internal/mesh"
-	"log"
-	"os"
-	"os/signal"
-	"os/user"
-	"strconv"
-	"syscall"
-)
+import "lightningos-light/internal/mesh"
 
-func main() {
-	if len(os.Args) != 1 {
-		log.Fatal("no command-line arguments accepted")
-	}
-	content, err := os.ReadFile("/var/lib/lightningos-mesh/device.json")
-	if err != nil {
-		log.Fatal("radio configuration unavailable")
-	}
-	var cfg struct {
-		Device string `json:"device"`
-	}
-	if json.Unmarshal(content, &cfg) != nil {
-		log.Fatal("invalid radio configuration")
-	}
-	manager, err := user.Lookup("lightningos")
-	if err != nil {
-		log.Fatal("Manager identity unavailable")
-	}
-	uid, err := strconv.ParseUint(manager.Uid, 10, 32)
-	if err != nil {
-		log.Fatal("invalid Manager identity")
-	}
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt)
-	defer cancel()
-	b := mesh.NewBridge(cfg.Device)
-	go b.Run(ctx, func() (io.ReadWriteCloser, error) { return mesh.OpenRadio(ctx, cfg.Device) })
-	if err = mesh.Serve(ctx, b, uint32(uid)); err != nil && ctx.Err() == nil {
-		log.Fatal("radio bridge stopped")
-	}
-}
+func main() { mesh.RunDaemon() }

--- a/lightningos-light/cmd/lightningos-privileged/main.go
+++ b/lightningos-light/cmd/lightningos-privileged/main.go
@@ -3,13 +3,29 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"lightningos-light/internal/mesh"
 	"os"
+	"path/filepath"
 	"time"
 
 	"lightningos-light/internal/privileged"
 )
 
 func main() {
+	if filepath.Base(os.Args[0]) == "lightningos-mesh" {
+		if os.Geteuid() == 0 {
+			os.Exit(1)
+		}
+		mesh.RunDaemon()
+		return
+	}
+	if len(os.Args) == 2 && os.Args[1] == "--repair-mesh-binary" {
+		if err := privileged.RepairMeshBinary(); err != nil {
+			os.Stderr.WriteString("mesh binary repair failed\n")
+			os.Exit(1)
+		}
+		return
+	}
 	if len(os.Args) != 1 {
 		writeResponse(privileged.ErrorResponse("", "invalid_invocation", "broker accepts no command-line arguments"))
 		return

--- a/lightningos-light/internal/mesh/daemon.go
+++ b/lightningos-light/internal/mesh/daemon.go
@@ -1,0 +1,44 @@
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+func RunDaemon() {
+	if len(os.Args) != 1 {
+		log.Fatal("no command-line arguments accepted")
+	}
+	content, err := os.ReadFile("/var/lib/lightningos-mesh/device.json")
+	if err != nil {
+		log.Fatal("radio configuration unavailable")
+	}
+	var cfg struct {
+		Device string `json:"device"`
+	}
+	if json.Unmarshal(content, &cfg) != nil {
+		log.Fatal("invalid radio configuration")
+	}
+	manager, err := user.Lookup("lightningos")
+	if err != nil {
+		log.Fatal("Manager identity unavailable")
+	}
+	uid, err := strconv.ParseUint(manager.Uid, 10, 32)
+	if err != nil {
+		log.Fatal("invalid Manager identity")
+	}
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt)
+	defer cancel()
+	b := NewBridge(cfg.Device)
+	go b.Run(ctx, func() (io.ReadWriteCloser, error) { return OpenRadio(ctx, cfg.Device) })
+	if err = Serve(ctx, b, uint32(uid)); err != nil && ctx.Err() == nil {
+		log.Fatal("radio bridge stopped")
+	}
+}

--- a/lightningos-light/internal/privileged/mesh.go
+++ b/lightningos-light/internal/privileged/mesh.go
@@ -116,6 +116,11 @@ func (m *NativeMeshManager) Control(ctx context.Context, p MeshParams, dry bool)
 		if err != nil {
 			return MeshState{}, errors.New("selected USB radio is unavailable")
 		}
+		if _, missing := os.Lstat(meshBinaryPath); os.IsNotExist(missing) {
+			if _, err = m.Runner.Run(ctx, systemdRunPath, "--wait", "--pipe", "--collect", "--quiet", "--unit=lightningos-mesh-repair", "--", "/usr/local/libexec/lightningos-privileged", "--repair-mesh-binary"); err != nil {
+				return MeshState{}, errors.New("mesh binary repair failed")
+			}
+		}
 		if !safeNonEmptyRegularFile(meshBinaryPath) || validateRootOwnedRegularFile(meshBinaryPath, 0755) != nil {
 			return MeshState{}, errors.New("upgrade LightningOS to install the radio bridge")
 		}

--- a/lightningos-light/internal/privileged/mesh_repair.go
+++ b/lightningos-light/internal/privileged/mesh_repair.go
@@ -1,0 +1,71 @@
+package privileged
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// RepairMeshBinary is a fixed, root-only host operation. Older upgrade helpers
+// build the new broker but omit the standalone Mesh executable. The broker
+// includes the identical unprivileged daemon entry point for this migration.
+// Existing files are never replaced, and no caller-supplied path is accepted.
+func RepairMeshBinary() error {
+	if os.Geteuid() != 0 {
+		return errors.New("root required")
+	}
+	const broker = "/usr/local/libexec/lightningos-privileged"
+	executable, err := os.Executable()
+	if err != nil || executable != broker {
+		return errors.New("unexpected repair executable")
+	}
+	return repairMeshBinaryFrom(broker, meshBinaryPath)
+}
+
+func repairMeshBinaryFrom(source, target string) error {
+	if err := validateMeshRootDirectory(filepath.Dir(target)); err != nil {
+		return err
+	}
+	if err := validateRootOwnedRegularFile(source, 0755); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(target); err == nil {
+		return validateRootOwnedRegularFile(target, 0755)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.CreateTemp(filepath.Dir(target), ".mesh-repair-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(out.Name())
+	defer out.Close()
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	if err = out.Chmod(0755); err != nil {
+		return err
+	}
+	if err = out.Sync(); err != nil {
+		return err
+	}
+	if err = out.Close(); err != nil {
+		return err
+	}
+	// Link publishes atomically without overwriting a concurrent installation.
+	if err = os.Link(out.Name(), target); err != nil {
+		return err
+	}
+	dir, err := os.Open(filepath.Dir(target))
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/lightningos-light/internal/privileged/mesh_repair_linux_test.go
+++ b/lightningos-light/internal/privileged/mesh_repair_linux_test.go
@@ -1,0 +1,47 @@
+package privileged
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMeshMissingBinaryRepair(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("root filesystem migration test")
+	}
+	dir := t.TempDir()
+	source, target := filepath.Join(dir, "broker"), filepath.Join(dir, "mesh")
+	if err := os.WriteFile(source, []byte("trusted executable"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := repairMeshBinaryFrom(source, target); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(target)
+	if !bytes.Equal(raw, []byte("trusted executable")) {
+		t.Fatal("copy mismatch")
+	}
+	// Idempotence: don't replace an already-installed standalone bridge.
+	os.WriteFile(source, []byte("different executable"), 0755)
+	if err := repairMeshBinaryFrom(source, target); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ = os.ReadFile(target)
+	if !bytes.Equal(raw, []byte("trusted executable")) {
+		t.Fatal("existing bridge overwritten")
+	}
+	os.Remove(target)
+	if err := os.Symlink(source, target); err != nil {
+		t.Fatal(err)
+	}
+	if repairMeshBinaryFrom(source, target) == nil {
+		t.Fatal("symlink target accepted")
+	}
+	os.Remove(target)
+	os.Chmod(source, 0777)
+	if repairMeshBinaryFrom(source, target) == nil {
+		t.Fatal("writable source accepted")
+	}
+}


### PR DESCRIPTION
Upgrades initiated by older embedded helpers can build the new Manager and broker while omitting lightningos-mesh. Installing/connecting Mesh now repairs a missing executable from the root-controlled local broker, which includes the identical unprivileged daemon entry point.

The repair uses fixed paths, requires root, publishes atomically without overwriting existing files, rejects unsafe paths, and leaves radio configuration unchanged. No network fetch is required.

Validation: full Go suite passed; Linux root migration and candidate deployment pending.

Candidate b741abfb deployed to LOS-TEST2 first, then Friendspool. Identical Manager/broker/bridge hashes verified. Broker self-test, authenticated API health and LND sync passed; both radios reconnected with existing settings. On LOS-TEST2, the missing executable was restored from the new broker and connected successfully before installing the standalone binary. Root Linux migration test passed (idempotence and unsafe source/symlink rejection). Physical invoice delivery and user-approved payment remain the release gate.
