### PR TITLE
0.5.28-Beta: update LNbits to 1.6.1 and LND installer to 0.21.3-beta

### DIFF
--- a/lightningos-light/install.sh
+++ b/lightningos-light/install.sh
@@ -17,7 +17,7 @@ if [[ ! -r "$ARTIFACT_VERIFY_SCRIPT" ]]; then
 fi
 source "$ARTIFACT_VERIFY_SCRIPT"
 
-LND_VERSION="0.21.2-beta"
+LND_VERSION="0.21.3-beta"
 
 GOTTY_VERSION="1.8.0"
 GOTTY_ARTIFACT="gotty_v${GOTTY_VERSION}_linux_amd64.tar.gz"

--- a/lightningos-light/internal/appmanifest/catalog_test.go
+++ b/lightningos-light/internal/appmanifest/catalog_test.go
@@ -122,10 +122,13 @@ func TestCatalogImageVariantsAreClosedByApp(t *testing.T) {
 }
 
 func TestLNbitsCatalogPinsOfficialStableManifest(t *testing.T) {
-	if LNbitsRelease != "1.5.6" {
+	if LNbitsRelease != "1.6.1" {
 		t.Fatalf("unexpected LNbits release: %q", LNbitsRelease)
 	}
-	if LNbitsImage != "lnbits/lnbits:v1.5.6@sha256:"+LNbitsManifestSHA256 {
+	if LNbitsManifestSHA256 != "fe328a130414d54e45c54e4c12b44ea10b4b542eace7df9e66f5b076b2e33816" {
+		t.Fatalf("unexpected LNbits manifest digest: %q", LNbitsManifestSHA256)
+	}
+	if LNbitsImage != "lnbits/lnbits:v1.6.1@sha256:"+LNbitsManifestSHA256 {
 		t.Fatalf("LNbits image is not pinned to the catalog digest: %q", LNbitsImage)
 	}
 	if len(LNbitsManifestSHA256) != 64 || strings.Contains(LNbitsImage, ":latest") {

--- a/lightningos-light/internal/appmanifest/lnbits.go
+++ b/lightningos-light/internal/appmanifest/lnbits.go
@@ -13,8 +13,8 @@ const (
 	LNbitsComposeFile                    = "docker-compose.yaml"
 	LNbitsEnvFile                        = ".env"
 	LNbitsPrimaryService                 = "lnbits"
-	LNbitsRelease                        = "1.5.6"
-	LNbitsManifestSHA256                 = "6e37fbf9b847c066d7e022e19a018b3df7f12602a370f117857165d36bfb165b"
+	LNbitsRelease                        = "1.6.1"
+	LNbitsManifestSHA256                 = "fe328a130414d54e45c54e4c12b44ea10b4b542eace7df9e66f5b076b2e33816"
 	LNbitsImage                          = "lnbits/lnbits:v" + LNbitsRelease + "@sha256:" + LNbitsManifestSHA256
 	LNbitsMacaroonFile                   = "lnbits.macaroon"
 	LNbitsTLSCertFile                    = "tls.cert"

--- a/lightningos-light/internal/server/apps_lnbits.go
+++ b/lightningos-light/internal/server/apps_lnbits.go
@@ -296,7 +296,7 @@ func validateLnbitsCredentialNotAdmin(credential []byte) error {
 	return nil
 }
 
-// LNbits v1.5.6 uses this credential for both LndRestWallet and its built-in
+// LNbits v1.6.1 uses this credential for both LndRestWallet and its built-in
 // LndRestNode manager. The latter adds node info, peer, channel, fee-policy,
 // and on-chain balance/open/close RPCs to the wallet's invoice/payment calls.
 func lnbitsMacaroonPermissions() []lndclient.MacaroonPermission {

--- a/lightningos-light/internal/server/installer_scripts_test.go
+++ b/lightningos-light/internal/server/installer_scripts_test.go
@@ -255,7 +255,7 @@ func TestInstallersUseAuthenticatedLNDReleaseHelper(t *testing.T) {
 	}
 	fresh := strings.ReplaceAll(string(freshRaw), "\r\n", "\n")
 	for _, expected := range []string{
-		`LND_VERSION="0.21.2-beta"`,
+		`LND_VERSION="0.21.3-beta"`,
 		`"$LND_UPGRADE_SCRIPT" --version "$LND_VERSION" --install-new`,
 		`Unable to authenticate the installed LND version; refusing replacement`,
 	} {


### PR DESCRIPTION
## Summary

- update the App Store LNbits image from v1.5.6 to the official stable v1.6.1 release
- pin the verified Docker Hub multi-architecture OCI digest for amd64 and arm64
- update fresh install.sh deployments from LND v0.21.2-beta to the official v0.21.3-beta release
- keep install_existing.sh unchanged because it adopts the host's pre-existing LND

## Validation

- go test ./...
- go test ./internal/server -run TestValidateAppRegistry -count=1
- Git Bash syntax validation for install.sh and the authenticated LND upgrade helper
- verified the LNbits v1.6.1 OCI index and platform manifests directly from Docker Hub
- verified the LND v0.21.3-beta release and Linux amd64/arm64 assets from the official GitHub release

## Upstream releases

- https://github.com/lnbits/lnbits/releases/tag/v1.6.1
- https://github.com/lightningnetwork/lnd/releases/tag/v0.21.3-beta