### PR TITLE
0.5.28: unlock safe AutoFee discovery below idle reference floors

### DIFF
--- a/docs/AUTOFEE_IDLE_DISCOVERY.md
+++ b/docs/AUTOFEE_IDLE_DISCOVERY.md
@@ -1,0 +1,71 @@
+# AutoFee: idle-channel price discovery (0.5.28)
+
+## Purpose
+
+An Amboss/native-graph seed is a market reference, not proof that a channel can
+sell liquidity at that price. Mature channels with usable local liquidity and
+no recent outbound demand may explore below it. This is not a global fee cut,
+an automatic channel-close policy, or a change to sovereign rebalance selection.
+
+## Bounded reference-floor relaxation
+
+The existing `relaxStaleNoFlowAdvisoryFloor` path now also recognizes `rescue`,
+`rank`, and `revfloor` wrappers when their underlying reference is `seed`.
+Rebalance-cost or current-outbound-rate provenance is not eligible for those
+wrappers. Existing eligible seed and stale-outrate-memory sources remain.
+
+If the seed/no-signal hold also pins the target to the current policy, the same
+bounded experiment lowers the target, but only with Discovery enabled and a
+seed/no-signal hold identified by the evaluator. An independent upward target
+is not converted into a decrease.
+
+Eligibility retains the existing maturity/bootstrap, effective-liquidity,
+recent-rebalance and HTLC-pressure checks. The evaluator additionally checks
+seven-day forward counts/amounts: zero-fee forwards are movement, not evidence
+of no demand. No recent outbound reference, rebalance-history reference, recent
+rebalance count, weak attempt signal, or recent cost may be present.
+
+The existing step parameters are unchanged: normally at least 24 hours since
+the last outgoing change, a 4% floor step bounded to 15–60 ppm; the existing
+small-channel exception requires 96 hours and uses 2.5%, bounded to 15–20 ppm.
+Configured minimum ppm, the raw target and subsequent safety gates can reduce
+the actual step further. A just-changed or future-dated timestamp is not
+mistaken for an unknown timestamp/channel age.
+
+All downstream caps, reversals, cooldowns, economic interlock floors and fee
+contracts remain in the normal decision path. Inbound-discount calculation and
+Market Refill mode are not changed. Low-liquidity/new inbound bootstrap rules
+remain protected. This relaxation does not promise any additional routing.
+
+## Automatic idle refresh
+
+Automatic refresh still requires seven days without outgoing, incoming or
+rebalance movement, and only runs in Balanced mode when enabled.
+
+- Seed or local-policy drift no longer bypasses the seven-day repeat interval.
+- The normal evaluator keeps running during that interval; its reductions are
+  not frozen by the refresh cooldown.
+- Refresh does not replace a computed normal decrease with a hard-set reference,
+  reverse downward intent upward, raise an idle channel with sufficient effective
+  liquidity, or undercut an identified hard cost floor.
+- An enforced economic intent that must raise the normal result remains able to
+  bypass these discretionary refresh guards. A weaker floor is not permission
+  to accelerate a decrease; shadow intents cannot bypass the interval.
+- Explicit/manual refresh behavior is unchanged.
+
+No database migration, API/configuration field, production parameter adjustment,
+or change in default enablement is required.
+
+## Validation and rollout
+
+Regression coverage includes seed-wrapper provenance, bounded multi-round
+descent below a fixed seed, repeat scans, zero-fee traffic, disabled discovery,
+bootstrap/low-liquidity/cost/HTLC protections, economic-interlock precedence,
+and changed-seed refresh intervals. Existing AutoFee golden scenarios remain
+unchanged.
+
+After an operator-approved release/deploy, inspect the new tags in the Results
+history. Compare channel-level outgoing volume, revenue and available liquidity
+over completed windows, allowing time after each price experiment. Overlapping
+24-hour outcome windows are observations, not independent causal evidence that
+a fee reduction caused traffic.

--- a/docs/AUTOFEE_TAG_GLOSSARIO_PT_BR.md
+++ b/docs/AUTOFEE_TAG_GLOSSARIO_PT_BR.md
@@ -19,6 +19,10 @@ Notas:
 - `trend-flat`: tendencia neutra (sem direcao forte).
 
 ## Controles de movimento e execucao
+
+- `stale-noflow-target-relax`: canal maduro, ocioso e com liquidez local efetiva suficiente estava preso pelo alvo da seed/ausencia de sinais; uma exploracao gradual para baixo reduziu tambem o alvo. As protecoes finais continuam valendo.
+- `idle-refresh-wait`: o intervalo de sete dias do refresh automatico ainda nao terminou, mesmo que a seed tenha mudado. A decisao normal do AutoFee continua valendo.
+- `idle-refresh-preserve-decision`: o refresh de uma referencia antiga substituiria uma reducao normal, inverteria a intencao de queda, aumentaria a taxa de um canal ocioso com liquidez ou atravessaria um piso de custo real; a decisao normal foi preservada.
 - `stepcap`: alvo foi limitado por limite de passo por rodada.
 - `stepcap-lock`: alvo pedia mudanca, mas o limite de passo segurou em `same-ppm`.
 - `floor-lock`: fee final ficou travada no floor.

--- a/docs/AUTOFEE_TAG_GLOSSARY_EN.md
+++ b/docs/AUTOFEE_TAG_GLOSSARY_EN.md
@@ -19,6 +19,10 @@ Notes:
 - `trend-flat`: no strong directional trend.
 
 ## Movement and execution controls
+
+- `stale-noflow-target-relax`: a mature, idle channel with sufficient effective local liquidity was pinned by a seed/no-signal hold; a bounded downward price experiment also lowered its target. Final safety gates still apply.
+- `idle-refresh-wait`: the seven-day automatic reference-refresh interval has not elapsed, even if the seed changed. The normal AutoFee decision remains in effect.
+- `idle-refresh-preserve-decision`: a stale reference refresh would replace a normal decrease, reverse downward intent, raise an idle liquid channel, or undercut a hard cost floor; the normal decision was retained.
 - `stepcap`: target was limited by per-round step cap.
 - `stepcap-lock`: target wanted a move, but step cap kept `same-ppm`.
 - `floor-lock`: final fee is pinned at floor.

--- a/lightningos-light/internal/server/autofee_idle_discovery_test.go
+++ b/lightningos-light/internal/server/autofee_idle_discovery_test.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"lightningos-light/internal/lndclient"
+)
+
+func TestAutofeeStaleReferenceFloorSafetyMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		name, src, base                                                              string
+		target, floor                                                                int
+		liquidity, elapsed                                                           float64
+		market, flow, out, rebal, weak, cost, pressure, forwardHot, bootstrap, young bool
+		wantRelax                                                                    bool
+	}{
+		{name: "rescue seed above current", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, wantRelax: true},
+		{name: "amboss or native seed flat target", src: "no-signal", base: "seed", target: 740, floor: 740, liquidity: .49, elapsed: 48, wantRelax: true},
+		{name: "ranking wrapper", src: "rank", base: "seed", target: 278, floor: 740, liquidity: .49, elapsed: 48, wantRelax: true},
+		{name: "revenue fallback wrapper", src: "revfloor", base: "seed", target: 278, floor: 740, liquidity: .49, elapsed: 48, wantRelax: true},
+		{name: "real rescue cost", src: "rescue", base: "rebal", target: 278, floor: 821, liquidity: .49, elapsed: 48},
+		{name: "real revenue reference", src: "revfloor", base: "outrate", target: 278, floor: 821, liquidity: .49, elapsed: 48},
+		{name: "hard cost", src: "rebal-sink", base: "rebal", target: 278, floor: 821, liquidity: .49, elapsed: 48},
+		{name: "low liquidity", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .05, elapsed: 48},
+		{name: "just changed", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 0},
+		{name: "future last change", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: -1},
+		{name: "recent change", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 23},
+		{name: "up intent", src: "rescue", base: "seed", target: 800, floor: 821, liquidity: .49, elapsed: 48},
+		{name: "not blocked", src: "rescue", base: "seed", target: 278, floor: 700, liquidity: .49, elapsed: 48},
+		{name: "market refill", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, market: true},
+		{name: "flow", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, flow: true},
+		{name: "out rate", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, out: true},
+		{name: "rebalance history", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, rebal: true},
+		{name: "weak recent rebalance", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, weak: true},
+		{name: "recent cost", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, cost: true},
+		{name: "liquidity pressure", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, pressure: true},
+		{name: "forward pressure", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, forwardHot: true},
+		{name: "new inbound", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, bootstrap: true},
+		{name: "young outbound", src: "rescue", base: "seed", target: 278, floor: 821, liquidity: .49, elapsed: 48, young: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := func(b bool) int {
+				if b {
+					return 1
+				}
+				return 0
+			}
+			age := float64(30 * 24)
+			if tc.young {
+				age = 1
+			}
+			floor, src, tags := relaxStaleNoFlowAdvisoryFloor(tc.market, 740, tc.target, tc.floor, tc.src, tc.base,
+				outRatioNormalizationMeta{Raw: .99, Effective: tc.liquidity}, .20, !tc.flow,
+				flag(tc.out), flag(tc.rebal), 0, flag(tc.weak), flag(tc.cost), tc.pressure, tc.forwardHot,
+				tc.bootstrap, age, defaultBootstrapHours, tc.elapsed, 10)
+			if tc.wantRelax {
+				if floor != 710 || src != "stale-noflow" || !containsTag(tags, "advisory-floor-relax") {
+					t.Fatalf("expected bounded 30 ppm experiment: floor=%d src=%s tags=%v", floor, src, tags)
+				}
+			} else if floor != tc.floor || src != tc.src || len(tags) != 0 {
+				t.Fatalf("protection changed: floor=%d src=%s tags=%v", floor, src, tags)
+			}
+		})
+	}
+}
+
+func evaluateIdleDiscoveryChannel(e *autofeeEngine, ch lndclient.ChannelInfo, st *autofeeChannelState, fwd7d map[uint64]forwardStat) *decision {
+	return e.evaluateChannel(ch, st, fwd7d, nil, fwd7d, nil, nil, nil,
+		rebalStats{}, rebalStats{}, rebalStats{}, nil, nil, 0, 0, false)
+}
+
+func TestAutofeeIdleDiscoveryFullChannelProgressesBelowSeed(t *testing.T) {
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	cfg := goldenDefaultCfg()
+	cfg.RebalCostMode = "channel"
+	e := newGoldenEngine(t, cfg, goldenDefaultCalib(), now)
+	ch := goldenChannel(310, 4_000_000, 3_960_000, 1000, true)
+	st := &autofeeChannelState{ChannelID: ch.ChannelID, LastPpm: 1000, LastSeed: 1400, FirstSeen: now.Add(-60 * 24 * time.Hour), LastTs: now.Add(-48 * time.Hour)}
+	for round := 0; round < 3; round++ {
+		before := int(*ch.FeeRatePpm)
+		d := evaluateIdleDiscoveryChannel(e, ch, st, nil)
+		if !d.Apply || d.NewPpm >= before || before-d.NewPpm > staleNoFlowDownMaxStepPpm || !containsTag(d.Tags, "stale-noflow-target-relax") {
+			t.Fatalf("round %d: expected gradual down below unchanged seed: local=%d new=%d floor=%d/%s raw=%d tags=%v", round, before, d.NewPpm, d.Floor, d.FloorSrc, d.TargetRaw, d.Tags)
+		}
+		ch.FeeRatePpm = goldenInt64Ptr(int64(d.NewPpm))
+		// A second scan must not turn the daily experiment into per-run decay.
+		e.now = e.now.Add(time.Hour)
+		recheck := evaluateIdleDiscoveryChannel(e, ch, st, nil)
+		if containsTag(recheck.Tags, "stale-noflow-target-relax") {
+			t.Fatalf("round %d: stale experiment repeated too soon: %v", round, recheck.Tags)
+		}
+		e.now = e.now.Add(25 * time.Hour)
+	}
+}
+
+func TestAutofeeIdleDiscoveryStillEnforcesInterlockFloor(t *testing.T) {
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	cfg := goldenDefaultCfg()
+	cfg.RebalCostMode = "channel"
+	e := newGoldenEngine(t, cfg, goldenDefaultCalib(), now)
+	ch := goldenChannel(310, 4_000_000, 3_960_000, 1000, true)
+	e.automationIntentConfig = AutomationIntentConfig{Mode: automationIntentModeEnforce, MinConfidence: .70}
+	e.automationIntents = map[uint64][]AutomationIntent{ch.ChannelID: {{Kind: automationIntentKindProtectFeeFloor, Confidence: .95, FeeFloorPPM: 1000}}}
+	st := &autofeeChannelState{ChannelID: ch.ChannelID, LastPpm: 1000, LastSeed: 1400, FirstSeen: now.Add(-60 * 24 * time.Hour), LastTs: now.Add(-48 * time.Hour)}
+	d := evaluateIdleDiscoveryChannel(e, ch, st, nil)
+	if !containsTag(d.Tags, "stale-noflow-target-relax") || !containsTag(d.Tags, "intent-protect-fee-floor") || d.NewPpm < 1000 {
+		t.Fatalf("discovery must remain subordinate to economic protection: new=%d tags=%v", d.NewPpm, d.Tags)
+	}
+}
+
+func TestAutofeeIdleRefreshCannotUndoDiscoveryWithCheaperProtectedReference(t *testing.T) {
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	cfg := goldenDefaultCfg()
+	cfg.IdleRefreshEnabled = true
+	cfg.NativeSeedEnabled = true
+	e := newGoldenEngine(t, cfg, goldenDefaultCalib(), now)
+	ch := goldenChannel(310, 4_000_000, 3_960_000, 1000, true)
+	e.nativeSeedCache[ch.RemotePubkey] = autofeeSeedResult{Seed: 500, Ok: true}
+	e.automationIntentConfig = AutomationIntentConfig{Mode: automationIntentModeEnforce, MinConfidence: .70}
+	e.automationIntents = map[uint64][]AutomationIntent{ch.ChannelID: {{Kind: automationIntentKindProtectFeeFloor, Confidence: .95, FeeFloorPPM: 700}}}
+	st := &autofeeChannelState{LastPpm: 960, LastTs: now}
+	d := &decision{LocalPpm: 1000, NewPpm: 960, Target: 960, Apply: true, State: st}
+	d = e.maybeApplyIdleRefresh(context.Background(), ch, d, forwardStat{}, forwardStat{}, inboundStat{}, rebalStat{}, rebalStat{}, rebalStat{})
+	if d.NewPpm != 960 || !d.Apply || !st.LastIdleRefreshTs.IsZero() || !containsTag(d.Tags, "idle-refresh-preserve-decision") {
+		t.Fatalf("700 ppm floor is not permission to replace a bounded 960 ppm decrease: %+v", d)
+	}
+}
+
+func TestAutofeeIdleDiscoveryPreservesZeroFeeTrafficAndDisabledDiscovery(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		discovery bool
+		fwd       forwardStat
+	}{
+		{"zero fee traffic", true, forwardStat{Count: 1, AmtMsat: 100000}},
+		{"discovery disabled", false, forwardStat{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+			cfg := goldenDefaultCfg()
+			cfg.DiscoveryEnabled = tc.discovery
+			cfg.RebalCostMode = "channel"
+			e := newGoldenEngine(t, cfg, goldenDefaultCalib(), now)
+			ch := goldenChannel(310, 4_000_000, 3_960_000, 1000, true)
+			st := &autofeeChannelState{ChannelID: ch.ChannelID, LastPpm: 1000, LastSeed: 1400, FirstSeen: now.Add(-60 * 24 * time.Hour), LastTs: now.Add(-48 * time.Hour)}
+			d := evaluateIdleDiscoveryChannel(e, ch, st, map[uint64]forwardStat{ch.ChannelID: tc.fwd})
+			if containsTag(d.Tags, "stale-noflow-target-relax") {
+				t.Fatalf("unexpected no-demand experiment: %v", d.Tags)
+			}
+		})
+	}
+}
+
+func TestAutofeeIdleRefreshPreservesNormalDecision(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		next, target, refresh int
+		good                  bool
+		src, base             string
+		floor                 int
+		want                  bool
+	}{
+		{"normal down vs seed up", 670, 600, 728, true, "seed", "seed", 500, true},
+		{"normal down vs larger seed down", 670, 600, 400, true, "seed", "seed", 500, true},
+		{"down intent held", 700, 600, 728, false, "rescue", "seed", 730, true},
+		{"good liquidity no demand", 700, 700, 728, true, "no-signal", "seed", 700, true},
+		{"low liquidity bootstrap unchanged", 700, 700, 728, false, "seed", "seed", 700, false},
+		{"hard floor", 700, 700, 600, false, "rebal-sink", "rebal", 700, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &decision{LocalPpm: 700, NewPpm: tc.next, Target: tc.target, Floor: tc.floor, FloorSrc: tc.src, FloorBaseSrc: tc.base}
+			if got := shouldPreserveAutofeeDecisionOnIdleRefresh(d, tc.refresh, tc.good); got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAutofeeIdleRefreshEngineIntervalAndEconomicFloor(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		elapsed time.Duration
+		floor   int
+		mode    string
+		want    int
+		tag     string
+	}{
+		{"changed seed waits", time.Hour, 0, automationIntentModeOff, 700, "idle-refresh-wait"},
+		{"interval expires", 7 * 24 * time.Hour, 0, automationIntentModeOff, 910, "idle-refresh"},
+		{"enforced floor bypasses interval", time.Hour, 1000, automationIntentModeEnforce, 1000, "idle-refresh-intent-floor"},
+		{"shadow cannot bypass interval", time.Hour, 1000, automationIntentModeShadow, 700, "idle-refresh-wait"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+			cfg := goldenDefaultCfg()
+			cfg.IdleRefreshEnabled = true
+			cfg.NativeSeedEnabled = true
+			e := newGoldenEngine(t, cfg, goldenDefaultCalib(), now)
+			ch := goldenChannel(310, 4_000_000, 40_000, 700, false)
+			e.nativeSeedCache[ch.RemotePubkey] = autofeeSeedResult{Seed: 700, Ok: true}
+			e.automationIntentConfig = AutomationIntentConfig{Mode: tc.mode, MinConfidence: .70}
+			e.automationIntents = map[uint64][]AutomationIntent{ch.ChannelID: {{Kind: automationIntentKindProtectFeeFloor, Confidence: .95, FeeFloorPPM: int64(tc.floor)}}}
+			st := &autofeeChannelState{LastIdleRefreshTs: now.Add(-tc.elapsed), LastIdleRefreshPpm: 650}
+			d := &decision{LocalPpm: 700, NewPpm: 700, Target: 700, State: st}
+			d = e.maybeApplyIdleRefresh(context.Background(), ch, d, forwardStat{}, forwardStat{}, inboundStat{}, rebalStat{}, rebalStat{}, rebalStat{})
+			if d.NewPpm != tc.want || !containsTag(d.Tags, tc.tag) {
+				t.Fatalf("got %d want %d tag=%s tags=%v", d.NewPpm, tc.want, tc.tag, d.Tags)
+			}
+		})
+	}
+}

--- a/lightningos-light/internal/server/autofee_service.go
+++ b/lightningos-light/internal/server/autofee_service.go
@@ -5462,17 +5462,28 @@ func shouldSkipAutofeeIdleRefreshRepeat(st *autofeeChannelState, now time.Time, 
 	if st == nil || targetPpm <= 0 || st.LastIdleRefreshTs.IsZero() {
 		return false
 	}
-	if targetPpm != localPpm && !shouldHoldAutofeeSmallDelta(localPpm, targetPpm) {
-		return false
-	}
-	if st.LastIdleRefreshPpm > 0 && st.LastIdleRefreshPpm != targetPpm {
-		return false
-	}
+	// Reference drift is not new channel demand. Let the normal evaluator
+	// continue discovering prices between scheduled refreshes.
 	elapsed := now.Sub(st.LastIdleRefreshTs)
 	if elapsed < 0 {
 		return true
 	}
 	return elapsed < time.Duration(autofeeIdleRefreshWindowDays)*24*time.Hour
+}
+
+func shouldPreserveAutofeeDecisionOnIdleRefresh(d *decision, refreshTargetPpm int, goodLiquidity bool) bool {
+	if d == nil {
+		return true
+	}
+	// Never replace an already computed decrease (and its caps/cooldowns) with
+	// a hard-set reference, nor let a stale reference reverse downward intent.
+	if d.NewPpm < d.LocalPpm || (d.Target < d.LocalPpm && refreshTargetPpm >= d.LocalPpm) {
+		return true
+	}
+	if goodLiquidity && refreshTargetPpm > d.LocalPpm {
+		return true
+	}
+	return isHardAutofeeFloorSource(d.FloorSrc, d.FloorBaseSrc) && refreshTargetPpm < d.Floor
 }
 
 func minAutofeeApplyDeltaPpm(localPpm int) int {
@@ -5663,7 +5674,7 @@ func (e *autofeeEngine) maybeApplyIdleRefresh(ctx context.Context, ch lndclient.
 	if ch.CapacitySat > 0 {
 		rawOutRatio = float64(ch.LocalBalanceSat) / float64(ch.CapacitySat)
 	}
-	effectiveOutRatio, _ := effectiveChannelOutRatio(rawOutRatio, ch.LocalBalanceSat, ch.CapacitySat, e.calib.AvgCapacitySat, e.calib.LocalRatio)
+	effectiveOutRatio, outNormMeta := effectiveChannelOutRatio(rawOutRatio, ch.LocalBalanceSat, ch.CapacitySat, e.calib.AvgCapacitySat, e.calib.LocalRatio)
 	if adjustedTargetPpm, adjustedReferencePpm, adjustedSource, adjusted := applyAutofeeRefreshSeedLiquidityAdjustment(
 		targetPpm,
 		referencePpm,
@@ -5688,10 +5699,23 @@ func (e *autofeeEngine) maybeApplyIdleRefresh(ctx context.Context, ch lndclient.
 		e.cfg.MinPpm,
 		intentMaxPpm,
 	)
-	if shouldSkipAutofeeIdleRefreshRepeat(d.State, e.now, d.LocalPpm, effectiveTargetPpm) {
+	protectFloor := intent != nil && !intentShadow && effectiveTargetPpm != refreshTargetPpm
+	mustRaiseFloor := protectFloor && effectiveTargetPpm > d.NewPpm
+	if isHardAutofeeFloorSource(d.FloorSrc, d.FloorBaseSrc) && effectiveTargetPpm < d.Floor {
+		d.Tags = appendAutofeeTagOnce(d.Tags, "idle-refresh-preserve-decision")
 		return d
 	}
-	protectFloor := intent != nil && !intentShadow && effectiveTargetPpm != refreshTargetPpm
+	goodLiquidity := hasGoodLocalLiquidityForAutofeeUp(effectiveOutRatio, dynamicGoodOutRatio(e.profile, e.calib.LiquidityClass, e.calib.LocalRatio, outNormMeta))
+	if !mustRaiseFloor && shouldPreserveAutofeeDecisionOnIdleRefresh(d, refreshTargetPpm, goodLiquidity) {
+		d.Tags = appendAutofeeTagOnce(d.Tags, "idle-refresh-preserve-decision")
+		return d
+	}
+	// Economic protection may become stricter during the interval. It must
+	// still be enforced; only discretionary reference refreshes wait.
+	if !mustRaiseFloor && shouldSkipAutofeeIdleRefreshRepeat(d.State, e.now, d.LocalPpm, effectiveTargetPpm) {
+		d.Tags = appendAutofeeTagOnce(d.Tags, "idle-refresh-wait")
+		return d
+	}
 	applyAutofeeIdleRefreshDecisionWithFloor(d, e.now, effectiveTargetPpm, referencePpm, source, protectFloor)
 	if intent != nil {
 		// Keep the idle-refresh reference visible as the raw target while making
@@ -7563,6 +7587,10 @@ func isStaleNoFlowAdvisoryFloorSource(src string, baseSrc string) bool {
 		return true
 	case "outrate":
 		return strings.TrimSpace(baseSrc) == "outrate-mem"
+	case "rescue", "rank", "revfloor":
+		// These wrappers may carry either a seed or a real economic floor.
+		// Only seed provenance is eligible for this no-demand relaxation.
+		return strings.TrimSpace(baseSrc) == "seed"
 	default:
 		return false
 	}
@@ -7593,7 +7621,7 @@ func relaxStaleNoFlowAdvisoryFloor(
 ) (int, string, []string) {
 	if marketRefillMode ||
 		localPpm <= minPpm ||
-		targetPpm >= localPpm ||
+		targetPpm > localPpm ||
 		floorPpm < localPpm ||
 		!noFlow1d ||
 		outPpm7d > 0 ||
@@ -7615,9 +7643,8 @@ func relaxStaleNoFlowAdvisoryFloor(
 	if channelAgeHours <= float64(bootstrapHours) {
 		return floorPpm, floorSrc, nil
 	}
-	if hoursSinceLastChange <= 0 {
-		hoursSinceLastChange = channelAgeHours
-	}
+	// Zero means a change just happened, not an unknown timestamp. The caller
+	// already substitutes channel age when no last-change timestamp exists.
 	if hoursSinceLastChange < 0 {
 		hoursSinceLastChange = 0
 	}
@@ -7647,7 +7674,7 @@ func relaxStaleNoFlowAdvisoryFloor(
 	step := int(math.Round(float64(localPpm) * stepFrac))
 	step = clampInt(step, staleNoFlowDownMinStepPpm, maxStep)
 	relaxed := localPpm - step
-	if targetPpm > relaxed {
+	if targetPpm < localPpm && targetPpm > relaxed {
 		relaxed = targetPpm
 	}
 	if relaxed < minPpm {
@@ -11291,7 +11318,8 @@ func (e *autofeeEngine) evaluateChannel(ch lndclient.ChannelInfo, st *autofeeCha
 		floorBaseSrc,
 		outNormMeta,
 		goodOutRatio,
-		noFlow1d,
+		noFlow1d && !hasAutofeeForwardMovement(fwd7d) &&
+			(target < localPpm || (e.cfg.DiscoveryEnabled && (noSignalNoUpActive || seedFullHoldActive))),
 		outPpm7d,
 		rebalHistoryRefPpm,
 		recentRebalanceRelevantCount,
@@ -11308,6 +11336,15 @@ func (e *autofeeEngine) evaluateChannel(ch lndclient.ChannelInfo, st *autofeeCha
 		floor = relaxedFloor
 		floorSrc = relaxedSrc
 		tags = append(tags, relaxTags...)
+		if target == localPpm {
+			// A no-signal/seed hold can pin the target as well as the floor.
+			// Use the same bounded experiment; all final safety gates still run.
+			target = relaxedFloor
+			rawStep = applyStepCap(localPpm, target, capFrac, minStepDown, capRefPpm)
+			tags = removeAutofeeTags(tags, map[string]bool{"trend-flat": true})
+			tags = appendAutofeeTagOnce(tags, "stale-noflow-target-relax")
+			tags = appendAutofeeTagOnce(tags, "trend-down")
+		}
 	}
 	if target < localPpm && floor >= localPpm {
 		stallRelaxGapFrac := e.profile.StallFloorRelaxGapFrac
@@ -13469,6 +13506,8 @@ func formatAutofeeTags(d *decision) string {
 			add("🧭cap")
 		case t == "idle-refresh":
 			add("idle-refresh")
+		case t == "idle-refresh-wait" || t == "idle-refresh-preserve-decision":
+			add(t)
 		case strings.HasPrefix(t, "idle-refresh:"):
 			add(t)
 		case t == "rescue":
@@ -13673,6 +13712,8 @@ func formatAutofeeTags(d *decision) string {
 			add("🧯noflow-up-cap")
 		case t == "stale-noflow-down":
 			add("stale-noflow-down")
+		case t == "stale-noflow-target-relax":
+			add(t)
 		case t == "stale-noflow-small-down":
 			add("stale-noflow-small")
 		case t == "neg-margin-stale-down":

--- a/lightningos-light/internal/server/autofee_service_test.go
+++ b/lightningos-light/internal/server/autofee_service_test.go
@@ -810,14 +810,14 @@ func TestShouldSkipAutofeeIdleRefreshRepeat(t *testing.T) {
 	if !shouldSkipAutofeeIdleRefreshRepeat(st, now, 650, 650) {
 		t.Fatalf("expected recent same-ppm idle refresh to be skipped")
 	}
-	if shouldSkipAutofeeIdleRefreshRepeat(st, now, 600, 650) {
-		t.Fatalf("expected local ppm drift to allow idle refresh retry")
+	if !shouldSkipAutofeeIdleRefreshRepeat(st, now, 600, 650) {
+		t.Fatalf("local ppm drift must not bypass the idle refresh interval")
 	}
 	if !shouldSkipAutofeeIdleRefreshRepeat(st, now, 649, 650) {
 		t.Fatalf("expected recent same-target small-delta idle refresh to be skipped")
 	}
-	if shouldSkipAutofeeIdleRefreshRepeat(st, now, 650, 700) {
-		t.Fatalf("expected target change to allow idle refresh")
+	if !shouldSkipAutofeeIdleRefreshRepeat(st, now, 650, 700) {
+		t.Fatalf("reference drift must not bypass the idle refresh interval")
 	}
 	st.LastIdleRefreshTs = now.Add(-time.Duration(autofeeIdleRefreshWindowDays)*24*time.Hour - time.Minute)
 	st.LastIdleRefreshPpm = 650


### PR DESCRIPTION
## Summary

Allow mature, idle channels with sufficient effective local liquidity to continue bounded price discovery below synthetic reference floors, without weakening real-cost, low-liquidity or new-inbound protection.

Base: `agent/0.5.28-release`. No deployment or production configuration changes.

## Changes

- Reuse the existing stale/no-flow relaxation for seed-backed `rescue`, `rank` and `revfloor` wrappers; retain economic provenance checks.
- When Discovery is enabled and a seed/no-signal hold pins both target and floor, lower the target using the same bounded experiment instead of remaining stuck indefinitely.
- Require no seven-day forwarding movement, including zero-fee forwards; preserve bootstrap, effective-liquidity, rebalance and HTLC guards.
- Keep existing step parameters (normal 24h / 4%, bounded 15–60 ppm; existing small-channel exception 96h / 2.5%, bounded 15–20 ppm), followed by all normal final controls.
- Do not treat a just-changed/future timestamp as channel age.
- Make automatic idle-refresh repeat interval effective despite reference drift; keep the normal evaluator running between refreshes.
- Prevent stale refresh from replacing bounded decreases, reversing downward intent upward, raising idle liquid channels, or undercutting identified hard costs. Stronger enforced interlock protection can still take precedence; weaker/shadow floors cannot bypass these guards.
- Add auditable result tags, bilingual glossary entries and behavior/rollout documentation.

Manual refresh, Market Refill, inbound-discount calculation, default settings, API and schema are unchanged.

## Regression coverage

New tests cover wrapped seed vs real-cost provenance, multiple bounded reductions below an unchanged seed, repeat scans, zero-fee traffic, Discovery disabled, economic interlock precedence, low liquidity/bootstrap/HTLC/rebalance restrictions, changed-reference cooldown, interval expiry and shadow mode. Existing golden AutoFee scenarios were not rewritten.

## Validation

- PASS: `go test ./... -count=1`
- PASS: `go test ./internal/server -count=1`
- PASS: focused new AutoFee regressions repeated 10 times
- PASS: manager build for Windows and Linux
- PASS: `git diff --check`
- Existing unrelated limitation: explicit `go vet ./...` reports unreachable code at `internal/privileged/apps.go:1230`. That file is byte-identical to the base branch (Git blob `fb02735be1954b0ba8ca55def140e736821b5ca8`), and is not changed here.

## Operator validation after release

Inspect `stale-noflow-target-relax`, `idle-refresh-wait` and `idle-refresh-preserve-decision`. Compare completed channel-level windows for liquidity, outgoing volume and revenue, while keeping enforced economic floors. Additional traffic is not guaranteed; overlapping outcome windows are not independent causal evidence.