### PR TITLE
0.5.28: fix upgrade log compatibility and Tor repository conflicts

### DIFF
--- a/docs/03_API_SPEC.md
+++ b/docs/03_API_SPEC.md
@@ -191,10 +191,12 @@ Body:
 GET /api/tor/upgrade/status
 - Returns the installed Tor/runtime version, current APT candidate, package source, service/port health, update availability, transient upgrade state, and check timestamp.
 - `force=1` refreshes APT metadata before returning status.
+- `can_update` is also true for a recognized `Signed-By` conflict on the exact official Tor repository, even when APT cannot resolve a candidate. `error` explains the conflict and the confirmed upgrade/reconciliation action. Unrelated APT errors do not enable this recovery path.
 
 POST /api/tor/upgrade/start
 - Starts a transient `lightningos-tor-upgrade` systemd unit after the authenticated UI confirmation.
 - The embedded helper configures the official Tor Project repository when missing, upgrades `tor`, `tor-geoipdb`, and the repository keyring, restarts Tor, and waits for bootstrap.
+- After authenticating the pinned key and repository signature, it backs up and reconciles active Tor entries for the current OS suite in `.list` and `.sources` files. Unrelated repositories and disabled entries are preserved; mixed URI/suite stanzas are refused before writes. Reconciliation also handles a recognized conflict that left the APT candidate unavailable. It does not force a package downgrade or a service restart when no package update occurs.
 - Returns `409` when an upgrade is already running or the official candidate is already installed.
 
 ## Wizard

--- a/docs/TOR_UPGRADE_COMPATIBILITY.md
+++ b/docs/TOR_UPGRADE_COMPATIBILITY.md
@@ -1,0 +1,76 @@
+# Upgrade logs and existing Tor repositories (0.5.28)
+
+## Scope
+
+Two independent failures were observed on BRLN HUB: journal reads failed only
+when the browser's RFC3339 `since` filter was supplied, and the actual Tor
+upgrade failed because duplicate official APT sources used different Signed-By
+keyring paths. A logging failure alone does not imply an upgrade failure.
+
+The shared journal reader now converts RFC3339 timestamps into an explicit UTC
+calendar timestamp understood by older journalctl versions. It preserves the
+instant, handles offsets/day boundaries and retains microsecond precision.
+Relative and existing journal-native filters remain unchanged. Output formatting
+and the bounded line limit are unchanged. Tor's own bootstrap check also uses
+the UTC calendar spelling.
+
+## Tor source reconciliation
+
+Only the confirmed Tor upgrade workflow writes configuration. Status remains
+read-only (except the existing explicit `force=1` metadata refresh).
+
+1. Download and verify the pinned Tor key fingerprint and signed InRelease.
+2. In verify-only mode, exit without touching source/keyring files.
+3. Preflight all eligible APT source files, directory ownership and keyring paths.
+   Refuse symlinks, hard-linked source files and unsafe writable/owned paths.
+4. Plan changes to active official Tor entries for the current OS suite. Support
+   both `.list`/`deb-src` and deb822 `.sources`, including field continuations.
+   Keep disabled entries, unrelated repositories and other suites unchanged.
+   A stanza mixing Tor with unrelated URIs or suites is refused before writes;
+   the operator must split that exact stanza manually.
+5. Back up every changed source/keyring under a mode-0700 directory named
+   `/etc/apt/lightningos-tor-backup-*`, with originals and `manifest.json`.
+6. Comment superseded entries and maintain one canonical current-suite Tor
+   stanza in `sources.list.d/tor.sources`, preserving unrelated stanzas there.
+   Write the authenticated keyring. Files are replaced atomically individually;
+   a caught partial-write failure restores files changed by this invocation.
+7. Run the existing APT update/install/version checks. Do not downgrade. Only
+   restart Tor when an actual package update occurred and restart was authorized.
+
+The reconciler uses Python 3's standard library; it refuses to proceed if Python
+3 is unavailable. Its code is embedded in the existing broker-pinned shell
+helper, not downloaded or invoked from an untrusted sidecar. Manager and broker
+must be released/upgraded together because the helper digest changed.
+
+When APT cannot resolve a candidate due to the exact official Tor Signed-By
+conflict, status enables the existing confirmed Upgrade action and explains why.
+Other APT errors do not enable this recovery exception. Automatic discovery of
+an error never performs the repair by itself.
+
+## Recovery and validation
+
+The journal prints the backup directory before the first write. To undo a
+completed reconciliation, an operator should inspect its manifest, restore only
+the listed original files/modes and remove only listed newly created files.
+Restoring the original conflicting sources will also restore the APT conflict.
+Backups are retained; unrelated APT failures after reconciliation do not trigger
+an automatic return to a known conflicting configuration. Power loss is not a
+multi-file atomic transaction; the retained backup supports manual recovery.
+
+Tests exercise the embedded Python against isolated jammy/noble fixtures,
+idempotence, mixed files, refusals, backups, partial-write rollback and path
+safety. They never invoke APT/systemctl or modify the host's `/etc`. The full
+manager/broker artifact still requires normal release deployment and runtime
+validation; a cross-build or fixture is not a production deployment test.
+
+After an approved release, validate log filtering, Tor version/ports, LND sync,
+and APT status. Do not infer an upgrade failure solely from a missing log panel.
+
+## Format reference
+
+Ubuntu 22.04's [systemd.time documentation](https://manpages.ubuntu.com/manpages/jammy/man7/systemd.time.7.html)
+specifies the UTC calendar spelling and fractional seconds used for compatibility.
+
+APT's [sources.list documentation](https://manpages.debian.org/bookworm/apt/sources.list.5.en.html)
+defines line/deb822 formats, disabled entries and consistency requirements for
+options such as Signed-By across the same URI and suite.

--- a/lightningos-light/internal/privileged/tor_upgrade.go
+++ b/lightningos-light/internal/privileged/tor_upgrade.go
@@ -9,7 +9,7 @@ const (
 	torUpgradeHelperPath   = "/usr/local/sbin/lightningos-check-tor-update"
 	torUpgradeUnit         = "lightningos-tor-upgrade"
 	torVerifyUnit          = "lightningos-tor-verify"
-	torUpgradeHelperSHA256 = "3ba5b795d3a45403abc47126639ae76d0e3a0b2beaf0f8b231d51a87832240c5"
+	torUpgradeHelperSHA256 = "583c22363e74c8ea4b694e1b816c8db4f8db09f607decd16bfc771961c770141"
 	torAptGetPath          = "/usr/bin/apt-get"
 )
 

--- a/lightningos-light/internal/privileged/tor_upgrade_digest_test.go
+++ b/lightningos-light/internal/privileged/tor_upgrade_digest_test.go
@@ -1,0 +1,22 @@
+package privileged
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"testing"
+)
+
+func TestTorUpgradeHelperDigestAndPayloadSize(t *testing.T) {
+	helper, err := os.ReadFile("../server/assets/check-tor-update.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(helper)
+	if got := hex.EncodeToString(digest[:]); got != torUpgradeHelperSHA256 {
+		t.Fatalf("broker/helper digest mismatch: got %s", got)
+	}
+	if len(helper) >= 48*1024 {
+		t.Fatalf("helper exceeds broker payload limit: %d bytes", len(helper))
+	}
+}

--- a/lightningos-light/internal/server/assets/check-tor-update.sh
+++ b/lightningos-light/internal/server/assets/check-tor-update.sh
@@ -11,7 +11,6 @@ TOR_REPO_URL="https://deb.torproject.org/torproject.org"
 TOR_REPO_KEY_URL="${TOR_REPO_URL}/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc"
 TOR_REPO_KEY_FINGERPRINT="A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89"
 TOR_KEYRING="/usr/share/keyrings/deb.torproject.org-keyring.gpg"
-TOR_SOURCES="/etc/apt/sources.list.d/tor.sources"
 ASSUME_YES=0
 AUTO_CONFIGURE_REPO=0
 AUTO_RESTART=0
@@ -122,6 +121,186 @@ get_os_codename() {
   echo "$codename"
 }
 
+# Called only after the downloaded key AND repository signature are verified.
+# Keep this embedded so the privileged broker authenticates the entire helper.
+reconcile_tor_sources() {
+  require_command python3
+  python3 - /etc/apt "$TOR_KEYRING" "$1" "$2" "$3" <<'TOR_SOURCES_PY'
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+
+
+def official_uri(uri):
+    return uri.rstrip('/') in (
+        'https://deb.torproject.org/torproject.org',
+        'http://deb.torproject.org/torproject.org',
+    )
+
+
+def rewrite_list(text, suite):
+    result = []
+    for line in text.splitlines(keepends=True):
+        match = re.match(r'^\s*deb(?:-src)?\s+(?:\[[^\]\n]*\]\s+)?(\S+)\s+(\S+)', line)
+        if match and official_uri(match[1]) and match[2] == suite:
+            line = '# Disabled by LightningOS Tor repository reconciliation: ' + line
+        result.append(line)
+    return ''.join(result)
+
+
+def stanza_fields(block):
+    fields = {}
+    current = None
+    for line in block.splitlines():
+        if not line.strip() or line.lstrip().startswith('#'):
+            continue
+        if line[0].isspace() and current:
+            fields[current] += ' ' + line.strip()
+            continue
+        match = re.match(r'^([A-Za-z0-9-]+):\s*(.*)$', line)
+        if not match or match[1].lower() in fields:
+            raise RuntimeError('Invalid or duplicate deb822 field; review APT sources before retrying')
+        current = match[1].lower()
+        fields[current] = match[2]
+    return fields
+
+
+def rewrite_sources(text, suite, managed, canonical):
+    # Preserve unrelated stanzas, comments and field continuations. A mixed
+    # stanza needs an operator split: never disable unrelated URIs or suites.
+    parts = re.split(r'(\r?\n[ \t]*\r?\n)', text)
+    for index in range(0, len(parts), 2):
+        block = parts[index]
+        fields = stanza_fields(block)
+        if fields.get('enabled', 'yes').lower() == 'no':
+            continue
+        uris = fields.get('uris', '').split()
+        suites = fields.get('suites', '').split()
+        if not any(official_uri(uri) for uri in uris) or suite not in suites:
+            continue
+        if any(not official_uri(uri) for uri in uris) or any(item != suite for item in suites):
+            raise RuntimeError('Mixed Tor/non-Tor URI or suite stanza; split it manually before retrying')
+        if managed:
+            parts[index] = ''
+        else:
+            parts[index] = ''.join('# Disabled by LightningOS: ' + line for line in block.splitlines(keepends=True))
+    result = ''.join(parts)
+    if managed:
+        result = result.rstrip()
+        result = (result + '\n\n' if result else '') + canonical
+    return result
+
+
+def validate_path(path, directory=False):
+    info = path.lstat()
+    expected = stat.S_ISDIR(info.st_mode) if directory else stat.S_ISREG(info.st_mode)
+    if not expected or (not directory and info.st_nlink != 1):
+        raise RuntimeError('Unsafe APT/keyring path (not a plain directory/file): ' + str(path))
+    if os.name == 'posix' and (info.st_uid != 0 or info.st_mode & 0o022):
+        raise RuntimeError('APT/keyring path must be root-owned and not group/world writable: ' + str(path))
+
+
+def atomic_write(path, content, mode):
+    fd, temporary = tempfile.mkstemp(prefix='.lightningos-tor-', dir=path.parent)
+    try:
+        with os.fdopen(fd, 'wb') as output:
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def reconcile(apt_root, keyring, authenticated_key, suite, architecture):
+    sources_dir = apt_root / 'sources.list.d'
+    managed = sources_dir / 'tor.sources'
+    for path in (apt_root, sources_dir, keyring.parent):
+        validate_path(path, directory=True)
+    if not re.fullmatch(r'[a-z0-9][a-z0-9-]*', suite) or architecture not in ('amd64', 'arm64'):
+        raise RuntimeError('Unsupported Tor repository suite/architecture')
+    canonical = ('Types: deb\nURIs: https://deb.torproject.org/torproject.org/\n'
+                 f'Suites: {suite}\nComponents: main\nArchitectures: {architecture}\n'
+                 f'Signed-By: {keyring}\n')
+    paths = [apt_root / 'sources.list'] + sorted(
+        path for path in sources_dir.iterdir()
+        if re.fullmatch(r'[A-Za-z0-9_.-]+\.(list|sources)', path.name)
+    )
+    if managed not in paths:
+        paths.append(managed)
+    originals, updates = {}, {}
+    # Preflight ALL files and build the full plan before writing anything.
+    for path in paths + [keyring]:
+        exists = os.path.lexists(path)
+        if exists:
+            validate_path(path)
+        old = path.read_bytes() if exists else None
+        mode = stat.S_IMODE(path.stat().st_mode) if exists else 0o644
+        originals[path] = (old, mode)
+        if path == keyring:
+            new = authenticated_key.read_bytes()
+            if not new:
+                raise RuntimeError('Authenticated keyring is empty')
+        elif old is None and path != managed:
+            continue
+        else:
+            text = old.decode('utf-8') if old is not None else ''
+            try:
+                if path.suffix == '.sources':
+                    new = rewrite_sources(text, suite, path == managed, canonical).encode('utf-8')
+                else:
+                    new = rewrite_list(text, suite).encode('utf-8')
+            except RuntimeError as error:
+                raise RuntimeError(str(path) + ': ' + str(error)) from error
+        if new != old or (os.name == 'posix' and path == keyring and mode != 0o644):
+            updates[path] = new
+    if not updates:
+        print('[OK] Tor repository sources already reconciled.')
+        return
+    backup = Path(tempfile.mkdtemp(prefix='lightningos-tor-backup-', dir=apt_root))
+    os.chmod(backup, 0o700)
+    manifest = []
+    for index, path in enumerate(updates):
+        old, mode = originals[path]
+        saved = f'{index}.original'
+        if old is not None:
+            (backup / saved).write_bytes(old)
+            os.chmod(backup / saved, 0o600)
+        manifest.append({'path': str(path), 'backup': saved if old is not None else None, 'mode': mode})
+    (backup / 'manifest.json').write_text(json.dumps(manifest, indent=2), encoding='utf-8')
+    print('[OK] APT/keyring backup: ' + str(backup), flush=True)
+    applied = []
+    try:
+        for path, content in updates.items():
+            atomic_write(path, content, 0o644 if path == keyring else originals[path][1])
+            applied.append(path)
+    except Exception:
+        # Restore only exact paths changed by this invocation. Keep the backup
+        # even after rollback so a disk/permission failure remains recoverable.
+        for path in reversed(applied):
+            old, mode = originals[path]
+            if old is None:
+                path.unlink()
+            else:
+                atomic_write(path, old, mode)
+        raise
+    print(f'[OK] Reconciled {len(updates)} APT/keyring files; unrelated repositories preserved.')
+
+
+if __name__ == '__main__':
+    try:
+        reconcile(Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), sys.argv[4], sys.argv[5])
+    except Exception as error:
+        sys.exit('[ERROR] Tor repository reconciliation failed: ' + str(error))
+TOR_SOURCES_PY
+}
+
 configure_official_repo() {
   local architecture codename tmp_dir key_file keyring_file inrelease_file imported_fingerprint
 
@@ -171,18 +350,9 @@ configure_official_repo() {
     return 0
   fi
 
-  install -o root -g root -m 0644 "$keyring_file" "$TOR_KEYRING"
+  reconcile_tor_sources "$keyring_file" "$codename" "$architecture"
   rm -rf "$tmp_dir"
   trap - RETURN EXIT
-
-  cat > "$TOR_SOURCES" <<EOF
-Types: deb
-URIs: ${TOR_REPO_URL}/
-Suites: ${codename}
-Components: main
-Architectures: ${architecture}
-Signed-By: ${TOR_KEYRING}
-EOF
 
   print_ok "Official Tor Project repository configured (${codename}/${architecture})."
 }
@@ -390,7 +560,7 @@ main() {
     exit 0
   fi
 
-  restart_since=$(date --iso-8601=seconds)
+  restart_since=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
   systemctl restart "$unit"
 
   if ! wait_for_service "$unit"; then

--- a/lightningos-light/internal/server/tor_sources_reconcile_test.go
+++ b/lightningos-light/internal/server/tor_sources_reconcile_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Execute the exact reconciliation code embedded in the broker-pinned helper.
+// Fixtures never invoke APT, systemctl, downloads, or access the host's /etc.
+func torReconcileFixture(t *testing.T) (string, string, string, string, string) {
+	t.Helper()
+	pythonName := "python3"
+	if runtime.GOOS == "windows" {
+		pythonName = "python"
+	}
+	python, err := exec.LookPath(pythonName)
+	if err != nil {
+		t.Skip("Python is required for Tor reconciliation fixture tests")
+	}
+	if runtime.GOOS != "windows" && os.Geteuid() != 0 {
+		t.Skip("root-owned source-file safety checks require root for reconciliation fixtures")
+	}
+	_, script, ok := strings.Cut(embeddedTorUpgradeScript, "<<'TOR_SOURCES_PY'\n")
+	if !ok {
+		t.Fatal("embedded source reconciler not found")
+	}
+	script, _, ok = strings.Cut(script, "\nTOR_SOURCES_PY\n")
+	if !ok {
+		t.Fatal("embedded source reconciler terminator not found")
+	}
+	root := t.TempDir()
+	apt := filepath.Join(root, "apt")
+	key := filepath.Join(root, "keyrings", "tor.gpg")
+	for _, dir := range []string{filepath.Join(apt, "sources.list.d"), filepath.Dir(key)} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	program := filepath.Join(root, "reconcile.py")
+	writeTorFixture(t, program, script)
+	authenticated := filepath.Join(root, "authenticated.gpg")
+	writeTorFixture(t, authenticated, "authenticated fixture key")
+	return python, program, apt, key, authenticated
+}
+
+func writeTorFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readTorFixture(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestTorReconcileLegacyAndDeb822WithBackupAndIdempotence(t *testing.T) {
+	for _, suite := range []string{"jammy", "noble"} {
+		t.Run(suite, func(t *testing.T) {
+			python, program, apt, key, authenticated := torReconcileFixture(t)
+			main := filepath.Join(apt, "sources.list")
+			foreign := "deb https://ubuntu.example/ubuntu " + suite + " main\n"
+			legacy := "deb [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org/ " + suite + " main\n"
+			writeTorFixture(t, main, foreign+legacy+"# "+legacy)
+			d822 := filepath.Join(apt, "sources.list.d", "legacy.sources")
+			other := "# retain me\nTypes: deb\nURIs: https://ubuntu.example/ubuntu\nSuites: " + suite + "\nComponents: main\n"
+			old := "Types: deb deb-src\nURIs:\n https://deb.torproject.org/torproject.org/\nSuites: " + suite + "\nSigned-By: /old.gpg\n"
+			writeTorFixture(t, d822, old+"\n"+other)
+			writeTorFixture(t, key, "old fixture key")
+			cmd := exec.Command(python, "-I", program, apt, key, authenticated, suite, "amd64")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("reconcile: %v\n%s", err, out)
+			}
+			if got := readTorFixture(t, main); !strings.HasPrefix(got, foreign) || strings.Contains(got, "\n"+legacy) || !strings.HasSuffix(got, "# "+legacy) {
+				t.Fatalf("unexpected list rewrite: %s", got)
+			}
+			if got := readTorFixture(t, d822); !strings.Contains(got, other) || !strings.HasPrefix(got, "# Disabled by LightningOS: Types") {
+				t.Fatalf("unexpected deb822 rewrite: %s", got)
+			}
+			managed := filepath.Join(apt, "sources.list.d", "tor.sources")
+			canonical := readTorFixture(t, managed)
+			if !strings.Contains(canonical, "Signed-By: "+key) || !strings.Contains(canonical, "Suites: "+suite) {
+				t.Fatal("canonical source missing")
+			}
+			backups, _ := filepath.Glob(filepath.Join(apt, "lightningos-tor-backup-*"))
+			if len(backups) != 1 {
+				t.Fatalf("expected one backup, got %v", backups)
+			}
+			if got := readTorFixture(t, filepath.Join(backups[0], "0.original")); got != foreign+legacy+"# "+legacy {
+				t.Fatal("original file not backed up exactly")
+			}
+			if !strings.Contains(readTorFixture(t, filepath.Join(backups[0], "manifest.json")), "backup") {
+				t.Fatal("restore manifest missing")
+			}
+			cmd = exec.Command(python, "-I", program, apt, key, authenticated, suite, "amd64")
+			if out, err := cmd.CombinedOutput(); err != nil || !strings.Contains(string(out), "already reconciled") {
+				t.Fatalf("second run: %v\n%s", err, out)
+			}
+			if readTorFixture(t, managed) != canonical || readTorFixture(t, key) != "authenticated fixture key" {
+				t.Fatal("idempotence/key mismatch")
+			}
+		})
+	}
+}
+
+func TestTorReconcileRefusesMixedStanzaWithoutAnyWrite(t *testing.T) {
+	for _, fields := range []string{
+		"URIs: https://deb.torproject.org/torproject.org/ https://unrelated.example/repo\nSuites: jammy\n",
+		"URIs: https://deb.torproject.org/torproject.org/\nSuites: jammy noble\n",
+	} {
+		python, program, apt, key, authenticated := torReconcileFixture(t)
+		path := filepath.Join(apt, "sources.list.d", "mixed.sources")
+		original := "Types: deb\n" + fields + "Components: main\n"
+		writeTorFixture(t, path, original)
+		writeTorFixture(t, key, "old key")
+		out, err := exec.Command(python, "-I", program, apt, key, authenticated, "jammy", "amd64").CombinedOutput()
+		if err == nil || !strings.Contains(string(out), "split it manually") {
+			t.Fatalf("expected safe refusal: %v %s", err, out)
+		}
+		if readTorFixture(t, path) != original || readTorFixture(t, key) != "old key" {
+			t.Fatal("preflight failure wrote files")
+		}
+		if _, err := os.Stat(filepath.Join(apt, "sources.list.d", "tor.sources")); !os.IsNotExist(err) {
+			t.Fatal("canonical source created despite failed preflight")
+		}
+	}
+}
+
+func TestTorReconcilePreservesMixedFileDisabledEntriesAndOtherSuites(t *testing.T) {
+	python, program, apt, key, authenticated := torReconcileFixture(t)
+	path := filepath.Join(apt, "sources.list.d", "tor.sources")
+	preserved := "# another repository\nTypes: deb\nURIs: https://other.example/repo\nSuites: jammy\nSigned-By:\n -----BEGIN PGP PUBLIC KEY BLOCK-----\n .\n fixture\n -----END PGP PUBLIC KEY BLOCK-----\n\nTypes: deb\nURIs: https://deb.torproject.org/torproject.org/\nSuites: noble\nEnabled: no\n"
+	writeTorFixture(t, path, preserved)
+	list := filepath.Join(apt, "sources.list")
+	other := "deb https://deb.torproject.org/torproject.org/ noble main\ndeb https://deb.torproject.org/torproject.org/experimental/ jammy main\n"
+	writeTorFixture(t, list, other)
+	if out, err := exec.Command(python, "-I", program, apt, key, authenticated, "jammy", "arm64").CombinedOutput(); err != nil {
+		t.Fatalf("reconcile: %v %s", err, out)
+	}
+	if !strings.HasPrefix(readTorFixture(t, path), preserved) || readTorFixture(t, list) != other {
+		t.Fatal("unrelated configuration changed")
+	}
+}
+
+func TestTorReconcileRollsBackPartialCommit(t *testing.T) {
+	for _, failAt := range []string{"2", "3"} {
+		t.Run("replace-"+failAt, func(t *testing.T) {
+			python, program, apt, key, authenticated := torReconcileFixture(t)
+			path := filepath.Join(apt, "sources.list")
+			old := "deb https://deb.torproject.org/torproject.org/ jammy main\n"
+			writeTorFixture(t, path, old)
+			writeTorFixture(t, key, "old key")
+			harness := `import runpy, sys, os
+from pathlib import Path
+module = runpy.run_path(sys.argv[1])
+replace = os.replace
+calls = 0
+def fail_once(src, dst):
+    global calls
+    calls += 1
+    if calls == int(sys.argv[5]):
+        raise OSError('injected commit failure')
+    return replace(src, dst)
+os.replace = fail_once
+module['reconcile'](Path(sys.argv[2]), Path(sys.argv[3]), Path(sys.argv[4]), 'jammy', 'amd64')
+`
+			out, err := exec.Command(python, "-I", "-c", harness, program, apt, key, authenticated, failAt).CombinedOutput()
+			if err == nil || !strings.Contains(string(out), "injected commit failure") {
+				t.Fatalf("expected injected failure: %v %s", err, out)
+			}
+			if readTorFixture(t, path) != old || readTorFixture(t, key) != "old key" {
+				t.Fatal("partial commit not rolled back")
+			}
+			if _, err := os.Stat(filepath.Join(apt, "sources.list.d", "tor.sources")); !os.IsNotExist(err) {
+				t.Fatal("new source survived rollback")
+			}
+		})
+	}
+}
+
+func TestTorReconcileRejectsSymlinkWithoutTouchingTarget(t *testing.T) {
+	python, program, apt, key, authenticated := torReconcileFixture(t)
+	target := filepath.Join(filepath.Dir(apt), "outside.list")
+	original := "deb https://deb.torproject.org/torproject.org/ jammy main\n"
+	writeTorFixture(t, target, original)
+	if err := os.Symlink(target, filepath.Join(apt, "sources.list")); err != nil {
+		t.Skipf("symlink fixtures unavailable: %v", err)
+	}
+	out, err := exec.Command(python, "-I", program, apt, key, authenticated, "jammy", "amd64").CombinedOutput()
+	if err == nil || !strings.Contains(string(out), "Unsafe APT/keyring path") {
+		t.Fatalf("expected symlink refusal: %v %s", err, out)
+	}
+	if readTorFixture(t, target) != original {
+		t.Fatal("symlink target changed")
+	}
+}

--- a/lightningos-light/internal/server/tor_upgrade.go
+++ b/lightningos-light/internal/server/tor_upgrade.go
@@ -149,6 +149,13 @@ func torUpgradeStatus(ctx context.Context) torUpgradeStatusResponse {
 		resp.UpdateAvailable = compareErr == nil
 	}
 	resp.CanUpdate = resp.CandidatePackageVersion != "" && (resp.UpdateAvailable || !resp.RepositoryOfficial)
+	// A recognized Tor Signed-By conflict prevents apt-cache from returning any
+	// candidate. Still permit the explicitly confirmed, authenticated repository
+	// reconciliation workflow; unrelated APT errors must remain blocked.
+	torSourceConflict := policyErr != nil && torRepositorySignedByConflict(policyOut)
+	if torSourceConflict {
+		resp.CanUpdate = true
+	}
 
 	resp.ServiceUnit, resp.ServiceActive = firstActiveSystemdUnit(ctx, []string{"tor@default", "tor"})
 	if resp.ServiceUnit == "" {
@@ -169,13 +176,25 @@ func torUpgradeStatus(ctx context.Context) torUpgradeStatusResponse {
 	if installedErr != nil && versionErr != nil {
 		errorsFound = append(errorsFound, "Tor is not installed or its version could not be read")
 	}
-	if policyErr != nil {
+	if torSourceConflict {
+		errorsFound = append(errorsFound, "Conflicting Tor repository Signed-By entries; use Upgrade Tor to reconcile them with a backup and then check for an update")
+	} else if policyErr != nil {
 		errorsFound = append(errorsFound, "APT candidate could not be resolved")
 	} else if resp.CandidatePackageVersion == "" {
 		errorsFound = append(errorsFound, "APT did not provide a Tor candidate; refresh package metadata and verify the Tor repository")
 	}
 	resp.Error = strings.Join(errorsFound, "; ")
 	return resp
+}
+
+func torRepositorySignedByConflict(output string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "Conflicting values set for option Signed-By regarding source https://deb.torproject.org/torproject.org/ ") ||
+			strings.Contains(line, "Conflicting values set for option Signed-By regarding source http://deb.torproject.org/torproject.org/ ") {
+			return true
+		}
+	}
+	return false
 }
 
 func aptPolicyCandidate(policy string) string {

--- a/lightningos-light/internal/server/tor_upgrade_assets_hardening_test.go
+++ b/lightningos-light/internal/server/tor_upgrade_assets_hardening_test.go
@@ -11,7 +11,7 @@ func TestTorUpgradeAuthenticatesPinnedRepositoryKeyBeforeInstallation(t *testing
 		`TOR_REPO_KEY_FINGERPRINT="A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89"`,
 		`--fingerprint "$TOR_REPO_KEY_FINGERPRINT"`,
 		`if [[ "$imported_fingerprint" != "$TOR_REPO_KEY_FINGERPRINT" ]]`,
-		`Signed-By: ${TOR_KEYRING}`,
+		`Signed-By: {keyring}`,
 		`--verify-only`,
 		`--proto '=https' --tlsv1.2`,
 		`gpgv --keyring "$keyring_file" "$inrelease_file"`,
@@ -29,8 +29,12 @@ func TestTorUpgradeAuthenticatesPinnedRepositoryKeyBeforeInstallation(t *testing
 	}
 	fingerprintIndex := strings.Index(script, `if [[ "$imported_fingerprint" != "$TOR_REPO_KEY_FINGERPRINT" ]]`)
 	signatureIndex := strings.Index(script, `gpgv --keyring "$keyring_file" "$inrelease_file"`)
-	installIndex := strings.Index(script, `install -o root -g root -m 0644 "$keyring_file" "$TOR_KEYRING"`)
+	installIndex := strings.Index(script, `reconcile_tor_sources "$keyring_file" "$codename" "$architecture"`)
 	if fingerprintIndex < 0 || signatureIndex <= fingerprintIndex || installIndex <= signatureIndex {
 		t.Fatal("Tor helper installs the keyring before fingerprint and repository-signature validation")
+	}
+	verifyIndex := strings.Index(script, `if [[ "$VERIFY_ONLY" -eq 1 ]]; then`)
+	if verifyIndex <= signatureIndex || verifyIndex >= installIndex || !strings.Contains(script[verifyIndex:installIndex], "return 0") {
+		t.Fatal("verify-only must return before source/keyring reconciliation")
 	}
 }

--- a/lightningos-light/internal/server/tor_upgrade_test.go
+++ b/lightningos-light/internal/server/tor_upgrade_test.go
@@ -76,3 +76,21 @@ func TestTorUpgradeScriptForcesStableAptLocale(t *testing.T) {
 		}
 	}
 }
+
+func TestTorRepositorySignedByConflictIsRestrictedToOfficialTorSource(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  bool
+	}{
+		{"E: Conflicting values set for option Signed-By regarding source https://deb.torproject.org/torproject.org/ jammy: old.gpg != new.gpg", true},
+		{"E: Conflicting values set for option Signed-By regarding source http://deb.torproject.org/torproject.org/ noble: old.gpg != new.gpg", true},
+		{"E: Conflicting values set for option Signed-By regarding source https://other.example/repo/ jammy: old.gpg != new.gpg", false},
+		{"E: Conflicting values set for option Signed-By regarding source https://deb.torproject.org/torproject.org/evil/ jammy: old.gpg != new.gpg", false},
+		{"E: Conflicting values set for option Trusted regarding source https://deb.torproject.org/torproject.org/ jammy", false},
+		{"APT candidate could not be resolved", false},
+	} {
+		if got := torRepositorySignedByConflict(tc.input); got != tc.want {
+			t.Errorf("conflict(%q) = %v want %v", tc.input, got, tc.want)
+		}
+	}
+}

--- a/lightningos-light/internal/system/journal_test.go
+++ b/lightningos-light/internal/system/journal_test.go
@@ -12,10 +12,31 @@ func TestJournalTailArgsUsesStableTimestampFormat(t *testing.T) {
 		"-n", "25",
 		"--no-pager",
 		"--output=short-iso",
-		"--since", "2026-08-16T10:05:00-03:00",
+		"--since", "2026-08-16 13:05:00 UTC",
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("journalTailArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestJournalTailArgsNormalizesBrowserTimesWithoutChangingRelativeFilters(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{"2026-09-12T00:00:00.000Z", "2026-09-12 00:00:00 UTC"},
+		{"2026-09-12T10:11:49.123Z", "2026-09-12 10:11:49.123 UTC"},
+		{"2026-09-12T00:01:00.123456789+03:00", "2026-09-11 21:01:00.123456 UTC"},
+		{" 2026-09-12T00:00:00Z ", "2026-09-12 00:00:00 UTC"},
+		{"-15 minutes", "-15 minutes"},
+		{"2026-09-12 00:00:00 UTC", "2026-09-12 00:00:00 UTC"},
+		{"invalid-date", "invalid-date"},
+	} {
+		for _, service := range []string{"lightningos-tor-upgrade", "lightningos-app-upgrade", "lightningos-lnd-upgrade", "lnd"} {
+			t.Run(service+"/"+tc.input, func(t *testing.T) {
+				args := journalTailArgs(service, 25, tc.input)
+				if args[len(args)-2] != "--since" || args[len(args)-1] != tc.want {
+					t.Fatalf("args = %v, want filter %q", args, tc.want)
+				}
+			})
+		}
 	}
 }
 

--- a/lightningos-light/internal/system/system.go
+++ b/lightningos-light/internal/system/system.go
@@ -2164,6 +2164,12 @@ func journalTailArgs(service string, lines int, since string) []string {
 	// journalctl's ambiguous English "Mon DD HH:mm:ss" prefix.
 	args := []string{"-u", service, "-n", strconv.Itoa(lines), "--no-pager", "--output=short-iso"}
 	if strings.TrimSpace(since) != "" {
+		// Browsers send RFC3339 (including fractional seconds and Z). Older
+		// journalctl versions reject that spelling; use their UTC calendar form.
+		// Preserve legacy relative/calendar expressions supplied by other callers.
+		if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(since)); err == nil {
+			since = parsed.UTC().Format("2006-01-02 15:04:05.999999 UTC")
+		}
 		args = append(args, "--since", since)
 	}
 	return args


### PR DESCRIPTION
## Summary

Fix two independent BRLN HUB upgrade problems without changing AutoFee or deploying to production:

1. **Shared upgrade log retrieval:** the browser sends RFC3339 `since` timestamps that the older journalctl rejects. This affects LOS/app, Tor and LND upgrade panels even when the upgrade itself succeeds.
2. **Tor repository reconciliation:** the Tor helper could leave legacy and canonical official repository entries with conflicting Signed-By keyrings, causing APT to fail before any package upgrade.

Base: `agent/0.5.28-release`.

## Changes

- Normalize RFC3339 filters to an explicit UTC calendar timestamp before journalctl, preserving offsets/day boundaries and microseconds. Keep native/relative filters and log output unchanged.
- Use the compatible UTC format for the Tor bootstrap journal check too.
- After authenticating the pinned Tor key AND InRelease signature, preflight `.list` and deb822 `.sources`, back up changed files/keyring, reconcile only active official Tor entries for the current OS suite, and preserve unrelated/disabled sources.
- Refuse mixed URI/suite stanzas, unsafe ownership/permissions, symlinks and hard-linked source files rather than modifying ambiguous targets.
- Keep originals and a restore manifest under a private `/etc/apt/lightningos-tor-backup-*` directory; roll back caught partial commit failures. Repeated runs are idempotent.
- Permit the existing **confirmed** Upgrade Tor action for the narrowly recognized official-repository Signed-By conflict even when apt-cache cannot return a candidate. Other APT errors remain blocked. Status alone never repairs anything.
- Update the broker-pinned helper digest and add cross-platform digest/payload-size tests.
- Keep verify-only non-mutating, package no-downgrade checks and restart-only-after-update behavior.

The embedded reconciliation uses Python 3 standard library and explicitly checks its availability. No external parser dependency or untrusted helper download was introduced.

## Validation

- PASS: `go test ./... -count=1`
- PASS: journal regression matrix for app/LOS, Tor, LND and regular LND logs
- PASS: exact embedded Python reconciler executed against isolated jammy/noble fixtures (mixed files, deb822 continuations, backups, idempotence, mixed-stanza refusal and partial-write rollback), repeated three times
- PASS: `go vet ./internal/system ./internal/server`
- PASS: Bash syntax validation
- PASS: Linux cross-builds of Manager and privileged broker
- PASS: staged diff whitespace checks
- Limitation: real symlink fixture test is skipped on this Windows host because symlink creation privilege is unavailable. POSIX ownership fixtures require root. No live Linux/production upgrade was performed in this PR.

## Release / operator notes

Manager and broker must ship together because the authenticated helper digest changed. After the full release deploy, verify that LOS upgrade logs render independently of execution success. For Tor, use the normal confirmed workflow to reconcile sources, check the actual package outcome and verify Tor ports/LND sync. A repeated unrelated APT error must not trigger blind retries.

No production parameters, APT sources, packages or services were changed during implementation. This PR is separate from AutoFee PR #155.